### PR TITLE
Adds checkpoint blocks for HF 4 to mainnet and testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -166,12 +166,13 @@ public:
             ( 96577, uint256S("0x0000000177751545bd1af3ccf276ec2920d258453ab01f3d2f8f7fcc5f3a37b8"))
             ( 110000, uint256S("0x000000003f5d6ba1385c6cd2d4f836dfc5adf7f98834309ad67e26faef462454"))
             ( 139200, uint256S("0x00000001ea53c09a45e3f097ba8f48a4c117b5b368031c4eb2fa02cb5a84c99e"))
-            ( 294072, uint256S("0x000000005f9ceecc87d9e5eaab2cf548c787231829ad6f609975fadd10fff5be")),
-            1524276059, //1500666121,     // * UNIX timestamp of last checkpoint block
-            2132058, //355208,         // * total number of transactions between genesis and last checkpoint
-                            //   (the tx=... number in the SetBestChain debug.log lines)
-            1470            // * estimated number of transactions per day after checkpoint
-                            //   total number of tx / (checkpoint block height / (24 * 24))
+            ( 294072, uint256S("0x000000005f9ceecc87d9e5eaab2cf548c787231829ad6f609975fadd10fff5be"))
+            ( 344700, uint256S("0x000000000dcb36093820bbb8b293ef0196e7eab96ded3734346b2561e0cc4ec1")),
+            1532005401, // * UNIX timestamp of last checkpoint block
+            2995311,    // * total number of transactions between genesis and last checkpoint
+                        //   (the tx=... number in the SetBestChain debug.log lines)
+            5005        // * estimated number of transactions per day after checkpoint
+                        //   total number of tx / (checkpoint block height / (24 * 24))
         };
 
 //  commented out - seems to make no sense but kept around for reference just in case
@@ -266,11 +267,12 @@ public:
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
             (0, consensus.hashGenesisBlock)
-            (38000, uint256S("0x001e9a2d2e2892b88e9998cf7b079b41d59dd085423a921fe8386cecc42287b8")),
-            1486897419,  // * UNIX timestamp of last checkpoint block
-            47163,       // * total number of transactions between genesis and last checkpoint
-                         //   (the tx=... number in the SetBestChain debug.log lines)
-            715          //   total number of tx / (checkpoint block height / (24 * 24))
+            (38000, uint256S("0x001e9a2d2e2892b88e9998cf7b079b41d59dd085423a921fe8386cecc42287b8"))
+            (260500, uint256S("0x00020e207c65582e3498838f7a3e1140a64dc92b42af385ef183a139d77430ab")),
+            1529156288, // * UNIX timestamp of last checkpoint block
+            522823,     // * total number of transactions between genesis and last checkpoint
+                        //   (the tx=... number in the SetBestChain debug.log lines)
+            1156        //   total number of tx / (checkpoint block height / (24 * 24))
         };
 
 // ZEN_MOD_START


### PR DESCRIPTION
Closes https://github.com/ZencashOfficial/zen/issues/93

To test: build and reindex from before the HF blocks: 344700 for mainnet, and 260500 for testnet.