### PR TITLE
RD-Crypto-Spec/Responsible-Disclosure

### DIFF
--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -1,0 +1,65 @@
+This page is copyright The Electric Coin Company, 2019. It is posted in order to conform to this standard: https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6
+
+# Security Disclosures
+## Receiving Disclosures
+
+The Electric Coin Company is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
+
+Please submit issues to security@z.cash, using the following PGP key:
+
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBFaegcoBCAC+G82ZBYYm1GoVn4dKa0WiLYD/Q+BuU89PS1X7A4eOOy8g9yS4
+wJKMzB0AxFsH/t85P7pPZwHw3i2gmiJKeIqEGhEBL08D3id2u6ZyCnwDuWs0i6My
+MXWTwK5shvE61ZI/KPbjemoOG6MPF5QdrouNqei2Vk+4RjbRCyyS0A59GQi2dNZX
+BMwTnHnUZ5qi6T0RFelqJ3dE5Nc/UwJPdAcg71c3b3dMOHjaDBMPB6+fTLBeidV6
+5B72nGO3eIYkMUNj+qCQmM/esRkmGmlDH/9WGMBOKCq7Yw3LyEoPOi5cba1m8SN2
+xFlNzkUGrlVrwZMF+1UdjvN7BGDypA3Dr/STABEBAAG0JVpjYXNoIFNlY3VyaXR5
+IFRlYW0gPHNlY3VyaXR5QHouY2FzaD6JATcEEwEIACEFAlaegcoCGwMFCwkIBwIG
+FQgJCgsCBBYCAwECHgECF4AACgkQiPuLhti1poxlRAf/bZ6fhUby5bAbViAO4TzQ
+yfbD0ksGeF8MHicPz7HqOYuXAE9GrKnVAOFptwRo94O+iRC5aXhW8OAP+38IWorv
+gsAuag7Y8k0nlfNdrJRqqJpjyxtiuv+cd2o5dre8E9PVNE5IPv9qEJA4Zag3snmC
+a+O4HAqKeXYddunFq2drLkTRlOwuFkGXJzwi3VSNVYCuuGyezFDuaD45ltmsXgid
+jZSdnnc6L1BrEd9LVzahvFV0+fT4bNKQHQDk+f0RTnHed+m9NqAoC9K8ftPTQ/i4
+5+W/dXJATztWDrJ7ZevHXGR+RAhMNsT1psvnQsJzMkUz1GMdQOtk4PfuZLGSIiTM
+ErkBDQRWnoHKAQgAp+w+xsPJWFdadE6Ok1aZC0Lk1J9xU/cqX1aBlkwi5SynwOkV
+Eg1xNHLJMelp13bgDjLRsvaMbsseaCVk3goNln4atNbZpqz6FoM/f8pJx52LFD0j
+CFFOVUlGEF0h+KdFr+3JHI+mg+3ifXTD4Dajj4lpu8kR/FQjftcxyttByz01wLRO
+sK5BDC856WzHXAJuX6TpX4sGJujzKoLXR5V0SkUopqn9g4aJGnWuNh4kyOQI6fd7
+YZyPZhWDrXdgInCKAKAgq8r6hgSDMYFvmflp6+reCfeOe1VFF8q3Foio02YPIrQW
+WjjH0w6nOvOKCEtxistz1sP6ZoYq4gR41LOwIQARAQABiQEfBBgBCAAJBQJWnoHK
+AhsMAAoJEIj7i4bYtaaMiA4IALIy4xP/Btu86yT3b53t8cfYZddFSO8Nlg+y3EMu
+1LchdSOpWgpXCvQ7d4ndWGsuBSmQ+jaRwU2UIkq2iIxf5cg63dJz9grAcF6MXCrO
+t5BSowFC4m3RFaEaG6G6SjDVIA0ZEdEMFd9Gzc1ikqbVLyNuJXKmzz0evvbAJgVO
+D0nht5ifwLjQxM4olvYHUwtT0wPhniH69ghFo8LQiMgncjaukDzbgANiuj07QYy/
+DlzhQUsp1qZvqZnVKqUJ3lFb86b6zoqoRNiUnvP9JB2v3kLG0T39UlcXUFnZJ/4H
+CDHCrwSovQRMHtoOWZijBNobO2y1d0FkUpzNlNw44Ssw0Vo=
+=6GYS
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+## Sending Disclosures
+
+In the case where we become aware of security issues affecting other projects that has never affected Zcash, our intention is to inform those projects of security issues on a best effort basis.
+
+In the case where we fix a security issue in Zcash that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the that section.
+
+## Bilateral Responsible Disclosure Agreements
+
+We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviaions described in the next section.
+
+Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zcash technology with the following contacts:
+
+- security@horizen.com via PGP
+- ca333@komodoplatform.com via PGP
+
+## Deviations from the Standard
+
+Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.
+
+The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
+
+In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
+
+

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -43,11 +43,11 @@ CDHCrwSovQRMHtoOWZijBNobO2y1d0FkUpzNlNw44Ssw0Vo=
 
 In the case where we become aware of security issues affecting other projects that has never affected Zcash, our intention is to inform those projects of security issues on a best effort basis.
 
