### PR TITLE
Zcash/upstream security fixes

### DIFF
--- a/doc/amqp.md
+++ b/doc/amqp.md
@@ -40,6 +40,20 @@ In order to run the example Python client scripts in contrib/ one must
 also install *python-qpid-proton*, though this is not necessary for
 daemon operation.
 
+## Security WARNING
+
+Enabling this feature even on the loopback interface only (e.g. binding
+it to localhost or 127.0.0.1) will still expose it to the wilds of the
+Internet, because of an attack vector called DNS rebinding. DNS
+rebinding allows an attacker located remotely on the Internet to trick
+applications that you're running on the same computer as Zcashd to
+contact your supposedly localhost-only AMQP port, then, depending on the
+program they may be able to attempt to attack it.
+
+Do not enable this feature unless you are sure that you know what you
+are doing, and that you have a strong reason for thinking that you are
+not vulnerable to this type of attack.
+
 ## Enabling
 
 By default, the AMQP feature is automatically compiled in if the

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -1,8 +1,8 @@
 # Block and Transaction Broadcasting With ZeroMQ
 
 [ZeroMQ](http://zeromq.org/) is a lightweight wrapper around TCP
-connections, inter-process communication, and shared-memory,
-providing various message-oriented semantics such as publish/subcribe,
+connections, inter-process communication, and shared-memory, providing
+various message-oriented semantics such as publish/subscribe,
 request/reply, and push/pull.
 
 The Zcash daemon can be configured to act as a trusted "border
@@ -41,6 +41,20 @@ system. Typically, it is packaged by distributions as something like
 In order to run the example Python client scripts in contrib/ one must
 also install *python-zmq*, though this is not necessary for daemon
 operation.
+
+## Security WARNING
+
+Enabling this feature even on the loopback interface only (e.g. binding
+it to localhost or 127.0.0.1) will still expose it to the wilds of the
+Internet, because of an attack vector called DNS rebinding. DNS
+rebinding allows an attacker located remotely on the Internet to trick
+applications that you're running on the same computer as Zcashd to
+contact your supposedly localhost-only ZMQ port, then, depending on the
+program they may be able to attempt to attack it.
+
+Do not enable this feature unless you are sure that you know what you
+are doing, and that you have a strong reason for thinking that you are
+not vulnerable to this type of attack.
 
 ## Enabling
 

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -4,9 +4,13 @@
 
 #include "utiltest.h"
 
-CWalletTx GetValidReceive(ZCJoinSplit& params,
-                          const libzcash::SpendingKey& sk, CAmount value,
-                          bool randomInputs) {
+#include <array>
+
+CMutableTransaction GetValidReceiveTransaction(ZCJoinSplit& params,
+                                const libzcash::SpendingKey& sk,
+                                CAmount value,
+                                bool randomInputs,
+                                int32_t version /* = 2 */) {
     CMutableTransaction mtx;
     mtx.nVersion = 2; // Enable JoinSplits
     mtx.vin.resize(2);
@@ -53,6 +57,34 @@ CWalletTx GetValidReceive(ZCJoinSplit& params,
                                 joinSplitPrivKey
                                ) == 0);
 
+    return mtx;
+}
+
+CWalletTx GetValidReceive(ZCJoinSplit& params,
+                                const libzcash::SpendingKey& sk,
+                                CAmount value,
+                                bool randomInputs,
+                                int32_t version /* = 2 */)
+{
+    CMutableTransaction mtx = GetValidReceiveTransaction(
+        params, sk, value, randomInputs, version
+    );
+    CTransaction tx {mtx};
+    CWalletTx wtx {NULL, tx};
+    return wtx;
+}
+
+CWalletTx GetInvalidCommitmentReceive(ZCJoinSplit& params,
+                                const libzcash::SpendingKey& sk,
+                                CAmount value,
+                                bool randomInputs,
+                                int32_t version /* = 2 */)
+{
+    CMutableTransaction mtx = GetValidReceiveTransaction(
+        params, sk, value, randomInputs, version
+    );
+    mtx.vjoinsplit[0].commitments[0] = uint256();
+    mtx.vjoinsplit[0].commitments[1] = uint256();
     CTransaction tx {mtx};
     CWalletTx wtx {NULL, tx};
     return wtx;

--- a/src/utiltest.h
+++ b/src/utiltest.h
@@ -8,11 +8,19 @@
 #include "zcash/NoteEncryption.hpp"
 
 CWalletTx GetValidReceive(ZCJoinSplit& params,
-                          const libzcash::SpendingKey& sk, CAmount value,
-                          bool randomInputs);
+                                const libzcash::SpendingKey& sk,
+                                CAmount value,
+                                bool randomInputs,
+                                int32_t version = 2);
+CWalletTx GetInvalidCommitmentReceive(ZCJoinSplit& params,
+                                const libzcash::SpendingKey& sk,
+                                CAmount value,
+                                bool randomInputs,
+                                int32_t version = 2);
 libzcash::Note GetNote(ZCJoinSplit& params,
-                       const libzcash::SpendingKey& sk,
-                       const CTransaction& tx, size_t js, size_t n);
+                                   const libzcash::SpendingKey& sk,
+                                   const CTransaction& tx, size_t js, size_t n);
 CWalletTx GetValidSpend(ZCJoinSplit& params,
-                        const libzcash::SpendingKey& sk,
-                        const libzcash::Note& note, CAmount value);
+                              const libzcash::SpendingKey& sk,
+                              const libzcash::Note& note,
+                              CAmount value);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1272,6 +1272,12 @@ boost::optional<uint256> CWallet::GetNoteNullifier(const JSDescription& jsdesc,
         hSig,
         (unsigned char) n);
     auto note = note_pt.note(address);
+
+    // Check note plaintext against note commitment
+    if (note.cm() != jsdesc.commitments[n]) {
+        throw libzcash::note_decryption_failed();
+    }
+
     // SpendingKeys are only available if:
     // - We have them (this isn't a viewing key)
     // - The wallet is unlocked


### PR DESCRIPTION
* Backport of https://github.com/zcash/zcash/pull/3897, fixes security issue https://z.cash/support/security/announcements/security-announcement-2019-03-19/ reported to Zcash by Alexis Enston, thanks to the original reporter and the Zcash team for notifying us about the issue!
* Updates to documentation addressing DNS rebinding attacks with ZMQ/AMQP, Zcash PR https://github.com/zcash/zcash/pull/3890, credit to @zebambam.