### PR TITLE
change the getblocktemplate coinbasetxn object

### DIFF
--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -57,5 +57,13 @@ class GetBlockTemplateTest(BitcoinTestFramework):
 # ZEN_MOD_END
         assert(tmpl['coinbasetxn']['required'])
 
+# ZEN_MOD_START
+        node.generate(105) # Mine after the 07/2018 fork (supernodes and 10/10/10/70 split reward)
+        tmpl = node.getblocktemplate()
+        assert('communityfund' in tmpl['coinbasetxn'])
+        assert('supernodes' in tmpl['coinbasetxn'])
+        assert('securenodes' in tmpl['coinbasetxn'])
+
+# ZEN_MOD_END
 if __name__ == '__main__':
     GetBlockTemplateTest().main()

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -690,6 +690,10 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
                 // Correct this if GetBlockTemplate changes the order
 // ZEN_MOD_START
                 entry.push_back(Pair("communityfund", (int64_t)tx.vout[1].nValue));
+                if (pblock->vtx[0].vout.size() > 3) {
+                    entry.push_back(Pair("securenodes", (int64_t)tx.vout[2].nValue));
+                    entry.push_back(Pair("supernodes", (int64_t)tx.vout[3].nValue));
+                }
 // ZEN_MOD_END
             }
             entry.push_back(Pair("required", true));


### PR DESCRIPTION
adds the securenodes and supernodes fields and relative values to the coinbasetxn object in the getblocktemplate for the supernodes 10/10/10/70 HR 07/2018

closes #51 