-In the case where we fix a security issue in Zcash that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the that section.
+In the case where we fix a security issue in Zcash that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the section at the bottom of this document.
 
 ## Bilateral Responsible Disclosure Agreements
 
-We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviaions described in the next section.
+We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviations described in the next section.
 
 Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zcash technology with the following contacts:
 

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -1,65 +1,108 @@
-This page is copyright The Electric Coin Company, 2019. It is posted in order to conform to this standard: https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6
+This page is posted in order to conform to this standard: https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6
+
+Copyright The Electric Coin Company, 2019
+
+Copyright Zen Blockchain Foundation, 2019
 
 # Security Disclosures
 ## Receiving Disclosures
 
-The Electric Coin Company is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
+The Zen Blockchain Foundation is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
 
-Please submit issues to security@z.cash, using the following PGP key:
+Please submit issues to security@horizen.global, using the following PGP key:
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
-mQENBFaegcoBCAC+G82ZBYYm1GoVn4dKa0WiLYD/Q+BuU89PS1X7A4eOOy8g9yS4
-wJKMzB0AxFsH/t85P7pPZwHw3i2gmiJKeIqEGhEBL08D3id2u6ZyCnwDuWs0i6My
-MXWTwK5shvE61ZI/KPbjemoOG6MPF5QdrouNqei2Vk+4RjbRCyyS0A59GQi2dNZX
-BMwTnHnUZ5qi6T0RFelqJ3dE5Nc/UwJPdAcg71c3b3dMOHjaDBMPB6+fTLBeidV6
-5B72nGO3eIYkMUNj+qCQmM/esRkmGmlDH/9WGMBOKCq7Yw3LyEoPOi5cba1m8SN2
-xFlNzkUGrlVrwZMF+1UdjvN7BGDypA3Dr/STABEBAAG0JVpjYXNoIFNlY3VyaXR5
-IFRlYW0gPHNlY3VyaXR5QHouY2FzaD6JATcEEwEIACEFAlaegcoCGwMFCwkIBwIG
-FQgJCgsCBBYCAwECHgECF4AACgkQiPuLhti1poxlRAf/bZ6fhUby5bAbViAO4TzQ
-yfbD0ksGeF8MHicPz7HqOYuXAE9GrKnVAOFptwRo94O+iRC5aXhW8OAP+38IWorv
-gsAuag7Y8k0nlfNdrJRqqJpjyxtiuv+cd2o5dre8E9PVNE5IPv9qEJA4Zag3snmC
-a+O4HAqKeXYddunFq2drLkTRlOwuFkGXJzwi3VSNVYCuuGyezFDuaD45ltmsXgid
-jZSdnnc6L1BrEd9LVzahvFV0+fT4bNKQHQDk+f0RTnHed+m9NqAoC9K8ftPTQ/i4
-5+W/dXJATztWDrJ7ZevHXGR+RAhMNsT1psvnQsJzMkUz1GMdQOtk4PfuZLGSIiTM
-ErkBDQRWnoHKAQgAp+w+xsPJWFdadE6Ok1aZC0Lk1J9xU/cqX1aBlkwi5SynwOkV
-Eg1xNHLJMelp13bgDjLRsvaMbsseaCVk3goNln4atNbZpqz6FoM/f8pJx52LFD0j
-CFFOVUlGEF0h+KdFr+3JHI+mg+3ifXTD4Dajj4lpu8kR/FQjftcxyttByz01wLRO
-sK5BDC856WzHXAJuX6TpX4sGJujzKoLXR5V0SkUopqn9g4aJGnWuNh4kyOQI6fd7
-YZyPZhWDrXdgInCKAKAgq8r6hgSDMYFvmflp6+reCfeOe1VFF8q3Foio02YPIrQW
-WjjH0w6nOvOKCEtxistz1sP6ZoYq4gR41LOwIQARAQABiQEfBBgBCAAJBQJWnoHK
-AhsMAAoJEIj7i4bYtaaMiA4IALIy4xP/Btu86yT3b53t8cfYZddFSO8Nlg+y3EMu
-1LchdSOpWgpXCvQ7d4ndWGsuBSmQ+jaRwU2UIkq2iIxf5cg63dJz9grAcF6MXCrO
-t5BSowFC4m3RFaEaG6G6SjDVIA0ZEdEMFd9Gzc1ikqbVLyNuJXKmzz0evvbAJgVO
-D0nht5ifwLjQxM4olvYHUwtT0wPhniH69ghFo8LQiMgncjaukDzbgANiuj07QYy/
-DlzhQUsp1qZvqZnVKqUJ3lFb86b6zoqoRNiUnvP9JB2v3kLG0T39UlcXUFnZJ/4H
-CDHCrwSovQRMHtoOWZijBNobO2y1d0FkUpzNlNw44Ssw0Vo=
-=6GYS
+mQINBFqVI5kBEADFyQp7VGWWVIXSpkRrO3VObtzqPbr4a9WZHQ0uCDKEeY6hHlkZZJ6k+tWB
+eYWfVjADBsbSzrE+bbO3oiS8/k5/PKlqiS6EJIdPLqEyHjF5VwyP8PThiDpucZPGGIGlhib7
+vvEX/R7x10stw767tpNXKd1ysIdotzIhILx4omWXM7LfmMdvcO5jFvotpVHycrjp5/a7Nb+a
+pAG3QOE1DBSX0vVmprsO8TPAz8m+r3+vvbUTiX7AR2JubzWhN5d8W9R3Crqb1kFQAm7zsHRN
+QZ+eEOJW8l/YLPaZFV1C+aXNI8Mfn95b1m3hm3Wc5PetF8XsGIclDNvM6KXa+pT9nhbbjRG/
+aqw0zuFRLFkEwjHR7EIyTUMc7xul609LoxEH24TShdDr80m+YJ+KSQHfmGV+WA2hmhcMkFCx
+iQ2F9TzACfKsYuVfZHUlzvv/iO9FIdtgzmGnm5HNqnbzVih6K9yyBkMeBiPmKae4ew8ki2gF
+SK/ZclqKabbmY3ykgpZsQcBCJPw3bjn5zDHIk9HeGkb30mBqCqphw7wrjadK3CQ/EzU+EVTf
+TSu59t4GN5V5A/edJPhJdBEn/6A1PbO2wyDQoCqI1H4JBvX3D1oxmEJId4Ja1ZMJFteFiAu0
+OPykal92evKYz7JtvCtCUsSE7K51SxuEjDzJY7bsGNSF+CWloQARAQABtCdaZW5DYXNoIFNl
+Y3VyaXR5IDxzZWN1cml0eUB6ZW5jYXNoLmNvbT6JAjkEEwEIACMFAlqVI5kCGwMHCwkIBwMC
+AQYVCAIJCgsEFgIDAQIeAQIXgAAKCRBNIFg0EHBPLvEwD/9G+1b2IllqtmvvMCgH5NRM5T5E
+PEShXqqp286hADxPcEdwvMHKj1BmwgrZF6GiAEeEqt+zAXd9pnqriRmZWwIR8tfp7+JNA+1m
+yQfez7ZCFiiclOPtVNBRRl/OU2xnKJmq7FYIvj36fdpatVom6NBb24H4c42tld6xSA0HPsU9
+XXmaDP9/MwQPJQVmL/6ts//owN0bCR+M/eDllag3qv/EYfApzFr9WE48zRopmVSPM10wCRLA
+1V/OV3vbXFuhQE9tE+H9Kr5D/C0P1H5cxzZELXab8U0PHv03zYUp2piHVzsQDAHoGGrsvlLS
+KI0vSQJzR5Al4CSncLJDFBr/Y/e//7f2vhCtiPxQXhMFLdQl2ji+TX/EYUS6QZnJeBBgWBPO
+AFvETDf0lvrR7DsYgqD8wmb6txwF8Zkz5TcwqikdzPYa6YtBbkfh4hYXMoKpl4EKtpNc90dS
+3bSmmD5Chd+u9XbMpZhenwfn318jf8w1yP2TbOalvDN9z3IMdCNHk/dY4SQ+OcpqoWpNGlPZ
+faZPrz6vy0eqmIb8qkfxIL5Tg70dSL/anC9iF5HhkOc2SVyAsWDC2DtaSFiXzBCj4uo/Rhj+
+6tDfz4Y6SIR5pUaelI3V8qZFrRIk1neBNxd1KT/DOQafSGd3xSdmbPeVBz3qtS3zWO00P8Ck
+URwxSSWmUbQoWmVuQ2FzaCBTZWN1cml0eSA8c2VjdXJpdHlAemVuc3lzdGVtLmlvPokCOQQT
+AQgAIwUCWrPl7AIbAwcLCQgHAwIBBhUIAgkKCwQWAgMBAh4BAheAAAoJEE0gWDQQcE8uezoQ
+AKSFATvWyPRdGHf94KlpSesasn32WjCtCl4r62E41HCz/1TpHFKoaBhjUuxgupgMNfqwL1UW
+h3G53CNfkRtDlVETOAzuL6yTmG/9dRQQnQW20TPtV6NJ7pMe90z+NFDCIfo/Gz1TNbTysgdI
+gwjl5H0AB0jgGyIB+DD7lV8OPWd3DdHdvVqHkzNK1hXP+zTuYwqISMANhcFwnndEKDWpx5ey
+6uDss/f1pQR85bHFYhECbNWlsBxqu+C2ZOy2t4CVJzyfRG7L/r+FUAVf4q1oVEA1pPv2Ip6U
+GMgPg866cQcq3bG5iWh+jxwE58kfLqHa2VYCqA5xMUtfEhn5DJWp9kHmV5PTdMQNxkE+fgxM
+lqMX3bN2cfAq0pB0n8lir0A3EfgKDk0V4tVplr8G1x6Ut5F0TaEnuUwIeH+IN5JxwzCFlZgy
+CV0NGmHILo1BVwQdPW0xJ6bbqHnVldoPqmS1GxnnMR0MFCeIOwA9CB0o8Ql8ZKQcC10TVwUi
+IhPrhvIo5vtrplTj5P36gqEB9lCNBVAnUmwHHDjvekxmf85ywNcLXRhn3xxpbMeuLnqmBiWY
+xiHBSezyvguWVNM2FcMq5BKeVx2mR9S+y92VbUM2LSG600PJlsK2qw2TfEAbCQLvagCYM/Jf
+78DisO3IcxkSHqtBivy4oaZ+PfsRQLCrXgprtCpIb3JpemVuIFNlY3VyaXR5IDxzZWN1cml0
+eUBob3JpemVuLmdsb2JhbD6JAk4EEwEIADgWIQRca/WSiM3U7KRWb5lNIFg0EHBPLgUCW9MX
+ogIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRBNIFg0EHBPLmdgEAC4IEkGKM9OymKm
+RQsjRnmd7kNXbVW2JlGVA8Byd5Eu8kAgpHTjr0YWehYb3qKhOYBm7LpRZZo4Q/wCniSZTSMW
+aAVTh11ihPT4mLV9Wr5n3LDaf/ztLZ8sM1FLDmpeTRLjmm/rtmhm38sfz/4H6g4sCZU+Z2GW
+uBfcfqy/KGPiDhIC7rX8qkp8ao/2W2ge0SOx9pIIjM+6BWU1X/c9LpErOeUYjN8etOu9U9yi
+MovMqHLn91XxAtvfkqqMxHUxoxnDclPyJf+y/xQGQ1JGeLvATOky7TzkEjaplz5K4pxLMbxv
+4YeW6apO4SuISbMNK0r0v7R3g4dzrzYrJy+n605WVRkIUVcNKWp28TKiZbBDo0/iMLmJqtrf
+wJRdXKBJpcxrlmKw20gav4HEOXS0levJEe8zSrwHYn69erj4xupCCIcB37PymIuaG5FSKTXW
+BzstcVzRVoeZuRFbqi4/xorQqXtmVs3hV6iZ83SdrIV89gHOLnaL8QbdMhhkrep3oR9i5VEm
+nO7slg0HFBic4po8ZCs1roMy3YmiRn8xpXaoEVqdQo7XSOd4BdHBwmh72uJKWARY9PowyKZV
+pBg6iPGjv2U3iFmlaSaPZGKp0U344vyOVk3CDVbL0wgOoFo6Ejk4NsrTQRglUOSVHQHybUKB
+WXMjfqrJZHfXR4XQb+Pp3bkCDQRalSOZARAAxcD4ZctlkCIdHZuqsKtNjKDQhIft5fMo6nF6
+ExB9aftUd2e1ldpYVX4olOggoy9cwm+GPnqwCMJtlprLKMclkSUJTm/Lw1GamrtP/z63UOsF
+wY65U2jxFWApOAxUjdTyC1mDoO+EKCkuSZiHyIIDWxmwVPGkPSv4TKAAcUWMnhttk4q0SPyO
+f1k2ml6UfP9u70KCzgXFMdwDgPfCgCLzDAldwsBMWIHb3CUYaOf9wdYcuVxx3jyhXEx2XPmP
+IdNMvNCo9/WPVzgafEWaarJc1JKgTF1CseAdTQAtQvlO5PT2fsEGSs7pWdk74p2j8ZEDAmSS
+ImqfEEOYGs7xU0qEyZ/kMOrwpcovw6XjxhIMqhKRzvTqTqAEON7XzAG0DuG2+BypslOOVTIq
+6NPK3RTwQ4vme2USCp1Lw4FUNe8DRNopgNqwu89LyS7NWJYKMmWPCHgXIxIpidZQrl0rLyqq
+zBMXZ8ko4+dnUf79HmVbOkBwCQQjGmwJWtUI0xTzI3RhEtsQjQEO6xK9om/mTmuDi3E2lxGw
+gtBorzaxjKuTPnujmWFFScfIcJGwLh8Rzjm3nWL1zihWC9fWNdBEvYsstQm5cOa+3rvooKI+
+J56GP8pJ8ld4Le9/lw3XG89GQtDek50CqZQ2J6SLT+48p/5QYxowKg33UvbAbZcSsrDSbFsA
+EQEAAYkCHwQYAQgACQUCWpUjmQIbDAAKCRBNIFg0EHBPLj+JEACtKs+cnCivgNXoed0owpNa
+eF8J6ahnullR4JnhX5f/UdVizWsuNk5NmC4eLFhrx8GeluU476ZR+aEW0F47qEs2LEQlp9xU
+e5FNmry1ZEqlgfwd9c6B64yHwDgZIrQmt+bVj1sh+KLckrdztZnygqLyWH03ux1qFwuPGoms
+5w/W+qZnhfVfzNbRip5B84SWlGKrNbkTHyfs3lZHMuZlKlt70Y0WUKku87m4NVNmp2dcYCqx
+KH5w6dzsTnnX5KH8VcgAAOg24h2CCToZZgk8eCKZDU5/B6V8OI6ZZJJWpRG2ZlOKB658O6P7
+WLDOI/51OQXuIjh71QLJnwMOhdFsHn4UuaWi7/qHjf0fWP5KSkGLEv1sWT3qiD5+E9L/sgMw
+wwDieIk+Dc55yutrQrq2DWRKn5Ov1oy3zgrrYYm5ynqD8tBivTJmXp10mXFq7ELphN73jLBi
+ok1fNNfhY2SHroVYqmQo4IdRYEOQPi7jqLK+BzxLlku2SUNw6QDrB1Jd71ib04N1T+T62H75
+/4Gh0VwQjQjPKqSwlnNuY55ey6XgtxnxL1AW8Jbon+2I6gNzrlFeNZasTx6UPa10oASPQ/ln
+BYRcoQqZ9tQBSdBCfxmErCCUStOs2OaG8zn+qomJMeEH+0XUdK2Foov4M94yfN3A1NZmg39w
+SEzDO/s/HZbFjA==
+=2qIw
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
 ## Sending Disclosures
 
-In the case where we become aware of security issues affecting other projects that has never affected Zcash, our intention is to inform those projects of security issues on a best effort basis.
+In the case where we become aware of security issues affecting other projects that has never affected Horizen, our intention is to inform those projects of security issues on a best effort basis.
 
-In the case where we fix a security issue in Zcash that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the section at the bottom of this document.
+In the case where we fix a security issue in Horizen that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the section at the bottom of this document.
 
 ## Bilateral Responsible Disclosure Agreements
 
 We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviations described in the next section.
 
-Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zcash technology with the following contacts:
+Specifically, we have agreed to engage in responsible disclosures for security issues affecting Horizen technology with the following contacts:
 
-- security@horizen.com via PGP
-- ca333@komodoplatform.com via PGP
+- Zcash https://github.com/zcash/zcash/blob/master/responsible_disclosure.md
 
 ## Deviations from the Standard
 
-Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.
+Horizen is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zen. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.
 
 The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
 
-In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
+In the case of a counterfeiting bug, however, just like in Zcash's CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
 
 


### PR DESCRIPTION
Add Horizen responsible_disclosure.md.

Thanks to the Zcash Team and @zebambam for originally
writing this document and leading the effort to adopt standards for
Responsible Disclosure in Cryptocurrencies. And to the authors of
https://github.com/RD-Crypto-Spec/Responsible-Disclosure.