### PR TITLE
introducing getters for transactions and certificates members

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -49,7 +49,7 @@ except ImportError:
 
 USER_AGENT = "AuthServiceProxy/0.1"
 
-HTTP_TIMEOUT = 6000000
+HTTP_TIMEOUT = 600
 
 log = logging.getLogger("BitcoinRPC")
 
@@ -120,10 +120,12 @@ class AuthServiceProxy(object):
             return self._get_response()
         except Exception as e:
             # If connection was closed, try again.
+            # Python 2.7 error message was changed in https://github.com/python/cpython/pull/2825
             # Python 3.5+ raises BrokenPipeError instead of BadStatusLine when the connection was reset.
             # ConnectionResetError happens on FreeBSD with Python 3.4.
             # These classes don't exist in Python 2.x, so we can't refer to them directly.
-            if ((isinstance(e, httplib.BadStatusLine) and e.line == "''")
+            if ((isinstance(e, httplib.BadStatusLine)
+                    and e.line in ("''", "No status line received - the server has closed the connection"))
                 or e.__class__.__name__ in ('BrokenPipeError', 'ConnectionResetError')):
                 self.__conn.close()
                 self.__conn.request(method, path, postdata, headers)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -224,8 +224,6 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
         txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2);
-        #print "tx = ", txIdNotBroadcasted
-        #raw_input("Press enter to continue...")
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         self.sync_all()
         self.nodes[1].generate(1) #mine a block, tx should not be in there

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -6,7 +6,7 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, connect_nodes_bi, wait_and_assert_operationid_status
+    start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, sync_mempools
 
 import time
 from decimal import Decimal
@@ -92,6 +92,9 @@ class WalletTreeStateTest (BitcoinTestFramework):
 
         # Wait for Tx 2 to be created
         wait_and_assert_operationid_status(self.nodes[0], myopid)
+
+        # Wait for wallet to catch up with mempool
+        sync_mempools([self.nodes[0]])
 
         # Note that a bug existed in v1.0.0-1.0.3 where Tx 2 creation would fail with an error:
         # "Witness for spendable note does not have same anchor as change input"

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -430,7 +430,7 @@ static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
 
         // ... and merge in other signatures:
         BOOST_FOREACH(const CTransaction& txv, txVariants) {
-            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.GetVins()[i].scriptSig);
+            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.GetVin()[i].scriptSig);
         }
         if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i)))
             fComplete = false;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -430,7 +430,7 @@ static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
 
         // ... and merge in other signatures:
         BOOST_FOREACH(const CTransaction& txv, txVariants) {
-            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.getVins()[i].scriptSig);
+            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.GetVins()[i].scriptSig);
         }
         if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i)))
             fComplete = false;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -430,7 +430,7 @@ static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
 
         // ... and merge in other signatures:
         BOOST_FOREACH(const CTransaction& txv, txVariants) {
-            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.vin[i].scriptSig);
+            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.getVins()[i].scriptSig);
         }
         if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i)))
             fComplete = false;

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -146,9 +146,9 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (contains(hash))
         fFound = true;
 
-    for (unsigned int i = 0; i < tx.GetVouts().size(); i++)
+    for (unsigned int i = 0; i < tx.GetVout().size(); i++)
     {
-        const CTxOut& txout = tx.GetVouts()[i];
+        const CTxOut& txout = tx.GetVout()[i];
         // Match if the filter contains any arbitrary script data element in any scriptPubKey in tx
         // If this matches, also add the specific output that was matched.
         // This means clients don't have to update the filter themselves when a new relevant tx 
@@ -181,7 +181,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (fFound)
         return true;
 
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
     {
         // Match if the filter contains an outpoint tx spends
         if (contains(txin.prevout))

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -146,9 +146,9 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (contains(hash))
         fFound = true;
 
-    for (unsigned int i = 0; i < tx.vout.size(); i++)
+    for (unsigned int i = 0; i < tx.getVout().size(); i++)
     {
-        const CTxOut& txout = tx.vout[i];
+        const CTxOut& txout = tx.getVout()[i];
         // Match if the filter contains any arbitrary script data element in any scriptPubKey in tx
         // If this matches, also add the specific output that was matched.
         // This means clients don't have to update the filter themselves when a new relevant tx 

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -146,9 +146,9 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (contains(hash))
         fFound = true;
 
-    for (unsigned int i = 0; i < tx.getVout().size(); i++)
+    for (unsigned int i = 0; i < tx.GetVouts().size(); i++)
     {
-        const CTxOut& txout = tx.getVout()[i];
+        const CTxOut& txout = tx.GetVouts()[i];
         // Match if the filter contains any arbitrary script data element in any scriptPubKey in tx
         // If this matches, also add the specific output that was matched.
         // This means clients don't have to update the filter themselves when a new relevant tx 
@@ -181,7 +181,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (fFound)
         return true;
 
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
     {
         // Match if the filter contains an outpoint tx spends
         if (contains(txin.prevout))

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -181,7 +181,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (fFound)
         return true;
 
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
     {
         // Match if the filter contains an outpoint tx spends
         if (contains(txin.prevout))

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1064,8 +1064,8 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
         return 0;
 
     CAmount nResult = 0;
-    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
-        nResult += GetOutputFor(tx.GetVins()[i]).nValue;
+    for (unsigned int i = 0; i < tx.GetVin().size(); i++)
+        nResult += GetOutputFor(tx.GetVin()[i]).nValue;
 
     nResult += tx.GetJoinSplitValueIn();
 
@@ -1076,7 +1076,7 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 {
     boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits())
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetVjoinsplit())
     {
         BOOST_FOREACH(const uint256& nullifier, joinsplit.nullifiers)
         {
@@ -1109,8 +1109,8 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.GetVins().size(); i++) {
-            const COutPoint &prevout = tx.GetVins()[i].prevout;
+        for (unsigned int i = 0; i < tx.GetVin().size(); i++) {
+            const COutPoint &prevout = tx.GetVin()[i].prevout;
             const CCoins* coins = AccessCoins(prevout.hash);
             if (!coins || !coins->IsAvailable(prevout.n)) {
                 return false;
@@ -1131,12 +1131,12 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     // (Note that coinbase transactions cannot contain JoinSplits.)
     // FIXME: this logic is partially duplicated between here and CreateNewBlock in miner.cpp.
 
-    if (tx.GetJoinSplits().size() > 0) {
+    if (tx.GetVjoinsplit().size() > 0) {
         return MAXIMUM_PRIORITY;
     }
 
     double dResult = 0.0;
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
     {
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1064,8 +1064,8 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
         return 0;
 
     CAmount nResult = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-        nResult += GetOutputFor(tx.vin[i]).nValue;
+    for (unsigned int i = 0; i < tx.getVins().size(); i++)
+        nResult += GetOutputFor(tx.getVins()[i]).nValue;
 
     nResult += tx.GetJoinSplitValueIn();
 
@@ -1109,8 +1109,8 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            const COutPoint &prevout = tx.vin[i].prevout;
+        for (unsigned int i = 0; i < tx.getVins().size(); i++) {
+            const COutPoint &prevout = tx.getVins()[i].prevout;
             const CCoins* coins = AccessCoins(prevout.hash);
             if (!coins || !coins->IsAvailable(prevout.n)) {
                 return false;
@@ -1136,7 +1136,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     }
 
     double dResult = 0.0;
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
     {
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1076,7 +1076,7 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 {
     boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit)
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit())
     {
         BOOST_FOREACH(const uint256& nullifier, joinsplit.nullifiers)
         {
@@ -1131,7 +1131,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     // (Note that coinbase transactions cannot contain JoinSplits.)
     // FIXME: this logic is partially duplicated between here and CreateNewBlock in miner.cpp.
 
-    if (tx.vjoinsplit.size() > 0) {
+    if (tx.getJoinsSplit().size() > 0) {
         return MAXIMUM_PRIORITY;
     }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1064,8 +1064,8 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
         return 0;
 
     CAmount nResult = 0;
-    for (unsigned int i = 0; i < tx.getVins().size(); i++)
-        nResult += GetOutputFor(tx.getVins()[i]).nValue;
+    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
+        nResult += GetOutputFor(tx.GetVins()[i]).nValue;
 
     nResult += tx.GetJoinSplitValueIn();
 
@@ -1076,7 +1076,7 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 {
     boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit())
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits())
     {
         BOOST_FOREACH(const uint256& nullifier, joinsplit.nullifiers)
         {
@@ -1109,8 +1109,8 @@ bool CCoinsViewCache::HaveJoinSplitRequirements(const CTransaction& tx) const
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.getVins().size(); i++) {
-            const COutPoint &prevout = tx.getVins()[i].prevout;
+        for (unsigned int i = 0; i < tx.GetVins().size(); i++) {
+            const COutPoint &prevout = tx.GetVins()[i].prevout;
             const CCoins* coins = AccessCoins(prevout.hash);
             if (!coins || !coins->IsAvailable(prevout.n)) {
                 return false;
@@ -1131,12 +1131,12 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
     // (Note that coinbase transactions cannot contain JoinSplits.)
     // FIXME: this logic is partially duplicated between here and CreateNewBlock in miner.cpp.
 
-    if (tx.getJoinsSplit().size() > 0) {
+    if (tx.GetJoinSplits().size() > 0) {
         return MAXIMUM_PRIORITY;
     }
 
     double dResult = 0.0;
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
     {
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);

--- a/src/coins.h
+++ b/src/coins.h
@@ -92,7 +92,7 @@ public:
 
     void FromTx(const CTransactionBase &tx, int nHeightIn) {
         fCoinBase = tx.IsCoinBase() || tx.IsCoinCertified();
-        vout = tx.GetVouts();
+        vout = tx.GetVout();
         nHeight = nHeightIn;
         nVersion = tx.nVersion;
         ClearUnspendable();

--- a/src/coins.h
+++ b/src/coins.h
@@ -92,7 +92,7 @@ public:
 
     void FromTx(const CTransactionBase &tx, int nHeightIn) {
         fCoinBase = tx.IsCoinBase() || tx.IsCoinCertified();
-        vout = tx.vout;
+        vout = tx.getVout();
         nHeight = nHeightIn;
         nVersion = tx.nVersion;
         ClearUnspendable();

--- a/src/coins.h
+++ b/src/coins.h
@@ -92,7 +92,7 @@ public:
 
     void FromTx(const CTransactionBase &tx, int nHeightIn) {
         fCoinBase = tx.IsCoinBase() || tx.IsCoinCertified();
-        vout = tx.getVout();
+        vout = tx.GetVouts();
         nHeight = nHeightIn;
         nVersion = tx.nVersion;
         ClearUnspendable();

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -35,11 +35,11 @@ static inline size_t RecursiveDynamicUsage(const CTxBackwardTransferCrosschainOu
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = 0;
     mem += memusage::DynamicUsage(tx.vin);
-    mem += memusage::DynamicUsage(tx.vout);
+    mem += memusage::DynamicUsage(tx.getVout());
     for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.getVout().begin(); it != tx.getVout().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
 // what about shielded components???
@@ -60,9 +60,9 @@ static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
 
 static inline size_t RecursiveDynamicUsage(const CScCertificate& cert) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(cert.vout);
+    mem += memusage::DynamicUsage(cert.getVout());
     mem += memusage::DynamicUsage(cert.vbt_ccout); 
-    for (std::vector<CTxOut>::const_iterator it = cert.vout.begin(); it != cert.vout.end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = cert.getVout().begin(); it != cert.getVout().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     for (std::vector<CTxBackwardTransferCrosschainOut>::const_iterator it = cert.vbt_ccout.begin(); it != cert.vbt_ccout.end(); it++) {

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -34,12 +34,12 @@ static inline size_t RecursiveDynamicUsage(const CTxBackwardTransferCrosschainOu
 
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(tx.GetVins());
-    mem += memusage::DynamicUsage(tx.GetVouts());
-    for (std::vector<CTxIn>::const_iterator it = tx.GetVins().begin(); it != tx.GetVins().end(); it++) {
+    mem += memusage::DynamicUsage(tx.GetVin());
+    mem += memusage::DynamicUsage(tx.GetVout());
+    for (std::vector<CTxIn>::const_iterator it = tx.GetVin().begin(); it != tx.GetVin().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.GetVouts().begin(); it != tx.GetVouts().end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.GetVout().begin(); it != tx.GetVout().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
 // what about shielded components???
@@ -60,9 +60,9 @@ static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
 
 static inline size_t RecursiveDynamicUsage(const CScCertificate& cert) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(cert.GetVouts());
+    mem += memusage::DynamicUsage(cert.GetVout());
     mem += memusage::DynamicUsage(cert.vbt_ccout); 
-    for (std::vector<CTxOut>::const_iterator it = cert.GetVouts().begin(); it != cert.GetVouts().end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = cert.GetVout().begin(); it != cert.GetVout().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     for (std::vector<CTxBackwardTransferCrosschainOut>::const_iterator it = cert.vbt_ccout.begin(); it != cert.vbt_ccout.end(); it++) {

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -34,9 +34,9 @@ static inline size_t RecursiveDynamicUsage(const CTxBackwardTransferCrosschainOu
 
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(tx.vin);
+    mem += memusage::DynamicUsage(tx.getVins());
     mem += memusage::DynamicUsage(tx.getVout());
-    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
+    for (std::vector<CTxIn>::const_iterator it = tx.getVins().begin(); it != tx.getVins().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     for (std::vector<CTxOut>::const_iterator it = tx.getVout().begin(); it != tx.getVout().end(); it++) {

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -34,12 +34,12 @@ static inline size_t RecursiveDynamicUsage(const CTxBackwardTransferCrosschainOu
 
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(tx.getVins());
-    mem += memusage::DynamicUsage(tx.getVout());
-    for (std::vector<CTxIn>::const_iterator it = tx.getVins().begin(); it != tx.getVins().end(); it++) {
+    mem += memusage::DynamicUsage(tx.GetVins());
+    mem += memusage::DynamicUsage(tx.GetVouts());
+    for (std::vector<CTxIn>::const_iterator it = tx.GetVins().begin(); it != tx.GetVins().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.getVout().begin(); it != tx.getVout().end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.GetVouts().begin(); it != tx.GetVouts().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
 // what about shielded components???
@@ -60,9 +60,9 @@ static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
 
 static inline size_t RecursiveDynamicUsage(const CScCertificate& cert) {
     size_t mem = 0;
-    mem += memusage::DynamicUsage(cert.getVout());
+    mem += memusage::DynamicUsage(cert.GetVouts());
     mem += memusage::DynamicUsage(cert.vbt_ccout); 
-    for (std::vector<CTxOut>::const_iterator it = cert.getVout().begin(); it != cert.getVout().end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = cert.GetVouts().begin(); it != cert.GetVouts().end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     for (std::vector<CTxBackwardTransferCrosschainOut>::const_iterator it = cert.vbt_ccout.begin(); it != cert.vbt_ccout.end(); it++) {

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -101,7 +101,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
@@ -119,8 +119,8 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("vin", vin);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
-        const CTxOut& txout = tx.GetVouts()[i];
+    for (unsigned int i = 0; i < tx.GetVout().size(); i++) {
+        const CTxOut& txout = tx.GetVout()[i];
 
         UniValue out(UniValue::VOBJ);
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -119,8 +119,8 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("vin", vin);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        const CTxOut& txout = tx.vout[i];
+    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
+        const CTxOut& txout = tx.getVout()[i];
 
         UniValue out(UniValue::VOBJ);
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -101,7 +101,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins()) {
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
@@ -119,8 +119,8 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("vin", vin);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
-        const CTxOut& txout = tx.getVout()[i];
+    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
+        const CTxOut& txout = tx.GetVouts()[i];
 
         UniValue out(UniValue::VOBJ);
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -101,7 +101,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
+    BOOST_FOREACH(const CTxIn& txin, tx.getVins()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));

--- a/src/gtest/test_getblocktemplate.cpp
+++ b/src/gtest/test_getblocktemplate.cpp
@@ -314,12 +314,12 @@ void TestMaxWeight(int maxWeight, std::map<int,int> expectedInputTx)
         if(tx.IsCoinBase())
             continue;
 
-        ASSERT_TRUE(expectedInputTx.count(tx.vin.size()) > 0);
+        ASSERT_TRUE(expectedInputTx.count(tx.getVins().size()) > 0);
 
-        expectedInputTx.at(tx.vin.size()) --;
+        expectedInputTx.at(tx.getVins().size()) --;
 
-        if(expectedInputTx.at(tx.vin.size()) == 0) {
-            expectedInputTx.erase(tx.vin.size());
+        if(expectedInputTx.at(tx.getVins().size()) == 0) {
+            expectedInputTx.erase(tx.getVins().size());
         }
 
     }

--- a/src/gtest/test_getblocktemplate.cpp
+++ b/src/gtest/test_getblocktemplate.cpp
@@ -314,12 +314,12 @@ void TestMaxWeight(int maxWeight, std::map<int,int> expectedInputTx)
         if(tx.IsCoinBase())
             continue;
 
-        ASSERT_TRUE(expectedInputTx.count(tx.getVins().size()) > 0);
+        ASSERT_TRUE(expectedInputTx.count(tx.GetVins().size()) > 0);
 
-        expectedInputTx.at(tx.getVins().size()) --;
+        expectedInputTx.at(tx.GetVins().size()) --;
 
-        if(expectedInputTx.at(tx.getVins().size()) == 0) {
-            expectedInputTx.erase(tx.getVins().size());
+        if(expectedInputTx.at(tx.GetVins().size()) == 0) {
+            expectedInputTx.erase(tx.GetVins().size());
         }
 
     }

--- a/src/gtest/test_getblocktemplate.cpp
+++ b/src/gtest/test_getblocktemplate.cpp
@@ -314,12 +314,12 @@ void TestMaxWeight(int maxWeight, std::map<int,int> expectedInputTx)
         if(tx.IsCoinBase())
             continue;
 
-        ASSERT_TRUE(expectedInputTx.count(tx.GetVins().size()) > 0);
+        ASSERT_TRUE(expectedInputTx.count(tx.GetVin().size()) > 0);
 
-        expectedInputTx.at(tx.GetVins().size()) --;
+        expectedInputTx.at(tx.GetVin().size()) --;
 
-        if(expectedInputTx.at(tx.GetVins().size()) == 0) {
-            expectedInputTx.erase(tx.GetVins().size());
+        if(expectedInputTx.at(tx.GetVin().size()) == 0) {
+            expectedInputTx.erase(tx.GetVin().size());
         }
 
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -746,7 +746,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason, const int nHeight)
 
     unsigned int nDataOut = 0;
     txnouttype whichType;
-    BOOST_FOREACH(const CTxOut& txout, tx.vout) {
+    BOOST_FOREACH(const CTxOut& txout, tx.getVout()) {
 
         CheckBlockResult checkBlockResult;
         if (!::IsStandard(txout.scriptPubKey, whichType, checkBlockResult)) {
@@ -919,7 +919,7 @@ unsigned int GetLegacySigOpCount(const CTransaction& tx)
     {
         nSigOps += txin.scriptSig.GetSigOpCount(false);
     }
-    BOOST_FOREACH(const CTxOut& txout, tx.vout)
+    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
     {
         nSigOps += txout.scriptPubKey.GetSigOpCount(false);
     }
@@ -1024,7 +1024,7 @@ bool ContextualCheckTransaction(
 bool CheckCertificate(const CScCertificate& cert, CValidationState& state)
 {
     // we allow empty certificate, but if we have no vout the total amount must be 0
-    if (cert.vout.empty() && cert.totalAmount != 0) 
+    if (cert.getVout().empty() && cert.totalAmount != 0)
     {
         return state.DoS(10, error("vout empty and totalAmount != 0"), REJECT_INVALID, "bad-cert-invalid");
     }
@@ -1077,7 +1077,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
     }
 
     // Check for vout's without OP_CHECKBLOCKATHEIGHT opcode
-    BOOST_FOREACH(const CTxOut& txout, tx.vout)
+    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
     {
         txnouttype whichType;
         ::IsStandard(txout.scriptPubKey, whichType);
@@ -1119,7 +1119,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
 
     // also allow the case when crosschain outputs are not empty. In that case there might be no vout at all
     // when utxo reminder is only dust, which is added to fee leaving no change for the sender
-    if (tx.vout.empty() && tx.vjoinsplit.empty() && tx.ccIsNull())
+    if (tx.getVout().empty() && tx.vjoinsplit.empty() && tx.ccIsNull())
     {
         return state.DoS(10, error("CheckTransaction(): vout empty"),
                          REJECT_INVALID, "bad-txns-vout-empty");
@@ -1133,7 +1133,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
 
     // Check for negative or overflow output values
     CAmount nValueOut = 0;
-    BOOST_FOREACH(const CTxOut& txout, tx.vout)
+    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
     {
         if (txout.nValue < 0)
             return state.DoS(100, error("CheckTransaction(): txout.nValue negative"),
@@ -2193,7 +2193,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
                 // Disabled on regtest
                 if (fCoinbaseEnforcedProtectionEnabled &&
                     consensusParams.fCoinbaseMustBeProtected &&
-                    !tx.vout.empty()) {
+                    !tx.getVout().empty()) {
 
                     // Since HARD_FORK_HEIGHT there is an exemption for community fund coinbase coins, so it is allowed
                     // to send them to the transparent addr.
@@ -4158,7 +4158,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
         if (communityReward > 0) {
             bool found = false;
 
-            BOOST_FOREACH(const CTxOut& output, block.vtx[0].vout) {
+            BOOST_FOREACH(const CTxOut& output, block.vtx[0].getVout()) {
                 if (output.scriptPubKey == Params().GetCommunityFundScriptAtHeight(nHeight, cfType)) {
                     if (output.nValue == communityReward) {
                         found = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -627,7 +627,7 @@ bool AddOrphanTx(const CTransaction& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
 
     mapOrphanTransactions[hash].tx = tx;
     mapOrphanTransactions[hash].fromPeer = peer;
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
     LogPrint("mempool", "stored orphan tx %s (mapsz %u prevsz %u)\n", hash.ToString(),
@@ -640,7 +640,7 @@ void static EraseOrphanTx(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     map<uint256, COrphanTx>::iterator it = mapOrphanTransactions.find(hash);
     if (it == mapOrphanTransactions.end())
         return;
-    BOOST_FOREACH(const CTxIn& txin, it->second.tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, it->second.tx.GetVins())
     {
         map<uint256, set<uint256> >::iterator itPrev = mapOrphanTransactionsByPrev.find(txin.prevout.hash);
         if (itPrev == mapOrphanTransactionsByPrev.end())
@@ -725,7 +725,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason, const int nHeight)
     }
 
 
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
     {
         // Biggest 'standard' txin is a 15-of-15 P2SH multisig with compressed
         // keys. (remember the 520 byte limit on redeemScript size) That works
@@ -746,7 +746,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason, const int nHeight)
 
     unsigned int nDataOut = 0;
     txnouttype whichType;
-    BOOST_FOREACH(const CTxOut& txout, tx.getVout()) {
+    BOOST_FOREACH(const CTxOut& txout, tx.GetVouts()) {
 
         CheckBlockResult checkBlockResult;
         if (!::IsStandard(txout.scriptPubKey, whichType, checkBlockResult)) {
@@ -808,7 +808,7 @@ bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
         return true;
     if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
         return true;
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
     /* According to BIP 68, setting nSequence value to 0xFFFFFFFF for every input in the transaction disables nLocktime.
        So, whatever may be the value of nLocktime above, it will have no effect on the transaction as far as nSequence
        value is 0xFFFFFFFF.*/
@@ -862,9 +862,9 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     if (tx.IsCoinBase())
         return true; // Coinbases don't use vin normally
 
-    for (unsigned int i = 0; i < tx.getVins().size(); i++)
+    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
     {
-        const CTxOut& prev = mapInputs.GetOutputFor(tx.getVins()[i]);
+        const CTxOut& prev = mapInputs.GetOutputFor(tx.GetVins()[i]);
 
         vector<vector<unsigned char> > vSolutions;
         txnouttype whichType;
@@ -883,7 +883,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         // IsStandardTx() will have already returned false
         // and this method isn't called.
         vector<vector<unsigned char> > stack;
-        if (!EvalScript(stack, tx.getVins()[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker()))
+        if (!EvalScript(stack, tx.GetVins()[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker()))
             return false;
 
         if (whichType == TX_SCRIPTHASH || whichType == TX_SCRIPTHASH_REPLAY)
@@ -919,11 +919,11 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 unsigned int GetLegacySigOpCount(const CTransaction& tx)
 {
     unsigned int nSigOps = 0;
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
     {
         nSigOps += txin.scriptSig.GetSigOpCount(false);
     }
-    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
+    BOOST_FOREACH(const CTxOut& txout, tx.GetVouts())
     {
         nSigOps += txout.scriptPubKey.GetSigOpCount(false);
     }
@@ -936,11 +936,11 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
         return 0;
 
     unsigned int nSigOps = 0;
-    for (unsigned int i = 0; i < tx.getVins().size(); i++)
+    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
     {
-        const CTxOut &prevout = inputs.GetOutputFor(tx.getVins()[i]);
+        const CTxOut &prevout = inputs.GetOutputFor(tx.GetVins()[i]);
         if (prevout.scriptPubKey.IsPayToScriptHash())
-            nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.getVins()[i].scriptSig);
+            nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.GetVins()[i].scriptSig);
     }
     return nSigOps;
 }
@@ -987,7 +987,7 @@ bool ContextualCheckTransaction(
             (areSidechainsSupported && (tx.nVersion == sidechainVersion) ) )
         {
             //enforce empty joinsplit for transparent txs and sidechain tx
-            if(!tx.getJoinsSplit().empty()) {
+            if(!tx.GetJoinSplits().empty()) {
                 return state.DoS(dosLevel, error("ContextualCheckTransaction(): transparent or sc tx but vjoinsplit not empty"),
                                      REJECT_INVALID, "bad-txns-transparent-jsnotempty");
             }
@@ -1027,35 +1027,35 @@ bool ContextualCheckTransaction(
 
 bool CheckCertificate(const CScCertificate& cert, CValidationState& state)
 {
-    // we allow empty certificate, but if we have no vout the total amount must be 0
-    if (cert.getVout().empty() && cert.totalAmount != 0)
-    {
-        return state.DoS(10, error("vout empty and totalAmount != 0"), REJECT_INVALID, "bad-cert-invalid");
-    }
-
-    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE > MAX_CERT_SIZE); // sanity
-    if (cert.CalculateSize() > MAX_CERT_SIZE)
-    {
-        return state.DoS(100, error("size limits failed"), REJECT_INVALID, "bad-cert-oversize");
-    }
-
-    // Check for negative or overflow output values
-    CAmount nValueOut = 0;
-    if (!cert.CheckVout(nValueOut, state))
-    {
+    if (!cert.CheckVersionBasic(state))
         return false;
-    }
 
-    // Check for vout's without OP_CHECKBLOCKATHEIGHT opcode
-    if (!cert.CheckOutputsCheckBlockAtHeightOpCode(state) )
-    {
+    if (!cert.CheckInputsAvailability(state))
         return false;
-    }
 
-    if (!Sidechain::checkCertSemanticValidity(cert, state) )
-    {
+    if (!cert.CheckOutputsAvailability(state))
         return false;
-    }
+
+    if (!cert.CheckSerializedSize(state))
+        return false;
+
+    if (!cert.CheckOutputsAmount(state))
+        return false;
+
+    if (!cert.CheckInputsAmount(state))
+        return false;
+
+    if (!cert.CheckInputsDuplication(state))
+        return false;
+
+    if (!cert.CheckInputsInteraction(state))
+        return false;
+
+    if (!cert.CheckOutputsCheckBlockAtHeightOpCode(state))
+        return false;
+
+    if (!Sidechain::checkCertSemanticValidity(cert, state))
+        return false;
 
     return true;
 }
@@ -1073,180 +1073,51 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state,
     }
 
     // Ensure that zk-SNARKs verify
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
         if (!joinsplit.Verify(*pzcashParams, verifier, tx.joinSplitPubKey)) {
             return state.DoS(100, error("CheckTransaction(): joinsplit does not verify"),
                                 REJECT_INVALID, "bad-txns-joinsplit-verification-failed");
         }
     }
 
-    // Check for vout's without OP_CHECKBLOCKATHEIGHT opcode
-    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
-    {
-        txnouttype whichType;
-        ::IsStandard(txout.scriptPubKey, whichType);
-
-        // provide temporary replay protection for two minerconf windows during chainsplit
-        if ((!tx.IsCoinBase()) && (!ForkManager::getInstance().isTransactionTypeAllowedAtHeight(chainActive.Height(),whichType))) {
-                return state.DoS(0, error("%s: %s: %s is not activated at this block height %d. Transaction rejected. Tx id: %s", __FILE__, __func__, ::GetTxnOutputType(whichType), chainActive.Height(), tx.GetHash().ToString()),
-                             REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
-        }
-    }
-
-    if (!Sidechain::checkTxSemanticValidity(tx, state) )
-    {
+    if (!tx.CheckOutputsCheckBlockAtHeightOpCode(state))
         return false;
-    }
+
+    if (!Sidechain::checkTxSemanticValidity(tx, state))
+        return false;
 
     return true;
 }
 
 bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidationState &state)
 {
-    // Basic checks that don't depend on any context
-    // Check transaction version
-    if (tx.nVersion < MIN_OLD_TX_VERSION && tx.nVersion != GROTH_TX_VERSION && !tx.IsScVersion() )
+    if (!tx.CheckVersionBasic(state))
+        return false;
+
+    if (!tx.CheckInputsAvailability(state))
+        return false;
+
+    if (!tx.CheckOutputsAvailability(state))
+        return false;
+
+    if (!tx.CheckSerializedSize(state))
+        return false;
+
+    if (!tx.CheckOutputsAmount(state))
+        return false;
+
+    if (!tx.CheckInputsAmount(state))
+        return false;
+
+    if (!tx.CheckInputsDuplication(state))
+        return false;
+
+    if (!tx.CheckInputsInteraction(state))
+        return false;
+
+    if (!tx.IsCoinBase())
     {
-        return state.DoS(100, error("CheckTransaction(): version too low"),
-                         REJECT_INVALID, "bad-txns-version-too-low");
-    }
-
-
-    // Transactions can contain empty `vin` and `vout` so long as
-    // `vjoinsplit` is non-empty.
-    if (tx.getVins().empty() && tx.getJoinsSplit().empty())
-    {
-        LogPrint("sc", "%s():%d - Error: tx[%s]\n", __func__, __LINE__, tx.GetHash().ToString() );
-        return state.DoS(10, error("CheckTransaction(): vin empty"),
-                         REJECT_INVALID, "bad-txns-vin-empty");
-    }
-
-    // also allow the case when crosschain outputs are not empty. In that case there might be no vout at all
-    // when utxo reminder is only dust, which is added to fee leaving no change for the sender
-    if (tx.getVout().empty() && tx.getJoinsSplit().empty() && tx.ccIsNull())
-    {
-        return state.DoS(10, error("CheckTransaction(): vout empty"),
-                         REJECT_INVALID, "bad-txns-vout-empty");
-    }
-
-    // Size limits
-    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE > MAX_TX_SIZE); // sanity
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_TX_SIZE)
-        return state.DoS(100, error("CheckTransaction(): size limits failed"),
-                         REJECT_INVALID, "bad-txns-oversize");
-
-    // Check for negative or overflow output values
-    CAmount nValueOut = 0;
-    BOOST_FOREACH(const CTxOut& txout, tx.getVout())
-    {
-        if (txout.nValue < 0)
-            return state.DoS(100, error("CheckTransaction(): txout.nValue negative"),
-                             REJECT_INVALID, "bad-txns-vout-negative");
-        if (txout.nValue > MAX_MONEY)
-            return state.DoS(100, error("CheckTransaction(): txout.nValue too high"),
-                             REJECT_INVALID, "bad-txns-vout-toolarge");
-        nValueOut += txout.nValue;
-        if (!MoneyRange(nValueOut))
-            return state.DoS(100, error("CheckTransaction(): txout total out of range"),
-                             REJECT_INVALID, "bad-txns-txouttotal-toolarge");
-    }
-
-    // Ensure that joinsplit values are well-formed
-    BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit())
-    {
-        if (joinsplit.vpub_old < 0) {
-            return state.DoS(100, error("CheckTransaction(): joinsplit.vpub_old negative"),
-                             REJECT_INVALID, "bad-txns-vpub_old-negative");
-        }
-
-        if (joinsplit.vpub_new < 0) {
-            return state.DoS(100, error("CheckTransaction(): joinsplit.vpub_new negative"),
-                             REJECT_INVALID, "bad-txns-vpub_new-negative");
-        }
-
-        if (joinsplit.vpub_old > MAX_MONEY) {
-            return state.DoS(100, error("CheckTransaction(): joinsplit.vpub_old too high"),
-                             REJECT_INVALID, "bad-txns-vpub_old-toolarge");
-        }
-
-        if (joinsplit.vpub_new > MAX_MONEY) {
-            return state.DoS(100, error("CheckTransaction(): joinsplit.vpub_new too high"),
-                             REJECT_INVALID, "bad-txns-vpub_new-toolarge");
-        }
-
-        if (joinsplit.vpub_new != 0 && joinsplit.vpub_old != 0) {
-            return state.DoS(100, error("CheckTransaction(): joinsplit.vpub_new and joinsplit.vpub_old both nonzero"),
-                             REJECT_INVALID, "bad-txns-vpubs-both-nonzero");
-        }
-
-        nValueOut += joinsplit.vpub_old;
-        if (!MoneyRange(nValueOut)) {
-            return state.DoS(100, error("CheckTransaction(): txout total out of range"),
-                             REJECT_INVALID, "bad-txns-txouttotal-toolarge");
-        }
-    }
-
-    // Ensure input values do not exceed MAX_MONEY
-    // We have not resolved the txin values at this stage,
-    // but we do know what the joinsplits claim to add
-    // to the value pool.
-    {
-        CAmount nValueIn = 0;
-        for (std::vector<JSDescription>::const_iterator it(tx.getJoinsSplit().begin()); it != tx.getJoinsSplit().end(); ++it)
-        {
-            nValueIn += it->vpub_new;
-
-            if (!MoneyRange(it->vpub_new) || !MoneyRange(nValueIn)) {
-                return state.DoS(100, error("CheckTransaction(): txin total out of range"),
-                                 REJECT_INVALID, "bad-txns-txintotal-toolarge");
-            }
-        }
-    }
-
-
-    // Check for duplicate inputs
-    set<COutPoint> vInOutPoints;
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins())
-    {
-        if (vInOutPoints.count(txin.prevout))
-            return state.DoS(100, error("CheckTransaction(): duplicate inputs"),
-                             REJECT_INVALID, "bad-txns-inputs-duplicate");
-        vInOutPoints.insert(txin.prevout);
-    }
-
-    // Check for duplicate joinsplit nullifiers in this transaction
-    set<uint256> vJoinSplitNullifiers;
-    BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit())
-    {
-        BOOST_FOREACH(const uint256& nf, joinsplit.nullifiers)
-        {
-            if (vJoinSplitNullifiers.count(nf))
-                return state.DoS(100, error("CheckTransaction(): duplicate nullifiers"),
-                             REJECT_INVALID, "bad-joinsplits-nullifiers-duplicate");
-
-            vJoinSplitNullifiers.insert(nf);
-        }
-    }
-
-    if (tx.IsCoinBase())
-    {
-        // There should be no joinsplits in a coinbase transaction
-        if (tx.getJoinsSplit().size() > 0)
-            return state.DoS(100, error("CheckTransaction(): coinbase has joinsplits"),
-                             REJECT_INVALID, "bad-cb-has-joinsplits");
-
-        if (tx.getVins()[0].scriptSig.size() < 2 || tx.getVins()[0].scriptSig.size() > 100)
-            return state.DoS(100, error("CheckTransaction(): coinbase script size"),
-                             REJECT_INVALID, "bad-cb-length");
-    }
-    else
-    {
-        BOOST_FOREACH(const CTxIn& txin, tx.getVins())
-            if (txin.prevout.IsNull())
-                return state.DoS(10, error("CheckTransaction(): prevout is null"),
-                                 REJECT_INVALID, "bad-txns-prevout-null");
-
-        if (tx.getJoinsSplit().size() > 0) {
+        if (tx.GetJoinSplits().size() > 0) {
             // Empty output script.
             CScript scriptCode;
             uint256 dataToBeSigned;
@@ -1459,7 +1330,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     static_assert(std::numeric_limits<size_t>::max() >= std::numeric_limits<int64_t>::max(), "size_t too small");
     size_t limit = (size_t) GetArg("-mempooltxinputlimit", 0);
     if (limit > 0) {
-        size_t n = tx.getVins().size();
+        size_t n = tx.GetVins().size();
         if (n > limit) {
             LogPrint("mempool", "Dropping txid %s : too many transparent inputs %zu > limit %zu\n", tx.GetHash().ToString(), n, limit );
             return false;
@@ -1515,9 +1386,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     // Check for conflicts with in-memory transactions
     {
         LOCK(pool.cs); // protect pool.mapNextTx
-        for (unsigned int i = 0; i < tx.getVins().size(); i++)
+        for (unsigned int i = 0; i < tx.GetVins().size(); i++)
         {
-            COutPoint outpoint = tx.getVins()[i].prevout;
+            COutPoint outpoint = tx.GetVins()[i].prevout;
             if (pool.mapNextTx.count(outpoint))
             {
                 // Disable replacement feature for now
@@ -1533,7 +1404,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             }
         }
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 if (pool.mapNullifiers.count(nf))
                 {
@@ -1563,7 +1434,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             // do all inputs exist?
             // Note that this does not check for the presence of actual outputs (see the next check for that),
             // and only helps with filling in pfMissingInputs (to determine missing vs spent).
-            BOOST_FOREACH(const CTxIn txin, tx.getVins())
+            BOOST_FOREACH(const CTxIn txin, tx.GetVins())
             {
                 if (!view.HaveCoins(txin.prevout.hash))
                 {
@@ -1637,7 +1508,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         unsigned int nSize = entry.GetTxSize();
 
         // Accept a tx if it contains joinsplits and has at least the default fee specified by z_sendmany.
-        if (tx.getJoinsSplit().size() > 0 && nFees >= ASYNC_RPC_OPERATION_DEFAULT_MINERS_FEE) {
+        if (tx.GetJoinSplits().size() > 0 && nFees >= ASYNC_RPC_OPERATION_DEFAULT_MINERS_FEE) {
             // In future we will we have more accurate and dynamic computation of fees for tx with joinsplits.
         } else {
             // Don't accept it if it can't get into a block
@@ -2092,8 +1963,8 @@ void UpdateCoins(const CTransactionBase& txBase, CValidationState &state, CCoins
 {
     // mark inputs spent
     if (!txBase.IsCoinBase()) {
-        txundo.vprevout.reserve(txBase.getVins().size());
-        for(const CTxIn &txin: txBase.getVins()) {
+        txundo.vprevout.reserve(txBase.GetVins().size());
+        for(const CTxIn &txin: txBase.GetVins()) {
             CCoinsModifier coins = inputs.ModifyCoins(txin.prevout.hash);
             unsigned nPos = txin.prevout.n;
 
@@ -2112,7 +1983,7 @@ void UpdateCoins(const CTransactionBase& txBase, CValidationState &state, CCoins
     }
 
     // spend nullifiers
-    for(const JSDescription &joinsplit: txBase.getJoinsSplit()) {
+    for(const JSDescription &joinsplit: txBase.GetJoinSplits()) {
         for(const uint256 &nf: joinsplit.nullifiers) {
             inputs.SetNullifier(nf, true);
         }
@@ -2129,7 +2000,7 @@ void UpdateCoins(const CTransactionBase& txBase, CValidationState &state, CCoins
 }
 
 bool CScriptCheck::operator()() {
-    const CScript &scriptSig = ptxTo->getVins()[nIn].scriptSig;
+    const CScript &scriptSig = ptxTo->GetVins()[nIn].scriptSig;
     if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, chain, cacheStore), &error)) {
         return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->GetHash().ToString(), nIn, ScriptErrorString(error));
     }
@@ -2179,9 +2050,9 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 
         CAmount nValueIn = 0;
         CAmount nFees = 0;
-        for (unsigned int i = 0; i < tx.getVins().size(); i++)
+        for (unsigned int i = 0; i < tx.GetVins().size(); i++)
         {
-            const COutPoint &prevout = tx.getVins()[i].prevout;
+            const COutPoint &prevout = tx.GetVins()[i].prevout;
             const CCoins *coins = inputs.AccessCoins(prevout.hash);
             assert(coins);
 
@@ -2197,7 +2068,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
                 // Disabled on regtest
                 if (fCoinbaseEnforcedProtectionEnabled &&
                     consensusParams.fCoinbaseMustBeProtected &&
-                    !tx.getVout().empty()) {
+                    !tx.GetVouts().empty()) {
 
                     // Since HARD_FORK_HEIGHT there is an exemption for community fund coinbase coins, so it is allowed
                     // to send them to the transparent addr.
@@ -2251,7 +2122,7 @@ bool ContextualCheckInputs(const CTransaction& tx, CValidationState &state, cons
         }
 
         if (pvChecks)
-            pvChecks->reserve(tx.getVins().size());
+            pvChecks->reserve(tx.GetVins().size());
 
         // The first loop above does all the inexpensive checks.
         // Only if ALL inputs pass do we perform expensive ECDSA signature checks.
@@ -2261,8 +2132,8 @@ bool ContextualCheckInputs(const CTransaction& tx, CValidationState &state, cons
         // before the last block chain checkpoint. This is safe because block merkle hashes are
         // still computed and checked, and any change will be caught at the next checkpoint.
         if (fScriptChecks) {
-            for (unsigned int i = 0; i < tx.getVins().size(); i++) {
-                const COutPoint &prevout = tx.getVins()[i].prevout;
+            for (unsigned int i = 0; i < tx.GetVins().size(); i++) {
+                const COutPoint &prevout = tx.GetVins()[i].prevout;
                 const CCoins* coins = inputs.AccessCoins(prevout.hash);
                 assert(coins);
 
@@ -2467,7 +2338,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
         }
 
         // unspend nullifiers
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 view.SetNullifier(nf, false);
             }
@@ -2483,10 +2354,10 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
         // restore inputs
         if (i > 0) { // not coinbases
             const CTxUndo &txundo = blockUndo.vtxundo[i-1];
-            if (txundo.vprevout.size() != tx.getVins().size())
+            if (txundo.vprevout.size() != tx.GetVins().size())
                 return error("DisconnectBlock(): transaction and undo data inconsistent");
-            for (unsigned int j = tx.getVins().size(); j-- > 0;) {
-                const COutPoint &out = tx.getVins()[j].prevout;
+            for (unsigned int j = tx.GetVins().size(); j-- > 0;) {
+                const COutPoint &out = tx.GetVins()[j].prevout;
                 const CTxInUndo &undo = txundo.vprevout[j];
                 if (!ApplyTxInUndo(undo, view, out))
                     fClean = false;
@@ -2764,7 +2635,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     {
         const CTransaction &tx = block.vtx[i];
 
-        nInputs += tx.getVins().size();
+        nInputs += tx.GetVins().size();
         nSigOps += tx.GetLegacySigOpCount();
         if (nSigOps > MAX_BLOCK_SIGOPS)
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
@@ -2817,7 +2688,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             }
         }
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
             BOOST_FOREACH(const uint256 &note_commitment, joinsplit.commitments) {
                 // Insert the note commitments into our temporary tree.
                 tree.append(note_commitment);
@@ -3810,7 +3681,7 @@ bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBl
     pindexNew->nChainTx = 0;
     CAmount sproutValue = 0;
     for (auto tx : block.vtx) {
-        for (auto js : tx.getJoinsSplit()) {
+        for (auto js : tx.GetJoinSplits()) {
             sproutValue += js.vpub_old;
             sproutValue -= js.vpub_new;
         }
@@ -4141,8 +4012,8 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     if (nHeight > 0)
     {
         CScript expect = CScript() << nHeight;
-        if (block.vtx[0].getVins()[0].scriptSig.size() < expect.size() ||
-            !std::equal(expect.begin(), expect.end(), block.vtx[0].getVins()[0].scriptSig.begin())) {
+        if (block.vtx[0].GetVins()[0].scriptSig.size() < expect.size() ||
+            !std::equal(expect.begin(), expect.end(), block.vtx[0].GetVins()[0].scriptSig.begin())) {
             return state.DoS(100, error("%s: block height mismatch in coinbase", __func__), REJECT_INVALID, "bad-cb-height");
         }
     }
@@ -4162,7 +4033,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
         if (communityReward > 0) {
             bool found = false;
 
-            BOOST_FOREACH(const CTxOut& output, block.vtx[0].getVout()) {
+            BOOST_FOREACH(const CTxOut& output, block.vtx[0].GetVouts()) {
                 if (output.scriptPubKey == Params().GetCommunityFundScriptAtHeight(nHeight, cfType)) {
                     if (output.nValue == communityReward) {
                         found = true;
@@ -6154,7 +6025,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 EraseOrphanTx(hash);
         }
         // TODO: currently, prohibit joinsplits from entering mapOrphans
-        else if (fMissingInputs && tx.getJoinsSplit().size() == 0)
+        else if (fMissingInputs && tx.GetJoinSplits().size() == 0)
         {
             AddOrphanTx(tx, pfrom->GetId());
 

--- a/src/main.h
+++ b/src/main.h
@@ -423,7 +423,7 @@ private:
 public:
     CScriptCheck(): ptxTo(0), nIn(0), chain(nullptr), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, const CChain* chainIn, unsigned int nFlagsIn, bool cacheIn) :
-        scriptPubKey(txFromIn.vout[txToIn.getVins()[nInIn].prevout.n].scriptPubKey),
+        scriptPubKey(txFromIn.vout[txToIn.GetVins()[nInIn].prevout.n].scriptPubKey),
         ptxTo(&txToIn), nIn(nInIn), chain(chainIn), nFlags(nFlagsIn), cacheStore(cacheIn), error(SCRIPT_ERR_UNKNOWN_ERROR) { }
 
     bool operator()();

--- a/src/main.h
+++ b/src/main.h
@@ -423,7 +423,7 @@ private:
 public:
     CScriptCheck(): ptxTo(0), nIn(0), chain(nullptr), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, const CChain* chainIn, unsigned int nFlagsIn, bool cacheIn) :
-        scriptPubKey(txFromIn.vout[txToIn.GetVins()[nInIn].prevout.n].scriptPubKey),
+        scriptPubKey(txFromIn.vout[txToIn.GetVin()[nInIn].prevout.n].scriptPubKey),
         ptxTo(&txToIn), nIn(nInIn), chain(chainIn), nFlags(nFlagsIn), cacheStore(cacheIn), error(SCRIPT_ERR_UNKNOWN_ERROR) { }
 
     bool operator()();

--- a/src/main.h
+++ b/src/main.h
@@ -423,7 +423,7 @@ private:
 public:
     CScriptCheck(): ptxTo(0), nIn(0), chain(nullptr), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, const CChain* chainIn, unsigned int nFlagsIn, bool cacheIn) :
-        scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey),
+        scriptPubKey(txFromIn.vout[txToIn.getVins()[nInIn].prevout.n].scriptPubKey),
         ptxTo(&txToIn), nIn(nInIn), chain(chainIn), nFlags(nFlagsIn), cacheStore(cacheIn), error(SCRIPT_ERR_UNKNOWN_ERROR) { }
 
     bool operator()();

--- a/src/main.h
+++ b/src/main.h
@@ -375,10 +375,10 @@ bool ContextualCheckTransaction(const CTransaction& tx, CValidationState &state,
                                 bool (*isInitBlockDownload)() = IsInitialBlockDownload);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
-void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCache &inputs, int nHeight);
+void UpdateCoins(const CTransactionBase& txBase, CValidationState &state, CCoinsViewCache &inputs, int nHeight);
 
 class CTxUndo;
-void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCache &inputs, CTxUndo& txundo, int nHeight);
+void UpdateCoins(const CTransactionBase& txBase, CValidationState &state, CCoinsViewCache &inputs, CTxUndo& txundo, int nHeight);
 
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, CValidationState& state, libzcash::ProofVerifier& verifier);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -182,7 +182,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().vout[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().getVout()[txin.prevout.n].nValue;
             }
         }
 #if 1
@@ -305,7 +305,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().vout[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().getVout()[txin.prevout.n].nValue;
                 continue;
             }
             const CCoins* coins = view.AccessCoins(txin.prevout.hash);
@@ -719,7 +719,7 @@ static bool ProcessBlockFound(CBlock* pblock)
 #endif // ENABLE_WALLET
 {
     LogPrintf("%s\n", pblock->ToString());
-    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
+    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].getVout()[0].nValue));
 
     // Found a solution
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -546,11 +546,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 #endif
                 continue;
 
-#if 0
             UpdateCoins(tx, state, view, nHeight);
-#else
-            tx.UpdateCoins(state, view, nHeight);
-#endif
 
             // Added
 #if 0

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,7 +157,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         bool fMissingInputs = false;
 
         // Detect orphan transaction and its dependencies
-        BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
         {
 #if 0
             if (mempool.mapTx.count(txin.prevout.hash))
@@ -182,7 +182,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVouts()[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVout()[txin.prevout.n].nValue;
             }
         }
 #if 1
@@ -204,7 +204,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         }
         else
         {
-            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
             {
                 // Read prev transaction
                 // Skip transactions in mempool
@@ -278,7 +278,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
         double dPriority = 0;
         CAmount nTotalIn = 0;
         bool fMissingInputs = false;
-        BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
         {
             // Read prev transaction
             if (!view.HaveCoins(txin.prevout.hash))
@@ -305,7 +305,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVouts()[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVout()[txin.prevout.n].nValue;
                 continue;
             }
             const CCoins* coins = view.AccessCoins(txin.prevout.hash);
@@ -490,7 +490,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 
             // Skip transaction if max block complexity reached.
 #if 0
-            int nTxComplexity = tx.GetVins().size() * tx.GetVins().size();
+            int nTxComplexity = tx.GetVin().size() * tx.GetVin().size();
 #else
             int nTxComplexity = tx.GetComplexity();
 #endif
@@ -719,7 +719,7 @@ static bool ProcessBlockFound(CBlock* pblock)
 #endif // ENABLE_WALLET
 {
     LogPrintf("%s\n", pblock->ToString());
-    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].GetVouts()[0].nValue));
+    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].GetVout()[0].nValue));
 
     // Found a solution
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,7 +157,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         bool fMissingInputs = false;
 
         // Detect orphan transaction and its dependencies
-        BOOST_FOREACH(const CTxIn& txin, tx.vin)
+        BOOST_FOREACH(const CTxIn& txin, tx.getVins())
         {
 #if 0
             if (mempool.mapTx.count(txin.prevout.hash))
@@ -204,7 +204,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         }
         else
         {
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
+            BOOST_FOREACH(const CTxIn& txin, tx.getVins())
             {
                 // Read prev transaction
                 // Skip transactions in mempool
@@ -278,7 +278,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
         double dPriority = 0;
         CAmount nTotalIn = 0;
         bool fMissingInputs = false;
-        BOOST_FOREACH(const CTxIn& txin, tx.vin)
+        BOOST_FOREACH(const CTxIn& txin, tx.getVins())
         {
             // Read prev transaction
             if (!view.HaveCoins(txin.prevout.hash))
@@ -490,7 +490,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 
             // Skip transaction if max block complexity reached.
 #if 0
-            int nTxComplexity = tx.vin.size() * tx.vin.size();
+            int nTxComplexity = tx.getVins().size() * tx.getVins().size();
 #else
             int nTxComplexity = tx.GetComplexity();
 #endif

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,7 +157,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         bool fMissingInputs = false;
 
         // Detect orphan transaction and its dependencies
-        BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
         {
 #if 0
             if (mempool.mapTx.count(txin.prevout.hash))
@@ -182,7 +182,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().getVout()[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVouts()[txin.prevout.n].nValue;
             }
         }
 #if 1
@@ -204,7 +204,7 @@ void GetBlockTxPriorityData(const CBlock *pblock, int nHeight, int64_t nMedianTi
         }
         else
         {
-            BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
             {
                 // Read prev transaction
                 // Skip transactions in mempool
@@ -278,7 +278,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
         double dPriority = 0;
         CAmount nTotalIn = 0;
         bool fMissingInputs = false;
-        BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
         {
             // Read prev transaction
             if (!view.HaveCoins(txin.prevout.hash))
@@ -305,7 +305,7 @@ void GetBlockTxPriorityDataOld(const CBlock *pblock, int nHeight, int64_t nMedia
                 }
                 mapDependers[txin.prevout.hash].push_back(porphan);
                 porphan->setDependsOn.insert(txin.prevout.hash);
-                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().getVout()[txin.prevout.n].nValue;
+                nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().GetVouts()[txin.prevout.n].nValue;
                 continue;
             }
             const CCoins* coins = view.AccessCoins(txin.prevout.hash);
@@ -490,7 +490,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 
             // Skip transaction if max block complexity reached.
 #if 0
-            int nTxComplexity = tx.getVins().size() * tx.getVins().size();
+            int nTxComplexity = tx.GetVins().size() * tx.GetVins().size();
 #else
             int nTxComplexity = tx.GetComplexity();
 #endif
@@ -719,7 +719,7 @@ static bool ProcessBlockFound(CBlock* pblock)
 #endif // ENABLE_WALLET
 {
     LogPrintf("%s\n", pblock->ToString());
-    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].getVout()[0].nValue));
+    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].GetVouts()[0].nValue));
 
     // Found a solution
     {

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -116,20 +116,6 @@ void CScCertificate::AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount 
     pblocktemplate->vCertSigOps.push_back(sigops);
 }
 
-void CScCertificate::UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const
-{
-    // no inputs in cert, therefore no need to handle block undo
-    CBlockUndo dum;
-    UpdateCoins(state, view, dum, nHeight);
-}
-
-void CScCertificate::UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo& unused, int nHeight) const
-{
-    // no inputs in cert, therefore no need to handle block undo
-    LogPrint("cert", "%s():%d - adding coins for cert [%s]\n", __func__, __LINE__, GetHash().ToString());
-    view.ModifyCoins(GetHash())->FromTx(*this, nHeight);
-}
-
 bool CScCertificate::ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const 
 {
     bool areScSupported = zen::ForkManager::getInstance().areSidechainsSupported(nHeight);

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -200,7 +200,7 @@ CMutableScCertificate::CMutableScCertificate(const CScCertificate& cert) :
     totalAmount(cert.totalAmount), fee(cert.fee), vbt_ccout(cert.vbt_ccout), nonce(cert.nonce)
 {
     nVersion = cert.nVersion;
-    vout = cert.vout;
+    vout = cert.getVout();
 }
 
 uint256 CMutableScCertificate::GetHash() const

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -67,7 +67,7 @@ bool CScCertificate::CheckVersionBasic(CValidationState &state) const
 bool CScCertificate::CheckInputsAvailability(CValidationState &state) const
 {
     //Currently there are no inputs for certificates
-    if (!GetVins().empty())
+    if (!GetVin().empty())
     {
         return state.DoS(10, error("vin not empty"), REJECT_INVALID, "bad-cert-invalid");
     }
@@ -78,7 +78,7 @@ bool CScCertificate::CheckInputsAvailability(CValidationState &state) const
 bool CScCertificate::CheckOutputsAvailability(CValidationState &state) const
 {
     // we allow empty certificate, but if we have no vout the total amount must be 0
-    if (GetVouts().empty() && totalAmount != 0)
+    if (GetVout().empty() && totalAmount != 0)
     {
         return state.DoS(10, error("vout empty and totalAmount != 0"), REJECT_INVALID, "bad-cert-invalid");
     }
@@ -238,7 +238,7 @@ CMutableScCertificate::CMutableScCertificate(const CScCertificate& cert) :
     totalAmount(cert.totalAmount), fee(cert.fee), vbt_ccout(cert.vbt_ccout), nonce(cert.nonce)
 {
     nVersion = cert.nVersion;
-    vout = cert.GetVouts();
+    vout = cert.GetVout();
 }
 
 uint256 CMutableScCertificate::GetHash() const

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -66,9 +66,19 @@ public:
     template <typename Stream>
     CScCertificate(deserialize_type, Stream& s) : CScCertificate(CMutableScCertificate(deserialize, s)) {}
 
-    const std::vector<CTxIn>&         getVins()       const override {static const std::vector<CTxIn> noInputs; return noInputs;};
-    const std::vector<CTxOut>&        getVout()       const override {return vout;};
-    const std::vector<JSDescription>& getJoinsSplit() const override {static const std::vector<JSDescription> noJs; return noJs;};
+    //GETTERS
+    const std::vector<CTxIn>&         GetVins()       const override {static const std::vector<CTxIn> noInputs; return noInputs;};
+    const std::vector<CTxOut>&        GetVouts()       const override {return vout;};
+    const std::vector<JSDescription>& GetJoinSplits() const override {static const std::vector<JSDescription> noJs; return noJs;};
+    //END OF GETTERS
+
+    //CHECK FUNCTIONS
+    bool CheckVersionBasic        (CValidationState &state) const override;
+    bool CheckInputsAvailability  (CValidationState &state) const override;
+    bool CheckOutputsAvailability (CValidationState &state) const override;
+    bool CheckSerializedSize      (CValidationState &state) const override;
+    //END OF CHECK FUNCTIONS
+
 
     bool IsNull() const override {
         return (

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -66,6 +66,10 @@ public:
     template <typename Stream>
     CScCertificate(deserialize_type, Stream& s) : CScCertificate(CMutableScCertificate(deserialize, s)) {}
 
+    const std::vector<CTxIn>&         getVins()       const override {static const std::vector<CTxIn> noInputs; return noInputs;};
+    const std::vector<CTxOut>&        getVout()       const override {return vout;};
+    const std::vector<JSDescription>& getJoinsSplit() const override {static const std::vector<JSDescription> noJs; return noJs;};
+
     bool IsNull() const override {
         return (
             scId.IsNull() &&
@@ -96,9 +100,6 @@ public:
     bool IsApplicableToState(CValidationState& state, int nHeight = -1) const override;
 
     bool IsStandard(std::string& reason, int nHeight) const override;
-    
-    void UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const override;
-    void UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo& txundo, int nHeight) const override;
 
     bool TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee) override final;
 

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -67,9 +67,9 @@ public:
     CScCertificate(deserialize_type, Stream& s) : CScCertificate(CMutableScCertificate(deserialize, s)) {}
 
     //GETTERS
-    const std::vector<CTxIn>&         GetVins()       const override {static const std::vector<CTxIn> noInputs; return noInputs;};
-    const std::vector<CTxOut>&        GetVouts()       const override {return vout;};
-    const std::vector<JSDescription>& GetJoinSplits() const override {static const std::vector<JSDescription> noJs; return noJs;};
+    const std::vector<CTxIn>&         GetVin()        const override {static const std::vector<CTxIn> noInputs; return noInputs;};
+    const std::vector<CTxOut>&        GetVout()       const override {return vout;};
+    const std::vector<JSDescription>& GetVjoinsplit() const override {static const std::vector<JSDescription> noJs; return noJs;};
     //END OF GETTERS
 
     //CHECK FUNCTIONS

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -580,8 +580,6 @@ void CTransaction::HandleJoinSplitCommittments(ZCIncrementalMerkleTree& tree) co
 void CTransaction::AddJoinSplitToJSON(UniValue& entry) const { return; }
 void CTransaction::AddSidechainOutsToJSON(UniValue& entry) const { return; }
 bool CTransaction::HaveInputs(const CCoinsViewCache& view) const { return true; }
-void CTransaction::UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const { return; }
-void CTransaction::UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo &undo, int nHeight) const { return; }
 bool CTransaction::AreInputsStandard(CCoinsViewCache& view) const { return true; }
 unsigned int CTransaction::GetP2SHSigOpCount(CCoinsViewCache& view) const { return 0; }
 unsigned int CTransaction::GetLegacySigOpCount() const { return 0; }
@@ -765,20 +763,6 @@ void CTransaction::AddSidechainOutsToJSON(UniValue& entry) const
 bool CTransaction::HaveInputs(const CCoinsViewCache& view) const
 {
     return view.HaveInputs(*this);
-}
-
-void CTransaction::UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const
-{
-    return ::UpdateCoins(*this, state, view, nHeight);
-}
-
-void CTransaction::UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo& blockundo, int nHeight) const
-{
-    CTxUndo undoDummy;
-    if (!IsCoinBase() ) {
-        blockundo.vtxundo.push_back(CTxUndo());
-    }
-    return ::UpdateCoins(*this, state, view, (IsCoinBase() ? undoDummy : blockundo.vtxundo.back()), nHeight);
 }
 
 bool CTransaction::AreInputsStandard(CCoinsViewCache& view) const 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -298,7 +298,7 @@ CMutableTransaction::CMutableTransaction(const CTransaction& tx) :
     vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig)
 {
     nVersion = tx.nVersion;
-    vin = tx.vin;
+    vin = tx.getVins();
     vout = tx.getVout();
 }
     

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -295,7 +295,7 @@ CMutableTransaction::CMutableTransaction() : CMutableTransactionBase(), nLockTim
 
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) :
     vsc_ccout(tx.vsc_ccout), vcl_ccout(tx.vcl_ccout), vft_ccout(tx.vft_ccout), nLockTime(tx.nLockTime),
-    vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig)
+    vjoinsplit(tx.getJoinsSplit()), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig)
 {
     nVersion = tx.nVersion;
     vin = tx.getVins();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -299,7 +299,7 @@ CMutableTransaction::CMutableTransaction(const CTransaction& tx) :
 {
     nVersion = tx.nVersion;
     vin = tx.vin;
-    vout = tx.vout;
+    vout = tx.getVout();
 }
     
 uint256 CMutableTransaction::GetHash() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -681,6 +681,10 @@ public:
     bool CheckOutputsAreStandard(int nHeight, std::string& reason) const;
     bool CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const;
 
+    virtual const std::vector<CTxIn>&         getVins()       const = 0;
+    virtual const std::vector<CTxOut>&        getVout()       const = 0;
+    virtual const std::vector<JSDescription>& getJoinsSplit() const = 0;
+
     // Return sum of txouts.
     virtual CAmount GetValueOut() const;
 
@@ -707,9 +711,6 @@ public:
     virtual bool IsStandard(std::string& reason, int nHeight) const = 0;
     virtual bool CheckFinal(int flags = -1) const = 0;
     virtual bool IsApplicableToState(CValidationState& state, int nHeight = -1) const = 0;
-
-    virtual void UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const = 0;
-    virtual void UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo& txundo, int nHeight) const = 0;
 
     virtual double GetPriority(const CCoinsViewCache &view, int nHeight) const = 0;
     virtual unsigned int GetLegacySigOpCount() const = 0;
@@ -851,6 +852,10 @@ public:
         );
     }
     
+    const std::vector<CTxIn>&         getVins()       const override {return vin;};
+    const std::vector<CTxOut>&        getVout()       const override {return vout;};
+    const std::vector<JSDescription>& getJoinsSplit() const override {return vjoinsplit;};
+
     // Return sum of txouts.
     CAmount GetValueOut() const override;
     // Return sum of tx ins
@@ -960,8 +965,6 @@ public:
     void AddJoinSplitToJSON(UniValue& entry) const override;
     void AddSidechainOutsToJSON(UniValue& entry) const override;
     bool HaveInputs(const CCoinsViewCache& view) const override;
-    void UpdateCoins(CValidationState &state, CCoinsViewCache& view, int nHeight) const override;
-    void UpdateCoins(CValidationState &state, CCoinsViewCache& view, CBlockUndo& txundo, int nHeight) const override;
     bool AreInputsStandard(CCoinsViewCache& view) const override;
     bool ContextualCheckInputs(CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
                            const CChain& chain, unsigned int flags, bool cacheStore, const Consensus::Params& consensusParams,

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -640,13 +640,13 @@ class CTransactionBase
 protected:
     /** Memory only. */
     const uint256 hash;
+    const std::vector<CTxOut> vout;
 
     virtual void UpdateHash() const = 0;
 
 public:
     virtual bool TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee) = 0;
     const int32_t nVersion;
-    const std::vector<CTxOut> vout;
 
     CTransactionBase();
     CTransactionBase& operator=(const CTransactionBase& tx);
@@ -737,7 +737,6 @@ public:
         std::vector<CScriptCheck> *pvChecks = NULL) const { return true; }
 
     virtual unsigned int GetP2SHSigOpCount(CCoinsViewCache& view) const { return 0; }
-    virtual size_t getVjoinsplitSize() const { return 0; }
     virtual const uint256 getJoinSplitPubKey() const { return uint256(); }
     virtual int GetComplexity() const { return 0; }
 
@@ -863,7 +862,6 @@ public:
     // value in should be computed via the method above using a proper coin view
     CAmount GetFeeAmount(CAmount valueIn) const override { return (valueIn - GetValueOut() ); }
 
-    size_t getVjoinsplitSize() const override { return vjoinsplit.size(); }
     int GetComplexity() const override { return vin.size()*vin.size(); }
     const uint256 getJoinSplitPubKey() const override { return joinSplitPubKey; }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -676,14 +676,26 @@ public:
         return !(a==b);
     }
 
-    // Check for negative or overflow output values
-    bool CheckVout(CAmount& nValueOut, CValidationState &state) const;
+    //GETTERS
+    virtual const std::vector<CTxIn>&         GetVins()       const = 0;
+    virtual const std::vector<CTxOut>&        GetVouts()      const = 0;
+    virtual const std::vector<JSDescription>& GetJoinSplits() const = 0;
+    //END OF GETTERS
+
+    //CHECK FUNCTIONS
+    virtual bool CheckVersionBasic        (CValidationState &state) const = 0;
+    virtual bool CheckInputsAvailability  (CValidationState &state) const = 0;
+    virtual bool CheckOutputsAvailability (CValidationState &state) const = 0;
+    virtual bool CheckSerializedSize      (CValidationState &state) const = 0;
+
+    bool CheckInputsAmount (CValidationState &state) const;
+    bool CheckOutputsAmount(CValidationState &state) const;
+    bool CheckInputsDuplication(CValidationState &state) const;
+    bool CheckInputsInteraction(CValidationState &state) const;
+
     bool CheckOutputsAreStandard(int nHeight, std::string& reason) const;
     bool CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const;
-
-    virtual const std::vector<CTxIn>&         getVins()       const = 0;
-    virtual const std::vector<CTxOut>&        getVout()       const = 0;
-    virtual const std::vector<JSDescription>& getJoinsSplit() const = 0;
+    //END OF CHECK FUNCTIONS
 
     // Return sum of txouts.
     virtual CAmount GetValueOut() const;
@@ -853,9 +865,18 @@ public:
         );
     }
     
-    const std::vector<CTxIn>&         getVins()       const override {return vin;};
-    const std::vector<CTxOut>&        getVout()       const override {return vout;};
-    const std::vector<JSDescription>& getJoinsSplit() const override {return vjoinsplit;};
+    //GETTERS
+    const std::vector<CTxIn>&         GetVins()       const override {return vin;};
+    const std::vector<CTxOut>&        GetVouts()       const override {return vout;};
+    const std::vector<JSDescription>& GetJoinSplits() const override {return vjoinsplit;};
+    //END OF GETTERS
+
+    //CHECK FUNCTIONS
+    bool CheckVersionBasic        (CValidationState &state) const override;
+    bool CheckInputsAvailability  (CValidationState &state) const override;
+    bool CheckOutputsAvailability (CValidationState &state) const override;
+    bool CheckSerializedSize      (CValidationState &state) const override;
+    //END OF CHECK FUNCTIONS
 
     // Return sum of txouts.
     CAmount GetValueOut() const override;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -677,9 +677,9 @@ public:
     }
 
     //GETTERS
-    virtual const std::vector<CTxIn>&         GetVins()       const = 0;
-    virtual const std::vector<CTxOut>&        GetVouts()      const = 0;
-    virtual const std::vector<JSDescription>& GetJoinSplits() const = 0;
+    virtual const std::vector<CTxIn>&         GetVin()        const = 0;
+    virtual const std::vector<CTxOut>&        GetVout()       const = 0;
+    virtual const std::vector<JSDescription>& GetVjoinsplit() const = 0;
     //END OF GETTERS
 
     //CHECK FUNCTIONS
@@ -866,9 +866,9 @@ public:
     }
     
     //GETTERS
-    const std::vector<CTxIn>&         GetVins()       const override {return vin;};
-    const std::vector<CTxOut>&        GetVouts()       const override {return vout;};
-    const std::vector<JSDescription>& GetJoinSplits() const override {return vjoinsplit;};
+    const std::vector<CTxIn>&         GetVin()        const override {return vin;};
+    const std::vector<CTxOut>&        GetVout()       const override {return vout;};
+    const std::vector<JSDescription>& GetVjoinsplit() const override {return vjoinsplit;};
     //END OF GETTERS
 
     //CHECK FUNCTIONS

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -775,12 +775,12 @@ public:
     // structure, including the hash.
 private:
     const std::vector<CTxIn> vin;
+    const std::vector<JSDescription> vjoinsplit;
 public:
     const std::vector<CTxScCreationOut> vsc_ccout;
     const std::vector<CTxCertifierLockOut> vcl_ccout;
     const std::vector<CTxForwardTransferOut> vft_ccout;
     const uint32_t nLockTime;
-    const std::vector<JSDescription> vjoinsplit;
     const uint256 joinSplitPubKey;
     const joinsplit_sig_t joinSplitSig = {{0}};
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -773,7 +773,9 @@ public:
     // actually immutable; deserialization and assignment are implemented,
     // and bypass the constness. This is safe, as they update the entire
     // structure, including the hash.
+private:
     const std::vector<CTxIn> vin;
+public:
     const std::vector<CTxScCreationOut> vsc_ccout;
     const std::vector<CTxCertifierLockOut> vcl_ccout;
     const std::vector<CTxForwardTransferOut> vft_ccout;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -268,7 +268,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-            BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
             {
                 if (mempool.exists(txin.prevout.hash))
                     setDepends.insert(txin.prevout.hash.ToString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -268,7 +268,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
             {
                 if (mempool.exists(txin.prevout.hash))
                     setDepends.insert(txin.prevout.hash.ToString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -268,7 +268,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
+            BOOST_FOREACH(const CTxIn& txin, tx.getVins())
             {
                 if (mempool.exists(txin.prevout.hash))
                     setDepends.insert(txin.prevout.hash.ToString());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -673,7 +673,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         entry.push_back(Pair("hash", txHash.GetHex()));
 
         UniValue deps(UniValue::VARR);
-        BOOST_FOREACH (const CTxIn &in, tx.GetVins())
+        BOOST_FOREACH (const CTxIn &in, tx.GetVin())
         {
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
@@ -686,12 +686,12 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         if (tx.IsCoinBase()) {
             // Show community reward if it is required
-            if (pblock->vtx[0].GetVouts().size() > 1) {
+            if (pblock->vtx[0].GetVout().size() > 1) {
                 // Correct this if GetBlockTemplate changes the order
-                entry.push_back(Pair("communityfund", (int64_t)tx.GetVouts()[1].nValue));
-                if (pblock->vtx[0].GetVouts().size() > 3) {
-                    entry.push_back(Pair("securenodes", (int64_t)tx.GetVouts()[2].nValue));
-                    entry.push_back(Pair("supernodes", (int64_t)tx.GetVouts()[3].nValue));
+                entry.push_back(Pair("communityfund", (int64_t)tx.GetVout()[1].nValue));
+                if (pblock->vtx[0].GetVout().size() > 3) {
+                    entry.push_back(Pair("securenodes", (int64_t)tx.GetVout()[2].nValue));
+                    entry.push_back(Pair("supernodes", (int64_t)tx.GetVout()[3].nValue));
                 }
             }
             entry.push_back(Pair("required", true));
@@ -748,7 +748,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         result.push_back(Pair("coinbasetxn", txCoinbase));
     } else {
         result.push_back(Pair("coinbaseaux", aux));
-        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].GetVouts()[0].nValue));
+        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].GetVout()[0].nValue));
     }
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -673,7 +673,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         entry.push_back(Pair("hash", txHash.GetHex()));
 
         UniValue deps(UniValue::VARR);
-        BOOST_FOREACH (const CTxIn &in, tx.vin)
+        BOOST_FOREACH (const CTxIn &in, tx.getVins())
         {
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -686,12 +686,12 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         if (tx.IsCoinBase()) {
             // Show community reward if it is required
-            if (pblock->vtx[0].vout.size() > 1) {
+            if (pblock->vtx[0].getVout().size() > 1) {
                 // Correct this if GetBlockTemplate changes the order
-                entry.push_back(Pair("communityfund", (int64_t)tx.vout[1].nValue));
-                if (pblock->vtx[0].vout.size() > 3) {
-                    entry.push_back(Pair("securenodes", (int64_t)tx.vout[2].nValue));
-                    entry.push_back(Pair("supernodes", (int64_t)tx.vout[3].nValue));
+                entry.push_back(Pair("communityfund", (int64_t)tx.getVout()[1].nValue));
+                if (pblock->vtx[0].getVout().size() > 3) {
+                    entry.push_back(Pair("securenodes", (int64_t)tx.getVout()[2].nValue));
+                    entry.push_back(Pair("supernodes", (int64_t)tx.getVout()[3].nValue));
                 }
             }
             entry.push_back(Pair("required", true));
@@ -748,7 +748,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         result.push_back(Pair("coinbasetxn", txCoinbase));
     } else {
         result.push_back(Pair("coinbaseaux", aux));
-        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].getVout()[0].nValue));
     }
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -673,7 +673,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         entry.push_back(Pair("hash", txHash.GetHex()));
 
         UniValue deps(UniValue::VARR);
-        BOOST_FOREACH (const CTxIn &in, tx.getVins())
+        BOOST_FOREACH (const CTxIn &in, tx.GetVins())
         {
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
@@ -686,12 +686,12 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         if (tx.IsCoinBase()) {
             // Show community reward if it is required
-            if (pblock->vtx[0].getVout().size() > 1) {
+            if (pblock->vtx[0].GetVouts().size() > 1) {
                 // Correct this if GetBlockTemplate changes the order
-                entry.push_back(Pair("communityfund", (int64_t)tx.getVout()[1].nValue));
-                if (pblock->vtx[0].getVout().size() > 3) {
-                    entry.push_back(Pair("securenodes", (int64_t)tx.getVout()[2].nValue));
-                    entry.push_back(Pair("supernodes", (int64_t)tx.getVout()[3].nValue));
+                entry.push_back(Pair("communityfund", (int64_t)tx.GetVouts()[1].nValue));
+                if (pblock->vtx[0].GetVouts().size() > 3) {
+                    entry.push_back(Pair("securenodes", (int64_t)tx.GetVouts()[2].nValue));
+                    entry.push_back(Pair("supernodes", (int64_t)tx.GetVouts()[3].nValue));
                 }
             }
             entry.push_back(Pair("required", true));
@@ -748,7 +748,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         result.push_back(Pair("coinbasetxn", txCoinbase));
     } else {
         result.push_back(Pair("coinbaseaux", aux));
-        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].getVout()[0].nValue));
+        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].GetVouts()[0].nValue));
     }
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -120,7 +120,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
+    BOOST_FOREACH(const CTxIn& txin, tx.getVins()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.push_back(Pair("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -60,8 +60,8 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fInclud
 UniValue TxJoinSplitToJSON(const CTransaction& tx) {
     bool useGroth = tx.nVersion == GROTH_TX_VERSION;
     UniValue vjoinsplit(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.GetJoinSplits().size(); i++) {
-        const JSDescription& jsdescription = tx.GetJoinSplits()[i];
+    for (unsigned int i = 0; i < tx.GetVjoinsplit().size(); i++) {
+        const JSDescription& jsdescription = tx.GetVjoinsplit()[i];
         UniValue joinsplit(UniValue::VOBJ);
 
         joinsplit.push_back(Pair("vpub_old", ValueFromAmount(jsdescription.vpub_old)));
@@ -120,7 +120,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.push_back(Pair("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
@@ -137,8 +137,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     }
     entry.push_back(Pair("vin", vin));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
-        const CTxOut& txout = tx.GetVouts()[i];
+    for (unsigned int i = 0; i < tx.GetVout().size(); i++) {
+        const CTxOut& txout = tx.GetVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -178,8 +178,8 @@ void CertToJSON(const CScCertificate& cert, const uint256 hashBlock, UniValue& e
     entry.push_back(Pair("version", cert.nVersion));
     entry.push_back(Pair("nonce", cert.nonce.GetHex()));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
-        const CTxOut& txout = cert.GetVouts()[i];
+    for (unsigned int i = 0; i < cert.GetVout().size(); i++) {
+        const CTxOut& txout = cert.GetVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -60,8 +60,8 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fInclud
 UniValue TxJoinSplitToJSON(const CTransaction& tx) {
     bool useGroth = tx.nVersion == GROTH_TX_VERSION;
     UniValue vjoinsplit(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.getJoinsSplit().size(); i++) {
-        const JSDescription& jsdescription = tx.getJoinsSplit()[i];
+    for (unsigned int i = 0; i < tx.GetJoinSplits().size(); i++) {
+        const JSDescription& jsdescription = tx.GetJoinSplits()[i];
         UniValue joinsplit(UniValue::VOBJ);
 
         joinsplit.push_back(Pair("vpub_old", ValueFromAmount(jsdescription.vpub_old)));
@@ -120,7 +120,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.getVins()) {
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.push_back(Pair("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
@@ -137,8 +137,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     }
     entry.push_back(Pair("vin", vin));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
-        const CTxOut& txout = tx.getVout()[i];
+    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
+        const CTxOut& txout = tx.GetVouts()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -178,8 +178,8 @@ void CertToJSON(const CScCertificate& cert, const uint256 hashBlock, UniValue& e
     entry.push_back(Pair("version", cert.nVersion));
     entry.push_back(Pair("nonce", cert.nonce.GetHex()));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < cert.getVout().size(); i++) {
-        const CTxOut& txout = cert.getVout()[i];
+    for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
+        const CTxOut& txout = cert.GetVouts()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -60,8 +60,8 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fInclud
 UniValue TxJoinSplitToJSON(const CTransaction& tx) {
     bool useGroth = tx.nVersion == GROTH_TX_VERSION;
     UniValue vjoinsplit(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.vjoinsplit.size(); i++) {
-        const JSDescription& jsdescription = tx.vjoinsplit[i];
+    for (unsigned int i = 0; i < tx.getJoinsSplit().size(); i++) {
+        const JSDescription& jsdescription = tx.getJoinsSplit()[i];
         UniValue joinsplit(UniValue::VOBJ);
 
         joinsplit.push_back(Pair("vpub_old", ValueFromAmount(jsdescription.vpub_old)));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -137,8 +137,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     }
     entry.push_back(Pair("vin", vin));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        const CTxOut& txout = tx.vout[i];
+    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
+        const CTxOut& txout = tx.getVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -178,8 +178,8 @@ void CertToJSON(const CScCertificate& cert, const uint256 hashBlock, UniValue& e
     entry.push_back(Pair("version", cert.nVersion));
     entry.push_back(Pair("nonce", cert.nonce.GetHex()));
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < cert.vout.size(); i++) {
-        const CTxOut& txout = cert.vout[i];
+    for (unsigned int i = 0; i < cert.getVout().size(); i++) {
+        const CTxOut& txout = cert.getVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -31,7 +31,7 @@ bool Sidechain::checkTxSemanticValidity(const CTransaction& tx, CValidationState
     else
     {
         // we do not support joinsplit as of now
-        if (tx.vjoinsplit.size() > 0)
+        if (tx.getJoinsSplit().size() > 0)
         {
             return state.DoS(100,
                 error("mismatch between transaction version and joinsplit presence"),

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -31,7 +31,7 @@ bool Sidechain::checkTxSemanticValidity(const CTransaction& tx, CValidationState
     else
     {
         // we do not support joinsplit as of now
-        if (tx.getJoinsSplit().size() > 0)
+        if (tx.GetJoinSplits().size() > 0)
         {
             return state.DoS(100,
                 error("mismatch between transaction version and joinsplit presence"),

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -31,7 +31,7 @@ bool Sidechain::checkTxSemanticValidity(const CTransaction& tx, CValidationState
     else
     {
         // we do not support joinsplit as of now
-        if (tx.GetJoinSplits().size() > 0)
+        if (tx.GetVjoinsplit().size() > 0)
         {
             return state.DoS(100,
                 error("mismatch between transaction version and joinsplit presence"),

--- a/src/sc/sidechainrpc.cpp
+++ b/src/sc/sidechainrpc.cpp
@@ -361,7 +361,7 @@ void ScRpcCmd::addInputs()
     for (const auto& out: vAvailableCoins)
     {
         LogPrint("sc", "utxo %s depth: %d, val: %s, spendable: %s\n",
-            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->vout[out.i].nValue), out.fSpendable?"Y":"N");
+            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->getVout()[out.i].nValue), out.fSpendable?"Y":"N");
 
         if (!out.fSpendable || out.nDepth < _minConf) {
             continue;
@@ -370,7 +370,7 @@ void ScRpcCmd::addInputs()
         if (_hasFromAddress)
         {
             CTxDestination dest;
-            if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, dest)) {
+            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, dest)) {
                 continue;
             }
 
@@ -379,7 +379,7 @@ void ScRpcCmd::addInputs()
             }
         }
 
-        CAmount nValue = out.tx->vout[out.i].nValue;
+        CAmount nValue = out.tx->getVout()[out.i].nValue;
 
         SelectedUTXO utxo(out.tx->GetHash(), out.i, nValue);
         vInputUtxo.push_back(utxo);

--- a/src/sc/sidechainrpc.cpp
+++ b/src/sc/sidechainrpc.cpp
@@ -361,7 +361,7 @@ void ScRpcCmd::addInputs()
     for (const auto& out: vAvailableCoins)
     {
         LogPrint("sc", "utxo %s depth: %d, val: %s, spendable: %s\n",
-            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->getVout()[out.i].nValue), out.fSpendable?"Y":"N");
+            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->GetVouts()[out.i].nValue), out.fSpendable?"Y":"N");
 
         if (!out.fSpendable || out.nDepth < _minConf) {
             continue;
@@ -370,7 +370,7 @@ void ScRpcCmd::addInputs()
         if (_hasFromAddress)
         {
             CTxDestination dest;
-            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, dest)) {
+            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, dest)) {
                 continue;
             }
 
@@ -379,7 +379,7 @@ void ScRpcCmd::addInputs()
             }
         }
 
-        CAmount nValue = out.tx->getVout()[out.i].nValue;
+        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
 
         SelectedUTXO utxo(out.tx->GetHash(), out.i, nValue);
         vInputUtxo.push_back(utxo);

--- a/src/sc/sidechainrpc.cpp
+++ b/src/sc/sidechainrpc.cpp
@@ -361,7 +361,7 @@ void ScRpcCmd::addInputs()
     for (const auto& out: vAvailableCoins)
     {
         LogPrint("sc", "utxo %s depth: %d, val: %s, spendable: %s\n",
-            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->GetVouts()[out.i].nValue), out.fSpendable?"Y":"N");
+            out.tx->GetHash().ToString(), out.nDepth, FormatMoney(out.tx->GetVout()[out.i].nValue), out.fSpendable?"Y":"N");
 
         if (!out.fSpendable || out.nDepth < _minConf) {
             continue;
@@ -370,7 +370,7 @@ void ScRpcCmd::addInputs()
         if (_hasFromAddress)
         {
             CTxDestination dest;
-            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, dest)) {
+            if (!ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, dest)) {
                 continue;
             }
 
@@ -379,7 +379,7 @@ void ScRpcCmd::addInputs()
             }
         }
 
-        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
+        CAmount nValue = out.tx->GetVout()[out.i].nValue;
 
         SelectedUTXO utxo(out.tx->GetHash(), out.i, nValue);
         vInputUtxo.push_back(utxo);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1129,8 +1129,8 @@ public:
             // to the transaction.
             //
         	auto os = WithTxVersion(&s, txTo.nVersion);
-        	::Serialize(os, txTo.vjoinsplit, nType, nVersion);
-            if (txTo.vjoinsplit.size() > 0) {
+        	::Serialize(os, txTo.getJoinsSplit(), nType, nVersion);
+            if (txTo.getJoinsSplit().size() > 0) {
                 ::Serialize(s, txTo.joinSplitPubKey, nType, nVersion);
 
                 CTransaction::joinsplit_sig_t nullSig = {};

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1038,7 +1038,7 @@ public:
         if (fAnyoneCanPay)
             nInput = nIn;
         // Serialize the prevout
-        ::Serialize(s, txTo.GetVins()[nInput].prevout, nType, nVersion);
+        ::Serialize(s, txTo.GetVin()[nInput].prevout, nType, nVersion);
         // Serialize the script
         assert(nInput != NOT_AN_INPUT);
         if (nInput != nIn)
@@ -1051,7 +1051,7 @@ public:
             // let the others update at will
             ::Serialize(s, (int)0, nType, nVersion);
         else
-            ::Serialize(s, txTo.GetVins()[nInput].nSequence, nType, nVersion);
+            ::Serialize(s, txTo.GetVin()[nInput].nSequence, nType, nVersion);
     }
 
     /** Serialize an output of txTo */
@@ -1061,7 +1061,7 @@ public:
             // Do not lock-in the txout payee at other indices as txin
             ::Serialize(s, CTxOut(), nType, nVersion);
         else
-            ::Serialize(s, txTo.GetVouts()[nOutput], nType, nVersion);
+            ::Serialize(s, txTo.GetVout()[nOutput], nType, nVersion);
     }
 
     /** Serialize a cross chain outputs of txTo */
@@ -1086,12 +1086,12 @@ public:
         // Serialize nVersion
         ::Serialize(s, txTo.nVersion, nType, nVersion);
         // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.GetVins().size();
+        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.GetVin().size();
         ::WriteCompactSize(s, nInputs);
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput, nType, nVersion);
         // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.GetVouts().size());
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.GetVout().size());
         ::WriteCompactSize(s, nOutputs);
         for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
              SerializeOutput(s, nOutput, nType, nVersion);
@@ -1129,8 +1129,8 @@ public:
             // to the transaction.
             //
         	auto os = WithTxVersion(&s, txTo.nVersion);
-        	::Serialize(os, txTo.GetJoinSplits(), nType, nVersion);
-            if (txTo.GetJoinSplits().size() > 0) {
+        	::Serialize(os, txTo.GetVjoinsplit(), nType, nVersion);
+            if (txTo.GetVjoinsplit().size() > 0) {
                 ::Serialize(s, txTo.joinSplitPubKey, nType, nVersion);
 
                 CTransaction::joinsplit_sig_t nullSig = {};
@@ -1144,14 +1144,14 @@ public:
 
 uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    if (nIn >= txTo.GetVins().size() && nIn != NOT_AN_INPUT) {
+    if (nIn >= txTo.GetVin().size() && nIn != NOT_AN_INPUT) {
         //  nIn out of range
         throw logic_error("input index is out of range");
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
-        if (nIn >= txTo.GetVouts().size()) {
+        if (nIn >= txTo.GetVout().size()) {
             //  nOut out of range
             throw logic_error("no matching output for SIGHASH_SINGLE");
         }
@@ -1228,7 +1228,7 @@ bool TransactionSignatureChecker::CheckLockTime(const CScriptNum& nLockTime) con
     // prevent this condition. Alternatively we could test all
     // inputs, but testing just this input minimizes the data
     // required to prove correct CHECKLOCKTIMEVERIFY execution.
-    if (txTo->GetVins()[nIn].IsFinal())
+    if (txTo->GetVin()[nIn].IsFinal())
         return false;
 
     return true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1061,7 +1061,7 @@ public:
             // Do not lock-in the txout payee at other indices as txin
             ::Serialize(s, CTxOut(), nType, nVersion);
         else
-            ::Serialize(s, txTo.vout[nOutput], nType, nVersion);
+            ::Serialize(s, txTo.getVout()[nOutput], nType, nVersion);
     }
 
     /** Serialize a cross chain outputs of txTo */
@@ -1091,7 +1091,7 @@ public:
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput, nType, nVersion);
         // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.vout.size());
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.getVout().size());
         ::WriteCompactSize(s, nOutputs);
         for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
              SerializeOutput(s, nOutput, nType, nVersion);
@@ -1151,7 +1151,7 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
-        if (nIn >= txTo.vout.size()) {
+        if (nIn >= txTo.getVout().size()) {
             //  nOut out of range
             throw logic_error("no matching output for SIGHASH_SINGLE");
         }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1038,7 +1038,7 @@ public:
         if (fAnyoneCanPay)
             nInput = nIn;
         // Serialize the prevout
-        ::Serialize(s, txTo.getVins()[nInput].prevout, nType, nVersion);
+        ::Serialize(s, txTo.GetVins()[nInput].prevout, nType, nVersion);
         // Serialize the script
         assert(nInput != NOT_AN_INPUT);
         if (nInput != nIn)
@@ -1051,7 +1051,7 @@ public:
             // let the others update at will
             ::Serialize(s, (int)0, nType, nVersion);
         else
-            ::Serialize(s, txTo.getVins()[nInput].nSequence, nType, nVersion);
+            ::Serialize(s, txTo.GetVins()[nInput].nSequence, nType, nVersion);
     }
 
     /** Serialize an output of txTo */
@@ -1061,7 +1061,7 @@ public:
             // Do not lock-in the txout payee at other indices as txin
             ::Serialize(s, CTxOut(), nType, nVersion);
         else
-            ::Serialize(s, txTo.getVout()[nOutput], nType, nVersion);
+            ::Serialize(s, txTo.GetVouts()[nOutput], nType, nVersion);
     }
 
     /** Serialize a cross chain outputs of txTo */
@@ -1086,12 +1086,12 @@ public:
         // Serialize nVersion
         ::Serialize(s, txTo.nVersion, nType, nVersion);
         // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.getVins().size();
+        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.GetVins().size();
         ::WriteCompactSize(s, nInputs);
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput, nType, nVersion);
         // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.getVout().size());
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.GetVouts().size());
         ::WriteCompactSize(s, nOutputs);
         for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
              SerializeOutput(s, nOutput, nType, nVersion);
@@ -1129,8 +1129,8 @@ public:
             // to the transaction.
             //
         	auto os = WithTxVersion(&s, txTo.nVersion);
-        	::Serialize(os, txTo.getJoinsSplit(), nType, nVersion);
-            if (txTo.getJoinsSplit().size() > 0) {
+        	::Serialize(os, txTo.GetJoinSplits(), nType, nVersion);
+            if (txTo.GetJoinSplits().size() > 0) {
                 ::Serialize(s, txTo.joinSplitPubKey, nType, nVersion);
 
                 CTransaction::joinsplit_sig_t nullSig = {};
@@ -1144,14 +1144,14 @@ public:
 
 uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    if (nIn >= txTo.getVins().size() && nIn != NOT_AN_INPUT) {
+    if (nIn >= txTo.GetVins().size() && nIn != NOT_AN_INPUT) {
         //  nIn out of range
         throw logic_error("input index is out of range");
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
-        if (nIn >= txTo.getVout().size()) {
+        if (nIn >= txTo.GetVouts().size()) {
             //  nOut out of range
             throw logic_error("no matching output for SIGHASH_SINGLE");
         }
@@ -1228,7 +1228,7 @@ bool TransactionSignatureChecker::CheckLockTime(const CScriptNum& nLockTime) con
     // prevent this condition. Alternatively we could test all
     // inputs, but testing just this input minimizes the data
     // required to prove correct CHECKLOCKTIMEVERIFY execution.
-    if (txTo->getVins()[nIn].IsFinal())
+    if (txTo->GetVins()[nIn].IsFinal())
         return false;
 
     return true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1038,7 +1038,7 @@ public:
         if (fAnyoneCanPay)
             nInput = nIn;
         // Serialize the prevout
-        ::Serialize(s, txTo.vin[nInput].prevout, nType, nVersion);
+        ::Serialize(s, txTo.getVins()[nInput].prevout, nType, nVersion);
         // Serialize the script
         assert(nInput != NOT_AN_INPUT);
         if (nInput != nIn)
@@ -1051,7 +1051,7 @@ public:
             // let the others update at will
             ::Serialize(s, (int)0, nType, nVersion);
         else
-            ::Serialize(s, txTo.vin[nInput].nSequence, nType, nVersion);
+            ::Serialize(s, txTo.getVins()[nInput].nSequence, nType, nVersion);
     }
 
     /** Serialize an output of txTo */
@@ -1086,7 +1086,7 @@ public:
         // Serialize nVersion
         ::Serialize(s, txTo.nVersion, nType, nVersion);
         // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
+        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.getVins().size();
         ::WriteCompactSize(s, nInputs);
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput, nType, nVersion);
@@ -1144,7 +1144,7 @@ public:
 
 uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    if (nIn >= txTo.vin.size() && nIn != NOT_AN_INPUT) {
+    if (nIn >= txTo.getVins().size() && nIn != NOT_AN_INPUT) {
         //  nIn out of range
         throw logic_error("input index is out of range");
     }
@@ -1228,7 +1228,7 @@ bool TransactionSignatureChecker::CheckLockTime(const CScriptNum& nLockTime) con
     // prevent this condition. Alternatively we could test all
     // inputs, but testing just this input minimizes the data
     // required to prove correct CHECKLOCKTIMEVERIFY execution.
-    if (txTo->vin[nIn].IsFinal())
+    if (txTo->getVins()[nIn].IsFinal())
         return false;
 
     return true;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -152,8 +152,8 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
 {
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
-    assert(txin.prevout.n < txFrom.vout.size());
-    const CTxOut& txout = txFrom.vout[txin.prevout.n];
+    assert(txin.prevout.n < txFrom.getVout().size());
+    const CTxOut& txout = txFrom.getVout()[txin.prevout.n];
 
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, nHashType);
 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -152,8 +152,8 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
 {
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
-    assert(txin.prevout.n < txFrom.GetVouts().size());
-    const CTxOut& txout = txFrom.GetVouts()[txin.prevout.n];
+    assert(txin.prevout.n < txFrom.GetVout().size());
+    const CTxOut& txout = txFrom.GetVout()[txin.prevout.n];
 
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, nHashType);
 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -152,8 +152,8 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
 {
     assert(nIn < txTo.vin.size());
     CTxIn& txin = txTo.vin[nIn];
-    assert(txin.prevout.n < txFrom.getVout().size());
-    const CTxOut& txout = txFrom.getVout()[txin.prevout.n];
+    assert(txin.prevout.n < txFrom.GetVouts().size());
+    const CTxOut& txout = txFrom.GetVouts()[txin.prevout.n];
 
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, nHashType);
 }

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1120,20 +1120,20 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.vout.size() == 0);
+        BOOST_CHECK(tx.getVout().size() == 0);
 
         CAmount amount = 123.456;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.vout.size() == 1);
-        CTxOut out = tx.vout[0];
+        BOOST_CHECK(tx.getVout().size() == 1);
+        CTxOut out = tx.getVout()[0];
         BOOST_CHECK_EQUAL(out.nValue, amount);
 
         amount = 1.111;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.vout.size() == 2);
-        out = tx.vout[1];
+        BOOST_CHECK(tx.getVout().size() == 2);
+        out = tx.getVout()[1];
         BOOST_CHECK_EQUAL(out.nValue, amount);
     }
 
@@ -1151,10 +1151,10 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         proxy.add_taddr_outputs_to_tx();
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.vout.size() == 3);
-        BOOST_CHECK_EQUAL(tx.vout[0].nValue, CAmount(1.23));
-        BOOST_CHECK_EQUAL(tx.vout[1].nValue, CAmount(4.56));
-        BOOST_CHECK_EQUAL(tx.vout[2].nValue, CAmount(7.89));
+        BOOST_CHECK(tx.getVout().size() == 3);
+        BOOST_CHECK_EQUAL(tx.getVout()[0].nValue, CAmount(1.23));
+        BOOST_CHECK_EQUAL(tx.getVout()[1].nValue, CAmount(4.56));
+        BOOST_CHECK_EQUAL(tx.getVout()[2].nValue, CAmount(7.89));
     }
 
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1120,20 +1120,20 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.GetVouts().size() == 0);
+        BOOST_CHECK(tx.GetVout().size() == 0);
 
         CAmount amount = 123.456;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.GetVouts().size() == 1);
-        CTxOut out = tx.GetVouts()[0];
+        BOOST_CHECK(tx.GetVout().size() == 1);
+        CTxOut out = tx.GetVout()[0];
         BOOST_CHECK_EQUAL(out.nValue, amount);
 
         amount = 1.111;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.GetVouts().size() == 2);
-        out = tx.GetVouts()[1];
+        BOOST_CHECK(tx.GetVout().size() == 2);
+        out = tx.GetVout()[1];
         BOOST_CHECK_EQUAL(out.nValue, amount);
     }
 
@@ -1151,10 +1151,10 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         proxy.add_taddr_outputs_to_tx();
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.GetVouts().size() == 3);
-        BOOST_CHECK_EQUAL(tx.GetVouts()[0].nValue, CAmount(1.23));
-        BOOST_CHECK_EQUAL(tx.GetVouts()[1].nValue, CAmount(4.56));
-        BOOST_CHECK_EQUAL(tx.GetVouts()[2].nValue, CAmount(7.89));
+        BOOST_CHECK(tx.GetVout().size() == 3);
+        BOOST_CHECK_EQUAL(tx.GetVout()[0].nValue, CAmount(1.23));
+        BOOST_CHECK_EQUAL(tx.GetVout()[1].nValue, CAmount(4.56));
+        BOOST_CHECK_EQUAL(tx.GetVout()[2].nValue, CAmount(7.89));
     }
 
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1120,20 +1120,20 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.getVout().size() == 0);
+        BOOST_CHECK(tx.GetVouts().size() == 0);
 
         CAmount amount = 123.456;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.getVout().size() == 1);
-        CTxOut out = tx.getVout()[0];
+        BOOST_CHECK(tx.GetVouts().size() == 1);
+        CTxOut out = tx.GetVouts()[0];
         BOOST_CHECK_EQUAL(out.nValue, amount);
 
         amount = 1.111;
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
-        BOOST_CHECK(tx.getVout().size() == 2);
-        out = tx.getVout()[1];
+        BOOST_CHECK(tx.GetVouts().size() == 2);
+        out = tx.GetVouts()[1];
         BOOST_CHECK_EQUAL(out.nValue, amount);
     }
 
@@ -1151,10 +1151,10 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         proxy.add_taddr_outputs_to_tx();
 
         CTransaction tx = proxy.getTx();
-        BOOST_CHECK(tx.getVout().size() == 3);
-        BOOST_CHECK_EQUAL(tx.getVout()[0].nValue, CAmount(1.23));
-        BOOST_CHECK_EQUAL(tx.getVout()[1].nValue, CAmount(4.56));
-        BOOST_CHECK_EQUAL(tx.getVout()[2].nValue, CAmount(7.89));
+        BOOST_CHECK(tx.GetVouts().size() == 3);
+        BOOST_CHECK_EQUAL(tx.GetVouts()[0].nValue, CAmount(1.23));
+        BOOST_CHECK_EQUAL(tx.GetVouts()[1].nValue, CAmount(4.56));
+        BOOST_CHECK_EQUAL(tx.GetVouts()[2].nValue, CAmount(7.89));
     }
 
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -288,7 +288,7 @@ public:
     {
         TestBuilder copy = *this; // Make a copy so we can rollback the push.
         DoPush();
-        DoTest(creditTx.GetVouts()[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
+        DoTest(creditTx.GetVout()[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
         *this = copy;
         return *this;
     }
@@ -298,7 +298,7 @@ public:
         DoPush();
         UniValue array(UniValue::VARR);
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
-        array.push_back(FormatScript(creditTx.GetVouts()[0].scriptPubKey));
+        array.push_back(FormatScript(creditTx.GetVout()[0].scriptPubKey));
         array.push_back(FormatScriptFlags(flags));
         array.push_back(comment);
         return array;
@@ -311,7 +311,7 @@ public:
 
     const CScript& GetScriptPubKey()
     {
-        return creditTx.GetVouts()[0].scriptPubKey;
+        return creditTx.GetVout()[0].scriptPubKey;
     }
 };
 }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -288,7 +288,7 @@ public:
     {
         TestBuilder copy = *this; // Make a copy so we can rollback the push.
         DoPush();
-        DoTest(creditTx.getVout()[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
+        DoTest(creditTx.GetVouts()[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
         *this = copy;
         return *this;
     }
@@ -298,7 +298,7 @@ public:
         DoPush();
         UniValue array(UniValue::VARR);
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
-        array.push_back(FormatScript(creditTx.getVout()[0].scriptPubKey));
+        array.push_back(FormatScript(creditTx.GetVouts()[0].scriptPubKey));
         array.push_back(FormatScriptFlags(flags));
         array.push_back(comment);
         return array;
@@ -311,7 +311,7 @@ public:
 
     const CScript& GetScriptPubKey()
     {
-        return creditTx.getVout()[0].scriptPubKey;
+        return creditTx.GetVouts()[0].scriptPubKey;
     }
 };
 }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -288,7 +288,7 @@ public:
     {
         TestBuilder copy = *this; // Make a copy so we can rollback the push.
         DoPush();
-        DoTest(creditTx.vout[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
+        DoTest(creditTx.getVout()[0].scriptPubKey, spendTx.vin[0].scriptSig, flags, expect, comment);
         *this = copy;
         return *this;
     }
@@ -298,7 +298,7 @@ public:
         DoPush();
         UniValue array(UniValue::VARR);
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
-        array.push_back(FormatScript(creditTx.vout[0].scriptPubKey));
+        array.push_back(FormatScript(creditTx.getVout()[0].scriptPubKey));
         array.push_back(FormatScriptFlags(flags));
         array.push_back(comment);
         return array;
@@ -311,7 +311,7 @@ public:
 
     const CScript& GetScriptPubKey()
     {
-        return creditTx.vout[0].scriptPubKey;
+        return creditTx.getVout()[0].scriptPubKey;
     }
 };
 }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -26,7 +26,7 @@ extern UniValue read_json(const std::string& jsondata);
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-    if (nIn >= txTo.GetVins().size())
+    if (nIn >= txTo.GetVin().size())
     {
         printf("ERROR: SignatureHash(): nIn=%d out of range\n", nIn);
         return one;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -26,7 +26,7 @@ extern UniValue read_json(const std::string& jsondata);
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-    if (nIn >= txTo.vin.size())
+    if (nIn >= txTo.getVins().size())
     {
         printf("ERROR: SignatureHash(): nIn=%d out of range\n", nIn);
         return one;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -26,7 +26,7 @@ extern UniValue read_json(const std::string& jsondata);
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-    if (nIn >= txTo.getVins().size())
+    if (nIn >= txTo.GetVins().size())
     {
         printf("ERROR: SignatureHash(): nIn=%d out of range\n", nIn);
         return one;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -147,16 +147,16 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, verifier), strTest + comment);
             BOOST_CHECK_MESSAGE(state.IsValid(), comment);
 
-            for (unsigned int i = 0; i < tx.vin.size(); i++)
+            for (unsigned int i = 0; i < tx.getVins().size(); i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.vin[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.getVins()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                BOOST_CHECK_MESSAGE(VerifyScript(tx.vin[i].scriptSig, mapprevOutScriptPubKeys[tx.vin[i].prevout],
+                BOOST_CHECK_MESSAGE(VerifyScript(tx.getVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.getVins()[i].prevout],
                                                  verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err),
                                     strTest);
                 BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
@@ -230,16 +230,16 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             CValidationState state;
             fValid = CheckTransaction(tx, state, verifier) && state.IsValid();
 
-            for (unsigned int i = 0; i < tx.vin.size() && fValid; i++)
+            for (unsigned int i = 0; i < tx.getVins().size() && fValid; i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.vin[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.getVins()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                fValid = VerifyScript(tx.vin[i].scriptSig, mapprevOutScriptPubKeys[tx.vin[i].prevout],
+                fValid = VerifyScript(tx.getVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.getVins()[i].prevout],
                         verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err);
             }
             BOOST_CHECK_MESSAGE(!fValid, strTest + comment);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -147,16 +147,16 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, verifier), strTest + comment);
             BOOST_CHECK_MESSAGE(state.IsValid(), comment);
 
-            for (unsigned int i = 0; i < tx.getVins().size(); i++)
+            for (unsigned int i = 0; i < tx.GetVins().size(); i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.getVins()[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.GetVins()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                BOOST_CHECK_MESSAGE(VerifyScript(tx.getVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.getVins()[i].prevout],
+                BOOST_CHECK_MESSAGE(VerifyScript(tx.GetVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVins()[i].prevout],
                                                  verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err),
                                     strTest);
                 BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
@@ -230,16 +230,16 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             CValidationState state;
             fValid = CheckTransaction(tx, state, verifier) && state.IsValid();
 
-            for (unsigned int i = 0; i < tx.getVins().size() && fValid; i++)
+            for (unsigned int i = 0; i < tx.GetVins().size() && fValid; i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.getVins()[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.GetVins()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                fValid = VerifyScript(tx.getVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.getVins()[i].prevout],
+                fValid = VerifyScript(tx.GetVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVins()[i].prevout],
                         verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err);
             }
             BOOST_CHECK_MESSAGE(!fValid, strTest + comment);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -147,16 +147,16 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, verifier), strTest + comment);
             BOOST_CHECK_MESSAGE(state.IsValid(), comment);
 
-            for (unsigned int i = 0; i < tx.GetVins().size(); i++)
+            for (unsigned int i = 0; i < tx.GetVin().size(); i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.GetVins()[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.GetVin()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                BOOST_CHECK_MESSAGE(VerifyScript(tx.GetVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVins()[i].prevout],
+                BOOST_CHECK_MESSAGE(VerifyScript(tx.GetVin()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVin()[i].prevout],
                                                  verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err),
                                     strTest);
                 BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
@@ -230,16 +230,16 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             CValidationState state;
             fValid = CheckTransaction(tx, state, verifier) && state.IsValid();
 
-            for (unsigned int i = 0; i < tx.GetVins().size() && fValid; i++)
+            for (unsigned int i = 0; i < tx.GetVin().size() && fValid; i++)
             {
-                if (!mapprevOutScriptPubKeys.count(tx.GetVins()[i].prevout))
+                if (!mapprevOutScriptPubKeys.count(tx.GetVin()[i].prevout))
                 {
                     BOOST_ERROR("Bad test: " << strTest << comment);
                     break;
                 }
 
                 unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
-                fValid = VerifyScript(tx.GetVins()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVins()[i].prevout],
+                fValid = VerifyScript(tx.GetVin()[i].scriptSig, mapprevOutScriptPubKeys[tx.GetVin()[i].prevout],
                         verify_flags, TransactionSignatureChecker(&tx, i, nullptr), &err);
             }
             BOOST_CHECK_MESSAGE(!fValid, strTest + comment);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -132,10 +132,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     mapTx[hash] = entry;
     const CTransaction& tx = mapTx[hash].GetTx();
 
-    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
-        mapNextTx[tx.GetVins()[i].prevout] = CInPoint(&tx, i);
+    for (unsigned int i = 0; i < tx.GetVin().size(); i++)
+        mapNextTx[tx.GetVin()[i].prevout] = CInPoint(&tx, i);
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetVjoinsplit()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             mapNullifiers[nf] = &tx;
         }
@@ -200,7 +200,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origTx.GetVouts().size(); i++) {
+            for (unsigned int i = 0; i < origTx.GetVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -242,7 +242,7 @@ void::CTxMemPool::removeInternal(
         {
             const CTransaction& tx = mapTx[hash].GetTx();
             if (fRecursive) {
-                for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
+                for (unsigned int i = 0; i < tx.GetVout().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -263,9 +263,9 @@ void::CTxMemPool::removeInternal(
                 }
             }
 
-            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
                 mapNextTx.erase(txin.prevout);
-            BOOST_FOREACH(const JSDescription& joinsplit, tx.GetJoinSplits()) {
+            BOOST_FOREACH(const JSDescription& joinsplit, tx.GetVjoinsplit()) {
                 BOOST_FOREACH(const uint256& nf, joinsplit.nullifiers) {
                     mapNullifiers.erase(nf);
                 }
@@ -311,7 +311,7 @@ void::CTxMemPool::removeInternal(
             const CScCertificate& cert = mapCertificate[hash].GetCertificate();
             if (fRecursive)
             {
-                for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
+                for (unsigned int i = 0; i < cert.GetVout().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -349,7 +349,7 @@ void CTxMemPool::remove(const CScCertificate &origCert, std::list<CTransaction>&
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origCert isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origCert.GetVouts().size(); i++) {
+            for (unsigned int i = 0; i < origCert.GetVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origCert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -369,7 +369,7 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned in
     std::list<CTransaction> transactionsToRemove;
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->second.GetTx();
-        BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVin()) {
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end())
                 continue;
@@ -420,7 +420,7 @@ void CTxMemPool::removeOutOfEpochCertificates(const CBlockIndex* pindexDelete)
             certsToRemove.push_back(cert);
 
             // Remove also txes that depend on such certificates
-            for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
+            for (unsigned int i = 0; i < cert.GetVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(cert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -453,7 +453,7 @@ void CTxMemPool::removeWithAnchor(const uint256 &invalidRoot)
 
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->second.GetTx();
-        BOOST_FOREACH(const JSDescription& joinsplit, tx.GetJoinSplits()) {
+        BOOST_FOREACH(const JSDescription& joinsplit, tx.GetVjoinsplit()) {
             if (joinsplit.anchor == invalidRoot) {
                 transactionsToRemove.push_back(tx);
                 break;
@@ -473,7 +473,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
     // not used
     // list<CTransaction> result;
     LOCK(cs);
-    BOOST_FOREACH(const CTxIn &txin, tx.GetVins()) {
+    BOOST_FOREACH(const CTxIn &txin, tx.GetVin()) {
         std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = *it->second.ptx;
@@ -484,7 +484,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
         }
     }
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetVjoinsplit()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             std::map<uint256, const CTransaction*>::iterator it = mapNullifiers.find(nf);
             if (it != mapNullifiers.end()) {
@@ -589,19 +589,19 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         const CTransaction& tx = it->second.GetTx();
 
         bool fDependsWait = false;
-        BOOST_FOREACH(const CTxIn &txin, tx.GetVins()) {
+        BOOST_FOREACH(const CTxIn &txin, tx.GetVin()) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->second.GetTx();
-                assert(tx2.GetVouts().size() > txin.prevout.n && !tx2.GetVouts()[txin.prevout.n].IsNull());
+                assert(tx2.GetVout().size() > txin.prevout.n && !tx2.GetVout()[txin.prevout.n].IsNull());
                 fDependsWait = true;
             } else {
                 // maybe our input is a certificate?
                 std::map<uint256, CCertificateMemPoolEntry>::const_iterator itCert = mapCertificate.find(txin.prevout.hash);
                 if (itCert != mapCertificate.end()) {
                     const CTransactionBase& cert = itCert->second.GetCertificate();
-                    assert(cert.GetVouts().size() > txin.prevout.n && !cert.GetVouts()[txin.prevout.n].IsNull());
+                    assert(cert.GetVout().size() > txin.prevout.n && !cert.GetVout()[txin.prevout.n].IsNull());
                     fDependsWait = true;
                 }
                 else
@@ -645,7 +645,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
         boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetVjoinsplit()) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 assert(!pcoins->GetNullifier(nf));
             }
@@ -713,8 +713,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         const CTransaction& tx = it2->second.GetTx();
         assert(it2 != mapTx.end());
         assert(&tx == it->second.ptx);
-        assert(tx.GetVins().size() > it->second.n);
-        assert(it->first == it->second.ptx->GetVins()[it->second.n].prevout);
+        assert(tx.GetVin().size() > it->second.n);
+        assert(it->first == it->second.ptx->GetVin()[it->second.n].prevout);
     }
 
     for (std::map<uint256, const CTransaction*>::const_iterator it = mapNullifiers.begin(); it != mapNullifiers.end(); it++) {
@@ -835,8 +835,8 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
 
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
-    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
-        if (exists(tx.GetVins()[i].prevout.hash))
+    for (unsigned int i = 0; i < tx.GetVin().size(); i++)
+        if (exists(tx.GetVin()[i].prevout.hash))
             return false;
     return true;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -135,7 +135,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     for (unsigned int i = 0; i < tx.getVins().size(); i++)
         mapNextTx[tx.getVins()[i].prevout] = CInPoint(&tx, i);
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             mapNullifiers[nf] = &tx;
         }
@@ -265,7 +265,7 @@ void::CTxMemPool::removeInternal(
 
             BOOST_FOREACH(const CTxIn& txin, tx.getVins())
                 mapNextTx.erase(txin.prevout);
-            BOOST_FOREACH(const JSDescription& joinsplit, tx.vjoinsplit) {
+            BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit()) {
                 BOOST_FOREACH(const uint256& nf, joinsplit.nullifiers) {
                     mapNullifiers.erase(nf);
                 }
@@ -453,7 +453,7 @@ void CTxMemPool::removeWithAnchor(const uint256 &invalidRoot)
 
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->second.GetTx();
-        BOOST_FOREACH(const JSDescription& joinsplit, tx.vjoinsplit) {
+        BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit()) {
             if (joinsplit.anchor == invalidRoot) {
                 transactionsToRemove.push_back(tx);
                 break;
@@ -484,7 +484,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
         }
     }
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             std::map<uint256, const CTransaction*>::iterator it = mapNullifiers.find(nf);
             if (it != mapNullifiers.end()) {
@@ -645,7 +645,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
         boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 assert(!pcoins->GetNullifier(nf));
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -689,7 +689,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         assert(cert.ContextualCheckInputs(state, mempoolDuplicate, false, chainActive, 0, false, Params().GetConsensus(), NULL));
         // updating coins with cert outputs because the cache is checked below for
         // any tx inputs and maybe some tx has a cert out as its input.
-        cert.UpdateCoins(state, mempoolDuplicate, 1000000);
+        UpdateCoins(cert, state, mempoolDuplicate, 1000000);
     }
 
     unsigned int stepsSinceLastRemove = 0;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -132,10 +132,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     mapTx[hash] = entry;
     const CTransaction& tx = mapTx[hash].GetTx();
 
-    for (unsigned int i = 0; i < tx.getVins().size(); i++)
-        mapNextTx[tx.getVins()[i].prevout] = CInPoint(&tx, i);
+    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
+        mapNextTx[tx.GetVins()[i].prevout] = CInPoint(&tx, i);
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             mapNullifiers[nf] = &tx;
         }
@@ -200,7 +200,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origTx.getVout().size(); i++) {
+            for (unsigned int i = 0; i < origTx.GetVouts().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -242,7 +242,7 @@ void::CTxMemPool::removeInternal(
         {
             const CTransaction& tx = mapTx[hash].GetTx();
             if (fRecursive) {
-                for (unsigned int i = 0; i < tx.getVout().size(); i++) {
+                for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -263,9 +263,9 @@ void::CTxMemPool::removeInternal(
                 }
             }
 
-            BOOST_FOREACH(const CTxIn& txin, tx.getVins())
+            BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
                 mapNextTx.erase(txin.prevout);
-            BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit()) {
+            BOOST_FOREACH(const JSDescription& joinsplit, tx.GetJoinSplits()) {
                 BOOST_FOREACH(const uint256& nf, joinsplit.nullifiers) {
                     mapNullifiers.erase(nf);
                 }
@@ -311,7 +311,7 @@ void::CTxMemPool::removeInternal(
             const CScCertificate& cert = mapCertificate[hash].GetCertificate();
             if (fRecursive)
             {
-                for (unsigned int i = 0; i < cert.getVout().size(); i++) {
+                for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -349,7 +349,7 @@ void CTxMemPool::remove(const CScCertificate &origCert, std::list<CTransaction>&
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origCert isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origCert.getVout().size(); i++) {
+            for (unsigned int i = 0; i < origCert.GetVouts().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origCert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -369,7 +369,7 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned in
     std::list<CTransaction> transactionsToRemove;
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->second.GetTx();
-        BOOST_FOREACH(const CTxIn& txin, tx.getVins()) {
+        BOOST_FOREACH(const CTxIn& txin, tx.GetVins()) {
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end())
                 continue;
@@ -420,7 +420,7 @@ void CTxMemPool::removeOutOfEpochCertificates(const CBlockIndex* pindexDelete)
             certsToRemove.push_back(cert);
 
             // Remove also txes that depend on such certificates
-            for (unsigned int i = 0; i < cert.getVout().size(); i++) {
+            for (unsigned int i = 0; i < cert.GetVouts().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(cert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -453,7 +453,7 @@ void CTxMemPool::removeWithAnchor(const uint256 &invalidRoot)
 
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->second.GetTx();
-        BOOST_FOREACH(const JSDescription& joinsplit, tx.getJoinsSplit()) {
+        BOOST_FOREACH(const JSDescription& joinsplit, tx.GetJoinSplits()) {
             if (joinsplit.anchor == invalidRoot) {
                 transactionsToRemove.push_back(tx);
                 break;
@@ -473,7 +473,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
     // not used
     // list<CTransaction> result;
     LOCK(cs);
-    BOOST_FOREACH(const CTxIn &txin, tx.getVins()) {
+    BOOST_FOREACH(const CTxIn &txin, tx.GetVins()) {
         std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = *it->second.ptx;
@@ -484,7 +484,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
         }
     }
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+    BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
         BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
             std::map<uint256, const CTransaction*>::iterator it = mapNullifiers.find(nf);
             if (it != mapNullifiers.end()) {
@@ -589,19 +589,19 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         const CTransaction& tx = it->second.GetTx();
 
         bool fDependsWait = false;
-        BOOST_FOREACH(const CTxIn &txin, tx.getVins()) {
+        BOOST_FOREACH(const CTxIn &txin, tx.GetVins()) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->second.GetTx();
-                assert(tx2.getVout().size() > txin.prevout.n && !tx2.getVout()[txin.prevout.n].IsNull());
+                assert(tx2.GetVouts().size() > txin.prevout.n && !tx2.GetVouts()[txin.prevout.n].IsNull());
                 fDependsWait = true;
             } else {
                 // maybe our input is a certificate?
                 std::map<uint256, CCertificateMemPoolEntry>::const_iterator itCert = mapCertificate.find(txin.prevout.hash);
                 if (itCert != mapCertificate.end()) {
                     const CTransactionBase& cert = itCert->second.GetCertificate();
-                    assert(cert.getVout().size() > txin.prevout.n && !cert.getVout()[txin.prevout.n].IsNull());
+                    assert(cert.GetVouts().size() > txin.prevout.n && !cert.GetVouts()[txin.prevout.n].IsNull());
                     fDependsWait = true;
                 }
                 else
@@ -645,7 +645,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
         boost::unordered_map<uint256, ZCIncrementalMerkleTree, CCoinsKeyHasher> intermediates;
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.getJoinsSplit()) {
+        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetJoinSplits()) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
                 assert(!pcoins->GetNullifier(nf));
             }
@@ -713,8 +713,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         const CTransaction& tx = it2->second.GetTx();
         assert(it2 != mapTx.end());
         assert(&tx == it->second.ptx);
-        assert(tx.getVins().size() > it->second.n);
-        assert(it->first == it->second.ptx->getVins()[it->second.n].prevout);
+        assert(tx.GetVins().size() > it->second.n);
+        assert(it->first == it->second.ptx->GetVins()[it->second.n].prevout);
     }
 
     for (std::map<uint256, const CTransaction*>::const_iterator it = mapNullifiers.begin(); it != mapNullifiers.end(); it++) {
@@ -835,8 +835,8 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
 
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
-    for (unsigned int i = 0; i < tx.getVins().size(); i++)
-        if (exists(tx.getVins()[i].prevout.hash))
+    for (unsigned int i = 0; i < tx.GetVins().size(); i++)
+        if (exists(tx.GetVins()[i].prevout.hash))
             return false;
     return true;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -200,7 +200,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origTx.vout.size(); i++) {
+            for (unsigned int i = 0; i < origTx.getVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -242,7 +242,7 @@ void::CTxMemPool::removeInternal(
         {
             const CTransaction& tx = mapTx[hash].GetTx();
             if (fRecursive) {
-                for (unsigned int i = 0; i < tx.vout.size(); i++) {
+                for (unsigned int i = 0; i < tx.getVout().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -311,7 +311,7 @@ void::CTxMemPool::removeInternal(
             const CScCertificate& cert = mapCertificate[hash].GetCertificate();
             if (fRecursive)
             {
-                for (unsigned int i = 0; i < cert.vout.size(); i++) {
+                for (unsigned int i = 0; i < cert.getVout().size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it == mapNextTx.end())
                         continue;
@@ -349,7 +349,7 @@ void CTxMemPool::remove(const CScCertificate &origCert, std::list<CTransaction>&
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origCert isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origCert.vout.size(); i++) {
+            for (unsigned int i = 0; i < origCert.getVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origCert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -420,7 +420,7 @@ void CTxMemPool::removeOutOfEpochCertificates(const CBlockIndex* pindexDelete)
             certsToRemove.push_back(cert);
 
             // Remove also txes that depend on such certificates
-            for (unsigned int i = 0; i < cert.vout.size(); i++) {
+            for (unsigned int i = 0; i < cert.getVout().size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(cert.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
@@ -594,14 +594,14 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->second.GetTx();
-                assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
+                assert(tx2.getVout().size() > txin.prevout.n && !tx2.getVout()[txin.prevout.n].IsNull());
                 fDependsWait = true;
             } else {
                 // maybe our input is a certificate?
                 std::map<uint256, CCertificateMemPoolEntry>::const_iterator itCert = mapCertificate.find(txin.prevout.hash);
                 if (itCert != mapCertificate.end()) {
                     const CTransactionBase& cert = itCert->second.GetCertificate();
-                    assert(cert.vout.size() > txin.prevout.n && !cert.vout[txin.prevout.n].IsNull());
+                    assert(cert.getVout().size() > txin.prevout.n && !cert.getVout()[txin.prevout.n].IsNull());
                     fDependsWait = true;
                 }
                 else

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -94,11 +94,11 @@ libzcash::Note GetNote(ZCJoinSplit& params,
                        const libzcash::SpendingKey& sk,
                        const CTransaction& tx, size_t js, size_t n) {
     ZCNoteDecryption decryptor {sk.receiving_key()};
-    auto hSig = tx.getJoinsSplit()[js].h_sig(params, tx.joinSplitPubKey);
+    auto hSig = tx.GetJoinSplits()[js].h_sig(params, tx.joinSplitPubKey);
     auto note_pt = libzcash::NotePlaintext::decrypt(
         decryptor,
-        tx.getJoinsSplit()[js].ciphertexts[n],
-        tx.getJoinsSplit()[js].ephemeralKey,
+        tx.GetJoinSplits()[js].ciphertexts[n],
+        tx.GetJoinSplits()[js].ephemeralKey,
         hSig,
         (unsigned char) n);
     return note_pt.note(sk.address());

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -94,11 +94,11 @@ libzcash::Note GetNote(ZCJoinSplit& params,
                        const libzcash::SpendingKey& sk,
                        const CTransaction& tx, size_t js, size_t n) {
     ZCNoteDecryption decryptor {sk.receiving_key()};
-    auto hSig = tx.vjoinsplit[js].h_sig(params, tx.joinSplitPubKey);
+    auto hSig = tx.getJoinsSplit()[js].h_sig(params, tx.joinSplitPubKey);
     auto note_pt = libzcash::NotePlaintext::decrypt(
         decryptor,
-        tx.vjoinsplit[js].ciphertexts[n],
-        tx.vjoinsplit[js].ephemeralKey,
+        tx.getJoinsSplit()[js].ciphertexts[n],
+        tx.getJoinsSplit()[js].ephemeralKey,
         hSig,
         (unsigned char) n);
     return note_pt.note(sk.address());

--- a/src/utiltest.cpp
+++ b/src/utiltest.cpp
@@ -94,11 +94,11 @@ libzcash::Note GetNote(ZCJoinSplit& params,
                        const libzcash::SpendingKey& sk,
                        const CTransaction& tx, size_t js, size_t n) {
     ZCNoteDecryption decryptor {sk.receiving_key()};
-    auto hSig = tx.GetJoinSplits()[js].h_sig(params, tx.joinSplitPubKey);
+    auto hSig = tx.GetVjoinsplit()[js].h_sig(params, tx.joinSplitPubKey);
     auto note_pt = libzcash::NotePlaintext::decrypt(
         decryptor,
-        tx.GetJoinSplits()[js].ciphertexts[n],
-        tx.GetJoinSplits()[js].ephemeralKey,
+        tx.GetVjoinsplit()[js].ciphertexts[n],
+        tx.GetVjoinsplit()[js].ephemeralKey,
         hSig,
         (unsigned char) n);
     return note_pt.note(sk.address());

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -512,12 +512,12 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         JSDescription prevJoinSplit;
 
         // Keep track of previous JoinSplit and its commitments
-        if (tx_.vjoinsplit.size() > 0) {
-            prevJoinSplit = tx_.vjoinsplit.back();
+        if (tx_.getJoinsSplit().size() > 0) {
+            prevJoinSplit = tx_.getJoinsSplit().back();
         }
 
         // If there is no change, the chain has terminated so we can reset the tracked treestate.
-        if (jsChange==0 && tx_.vjoinsplit.size() > 0) {
+        if (jsChange==0 && tx_.getJoinsSplit().size() > 0) {
             intermediates.clear();
             previousCommitments.clear();
         }
@@ -958,7 +958,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.vjoinsplit.size(),
+            tx_.getJoinsSplit().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)
@@ -1066,7 +1066,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
     memcpy(&buffer[0], &joinSplitPrivKey_[0], 32); // private key in first half of 64 byte buffer
     std::vector<unsigned char> vch(&buffer[0], &buffer[0] + 32);
     uint256 joinSplitPrivKey = uint256(vch);
-    size_t js_index = tx_.vjoinsplit.size() - 1;
+    size_t js_index = tx_.getJoinsSplit().size() - 1;
     uint256 placeholder;
     for (int i = 0; i < ZC_NUM_JS_OUTPUTS; i++) {
         uint8_t mapped_index = outputMap[i];

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -512,12 +512,12 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         JSDescription prevJoinSplit;
 
         // Keep track of previous JoinSplit and its commitments
-        if (tx_.getJoinsSplit().size() > 0) {
-            prevJoinSplit = tx_.getJoinsSplit().back();
+        if (tx_.GetJoinSplits().size() > 0) {
+            prevJoinSplit = tx_.GetJoinSplits().back();
         }
 
         // If there is no change, the chain has terminated so we can reset the tracked treestate.
-        if (jsChange==0 && tx_.getJoinsSplit().size() > 0) {
+        if (jsChange==0 && tx_.GetJoinSplits().size() > 0) {
             intermediates.clear();
             previousCommitments.clear();
         }
@@ -839,7 +839,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -854,7 +854,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
             continue;
         }
 
-        CAmount nValue = out.tx->getVout()[out.i].nValue;
+        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
         SendManyInputUTXO utxo(out.tx->GetHash(), out.i, nValue, isCoinbase);
         t_inputs_.push_back(utxo);
     }
@@ -958,7 +958,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.getJoinsSplit().size(),
+            tx_.GetJoinSplits().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)
@@ -1066,7 +1066,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
     memcpy(&buffer[0], &joinSplitPrivKey_[0], 32); // private key in first half of 64 byte buffer
     std::vector<unsigned char> vch(&buffer[0], &buffer[0] + 32);
     uint256 joinSplitPrivKey = uint256(vch);
-    size_t js_index = tx_.getJoinsSplit().size() - 1;
+    size_t js_index = tx_.GetJoinSplits().size() - 1;
     uint256 placeholder;
     for (int i = 0; i < ZC_NUM_JS_OUTPUTS; i++) {
         uint8_t mapped_index = outputMap[i];

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -512,12 +512,12 @@ bool AsyncRPCOperation_sendmany::main_impl() {
         JSDescription prevJoinSplit;
 
         // Keep track of previous JoinSplit and its commitments
-        if (tx_.GetJoinSplits().size() > 0) {
-            prevJoinSplit = tx_.GetJoinSplits().back();
+        if (tx_.GetVjoinsplit().size() > 0) {
+            prevJoinSplit = tx_.GetVjoinsplit().back();
         }
 
         // If there is no change, the chain has terminated so we can reset the tracked treestate.
-        if (jsChange==0 && tx_.GetJoinSplits().size() > 0) {
+        if (jsChange==0 && tx_.GetVjoinsplit().size() > 0) {
             intermediates.clear();
             previousCommitments.clear();
         }
@@ -839,7 +839,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -854,7 +854,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
             continue;
         }
 
-        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
+        CAmount nValue = out.tx->GetVout()[out.i].nValue;
         SendManyInputUTXO utxo(out.tx->GetHash(), out.i, nValue, isCoinbase);
         t_inputs_.push_back(utxo);
     }
@@ -958,7 +958,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.GetJoinSplits().size(),
+            tx_.GetVjoinsplit().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)
@@ -1066,7 +1066,7 @@ UniValue AsyncRPCOperation_sendmany::perform_joinsplit(
     memcpy(&buffer[0], &joinSplitPrivKey_[0], 32); // private key in first half of 64 byte buffer
     std::vector<unsigned char> vch(&buffer[0], &buffer[0] + 32);
     uint256 joinSplitPrivKey = uint256(vch);
-    size_t js_index = tx_.GetJoinSplits().size() - 1;
+    size_t js_index = tx_.GetVjoinsplit().size() - 1;
     uint256 placeholder;
     for (int i = 0; i < ZC_NUM_JS_OUTPUTS; i++) {
         uint8_t mapped_index = outputMap[i];

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -839,7 +839,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -854,7 +854,7 @@ bool AsyncRPCOperation_sendmany::find_utxos(bool fAcceptCoinbase=false) {
             continue;
         }
 
-        CAmount nValue = out.tx->vout[out.i].nValue;
+        CAmount nValue = out.tx->getVout()[out.i].nValue;
         SendManyInputUTXO utxo(out.tx->GetHash(), out.i, nValue, isCoinbase);
         t_inputs_.push_back(utxo);
     }

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -304,7 +304,7 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.getJoinsSplit().size(),
+            tx_.GetJoinSplits().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -304,7 +304,7 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.vjoinsplit.size(),
+            tx_.getJoinsSplit().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -304,7 +304,7 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
 
     LogPrint("zrpcunsafe", "%s: creating joinsplit at index %d (vpub_old=%s, vpub_new=%s, in[0]=%s, in[1]=%s, out[0]=%s, out[1]=%s)\n",
             getId(),
-            tx_.GetJoinSplits().size(),
+            tx_.GetVjoinsplit().size(),
             FormatMoney(info.vpub_old), FormatMoney(info.vpub_new),
             FormatMoney(info.vjsin[0].note.value()), FormatMoney(info.vjsin[1].note.value()),
             FormatMoney(info.vjsout[0].value), FormatMoney(info.vjsout[1].value)

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -344,11 +344,11 @@ TEST(WalletTests, CheckNoteCommitmentAgainstNotePlaintext) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.getJoinsSplit()[0].h_sig(
+    auto hSig = wtx.GetJoinSplits()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     ASSERT_THROW(wallet.GetNoteNullifier(
-        wtx.getJoinsSplit()[0],
+        wtx.GetJoinSplits()[0],
         address,
         dec,
         hSig, 1), libzcash::note_decryption_failed);
@@ -365,11 +365,11 @@ TEST(WalletTests, GetNoteNullifier) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.getJoinsSplit()[0].h_sig(
+    auto hSig = wtx.GetJoinSplits()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     auto ret = wallet.GetNoteNullifier(
-        wtx.getJoinsSplit()[0],
+        wtx.GetJoinSplits()[0],
         address,
         dec,
         hSig, 1);
@@ -378,7 +378,7 @@ TEST(WalletTests, GetNoteNullifier) {
     wallet.AddSpendingKey(sk);
 
     ret = wallet.GetNoteNullifier(
-        wtx.getJoinsSplit()[0],
+        wtx.GetJoinSplits()[0],
         address,
         dec,
         hSig, 1);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -344,11 +344,11 @@ TEST(WalletTests, CheckNoteCommitmentAgainstNotePlaintext) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.GetJoinSplits()[0].h_sig(
+    auto hSig = wtx.GetVjoinsplit()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     ASSERT_THROW(wallet.GetNoteNullifier(
-        wtx.GetJoinSplits()[0],
+        wtx.GetVjoinsplit()[0],
         address,
         dec,
         hSig, 1), libzcash::note_decryption_failed);
@@ -365,11 +365,11 @@ TEST(WalletTests, GetNoteNullifier) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.GetJoinSplits()[0].h_sig(
+    auto hSig = wtx.GetVjoinsplit()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     auto ret = wallet.GetNoteNullifier(
-        wtx.GetJoinSplits()[0],
+        wtx.GetVjoinsplit()[0],
         address,
         dec,
         hSig, 1);
@@ -378,7 +378,7 @@ TEST(WalletTests, GetNoteNullifier) {
     wallet.AddSpendingKey(sk);
 
     ret = wallet.GetNoteNullifier(
-        wtx.GetJoinSplits()[0],
+        wtx.GetVjoinsplit()[0],
         address,
         dec,
         hSig, 1);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -344,11 +344,11 @@ TEST(WalletTests, CheckNoteCommitmentAgainstNotePlaintext) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.vjoinsplit[0].h_sig(
+    auto hSig = wtx.getJoinsSplit()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     ASSERT_THROW(wallet.GetNoteNullifier(
-        wtx.vjoinsplit[0],
+        wtx.getJoinsSplit()[0],
         address,
         dec,
         hSig, 1), libzcash::note_decryption_failed);
@@ -365,11 +365,11 @@ TEST(WalletTests, GetNoteNullifier) {
     auto note = GetNote(sk, wtx, 0, 1);
     auto nullifier = note.nullifier(sk);
 
-    auto hSig = wtx.vjoinsplit[0].h_sig(
+    auto hSig = wtx.getJoinsSplit()[0].h_sig(
         *params, wtx.joinSplitPubKey);
 
     auto ret = wallet.GetNoteNullifier(
-        wtx.vjoinsplit[0],
+        wtx.getJoinsSplit()[0],
         address,
         dec,
         hSig, 1);
@@ -378,7 +378,7 @@ TEST(WalletTests, GetNoteNullifier) {
     wallet.AddSpendingKey(sk);
 
     ret = wallet.GetNoteNullifier(
-        wtx.vjoinsplit[0],
+        wtx.getJoinsSplit()[0],
         address,
         dec,
         hSig, 1);

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -103,7 +103,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     const CWalletObjBase& wtx = *(pwalletMain->mapWallet[hash]);
 
     // Check if shielded tx
-    if (wtx.GetJoinSplits().size() == 0) {
+    if (wtx.GetVjoinsplit().size() == 0) {
 #endif
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
@@ -111,9 +111,9 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     // Check js_index
     int js_index = params[1].get_int();
 #if 0
-    if (js_index < 0 || js_index >= wtx.GetJoinSplits().size()) {
+    if (js_index < 0 || js_index >= wtx.GetVjoinsplit().size()) {
 #else
-    if (js_index < 0 || js_index >= wtx.GetJoinSplits().size()) {
+    if (js_index < 0 || js_index >= wtx.GetVjoinsplit().size()) {
 #endif
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid js_index");
     }
@@ -233,7 +233,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     }
 
     // Check if shielded tx
-    if (tx.GetJoinSplits().empty()) {
+    if (tx.GetVjoinsplit().empty()) {
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
 
@@ -242,7 +242,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     o.push_back(Pair("txid", pd.payload.txid.ToString()));
 
     // Check js_index
-    if (pd.payload.js >= tx.GetJoinSplits().size()) {
+    if (pd.payload.js >= tx.GetVjoinsplit().size()) {
         errs.push_back("Payment disclosure refers to an invalid joinsplit index");
     }
     o.push_back(Pair("jsIndex", pd.payload.js));
@@ -276,7 +276,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
 
         try {
             // Decrypt the note to get value and memo field
-            JSDescription jsdesc = tx.GetJoinSplits()[pd.payload.js];
+            JSDescription jsdesc = tx.GetVjoinsplit()[pd.payload.js];
             uint256 h_sig = jsdesc.h_sig(*pzcashParams, tx.joinSplitPubKey);
 
             ZCPaymentDisclosureNoteDecryption decrypter;

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -103,7 +103,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     const CWalletObjBase& wtx = *(pwalletMain->mapWallet[hash]);
 
     // Check if shielded tx
-    if (wtx.getVjoinsplitSize() == 0) {
+    if (wtx.getJoinsSplit().size() == 0) {
 #endif
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
@@ -113,7 +113,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
 #if 0
     if (js_index < 0 || js_index >= wtx.vjoinsplit.size()) {
 #else
-    if (js_index < 0 || js_index >= wtx.getVjoinsplitSize()) {
+    if (js_index < 0 || js_index >= wtx.getJoinsSplit().size()) {
 #endif
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid js_index");
     }

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -111,7 +111,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     // Check js_index
     int js_index = params[1].get_int();
 #if 0
-    if (js_index < 0 || js_index >= wtx.vjoinsplit.size()) {
+    if (js_index < 0 || js_index >= wtx.getJoinsSplit().size()) {
 #else
     if (js_index < 0 || js_index >= wtx.getJoinsSplit().size()) {
 #endif
@@ -233,7 +233,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     }
 
     // Check if shielded tx
-    if (tx.vjoinsplit.empty()) {
+    if (tx.getJoinsSplit().empty()) {
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
 
@@ -242,7 +242,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     o.push_back(Pair("txid", pd.payload.txid.ToString()));
 
     // Check js_index
-    if (pd.payload.js >= tx.vjoinsplit.size()) {
+    if (pd.payload.js >= tx.getJoinsSplit().size()) {
         errs.push_back("Payment disclosure refers to an invalid joinsplit index");
     }
     o.push_back(Pair("jsIndex", pd.payload.js));
@@ -276,7 +276,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
 
         try {
             // Decrypt the note to get value and memo field
-            JSDescription jsdesc = tx.vjoinsplit[pd.payload.js];
+            JSDescription jsdesc = tx.getJoinsSplit()[pd.payload.js];
             uint256 h_sig = jsdesc.h_sig(*pzcashParams, tx.joinSplitPubKey);
 
             ZCPaymentDisclosureNoteDecryption decrypter;

--- a/src/wallet/rpcdisclosure.cpp
+++ b/src/wallet/rpcdisclosure.cpp
@@ -103,7 +103,7 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     const CWalletObjBase& wtx = *(pwalletMain->mapWallet[hash]);
 
     // Check if shielded tx
-    if (wtx.getJoinsSplit().size() == 0) {
+    if (wtx.GetJoinSplits().size() == 0) {
 #endif
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
@@ -111,9 +111,9 @@ UniValue z_getpaymentdisclosure(const UniValue& params, bool fHelp)
     // Check js_index
     int js_index = params[1].get_int();
 #if 0
-    if (js_index < 0 || js_index >= wtx.getJoinsSplit().size()) {
+    if (js_index < 0 || js_index >= wtx.GetJoinSplits().size()) {
 #else
-    if (js_index < 0 || js_index >= wtx.getJoinsSplit().size()) {
+    if (js_index < 0 || js_index >= wtx.GetJoinSplits().size()) {
 #endif
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid js_index");
     }
@@ -233,7 +233,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     }
 
     // Check if shielded tx
-    if (tx.getJoinsSplit().empty()) {
+    if (tx.GetJoinSplits().empty()) {
         throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not a shielded transaction");
     }
 
@@ -242,7 +242,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
     o.push_back(Pair("txid", pd.payload.txid.ToString()));
 
     // Check js_index
-    if (pd.payload.js >= tx.getJoinsSplit().size()) {
+    if (pd.payload.js >= tx.GetJoinSplits().size()) {
         errs.push_back("Payment disclosure refers to an invalid joinsplit index");
     }
     o.push_back(Pair("jsIndex", pd.payload.js));
@@ -276,7 +276,7 @@ UniValue z_validatepaymentdisclosure(const UniValue& params, bool fHelp)
 
         try {
             // Decrypt the note to get value and memo field
-            JSDescription jsdesc = tx.getJoinsSplit()[pd.payload.js];
+            JSDescription jsdesc = tx.GetJoinSplits()[pd.payload.js];
             uint256 h_sig = jsdesc.h_sig(*pzcashParams, tx.joinSplitPubKey);
 
             ZCPaymentDisclosureNoteDecryption decrypter;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -89,8 +89,8 @@ void TxExpandedToJSON(const CWalletObjBase& tx, const std::vector<CWalletObjBase
     tx.AddVinExpandedToJSON(entry, vtxIn);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
-        const CTxOut& txout = tx.GetVouts()[i];
+    for (unsigned int i = 0; i < tx.GetVout().size(); i++) {
+        const CTxOut& txout = tx.GetVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -265,7 +265,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 #else
             const CWalletObjBase& wtx = *((*it).second);
 #endif
-            BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
+            BOOST_FOREACH(const CTxOut& txout, wtx.GetVout())
             {
                 /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
                  * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1432,7 +1432,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVout())
         {
             /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
              * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1499,7 +1499,7 @@ UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVout())
         {
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
@@ -2001,7 +2001,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
         if (nDepth < nMinDepth)
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVout())
         {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
@@ -3446,15 +3446,15 @@ UniValue listunspent(const UniValue& params, bool fHelp)
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address))
+            if (!ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, address))
                 continue;
 
             if (!setAddress.count(address))
                 continue;
         }
 
-        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
-        const CScript& pk = out.tx->GetVouts()[out.i].scriptPubKey;
+        CAmount nValue = out.tx->GetVout()[out.i].nValue;
+        const CScript& pk = out.tx->GetVout()[out.i].scriptPubKey;
         UniValue entry(UniValue::VOBJ);
 #if 1
         if (out.tx->IsCoinCertified() )
@@ -3475,7 +3475,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
         entry.push_back(Pair("generated", out.tx->IsCoinBase()));
 #endif
         CTxDestination address;
-        if (ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
+        if (ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, address)) {
             entry.push_back(Pair("address", CBitcoinAddress(address).ToString()));
             if (pwalletMain->mapAddressBook.count(address))
                 entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));
@@ -4106,7 +4106,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -4115,7 +4115,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
             }
         }
 
-        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
+        CAmount nValue = out.tx->GetVout()[out.i].nValue;
         balance += nValue;
     }
     return balance;
@@ -5172,7 +5172,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         CTxDestination address;
-        if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
+        if (!ExtractDestination(out.tx->GetVout()[out.i].scriptPubKey, address)) {
             continue;
         }
         // If taddr is not wildcard "*", filter utxos
@@ -5185,7 +5185,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         utxoCounter++;
-        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
+        CAmount nValue = out.tx->GetVout()[out.i].nValue;
 
         if (!maxedOutFlag) {
             CBitcoinAddress ba(address);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -89,8 +89,8 @@ void TxExpandedToJSON(const CWalletObjBase& tx, const std::vector<CWalletObjBase
     tx.AddVinExpandedToJSON(entry, vtxIn);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        const CTxOut& txout = tx.vout[i];
+    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
+        const CTxOut& txout = tx.getVout()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -265,7 +265,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 #else
             const CWalletObjBase& wtx = *((*it).second);
 #endif
-            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
             {
                 /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
                  * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1432,7 +1432,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
         {
             /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
              * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1499,7 +1499,7 @@ UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
         {
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
@@ -2001,7 +2001,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
         if (nDepth < nMinDepth)
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
         {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
@@ -3405,15 +3405,15 @@ UniValue listunspent(const UniValue& params, bool fHelp)
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
+            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address))
                 continue;
 
             if (!setAddress.count(address))
                 continue;
         }
 
-        CAmount nValue = out.tx->vout[out.i].nValue;
-        const CScript& pk = out.tx->vout[out.i].scriptPubKey;
+        CAmount nValue = out.tx->getVout()[out.i].nValue;
+        const CScript& pk = out.tx->getVout()[out.i].scriptPubKey;
         UniValue entry(UniValue::VOBJ);
 #if 1
         if (out.tx->IsCoinCertified() )
@@ -3434,7 +3434,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
         entry.push_back(Pair("generated", out.tx->IsCoinBase()));
 #endif
         CTxDestination address;
-        if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
+        if (ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
             entry.push_back(Pair("address", CBitcoinAddress(address).ToString()));
             if (pwalletMain->mapAddressBook.count(address))
                 entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));
@@ -4065,7 +4065,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -4074,7 +4074,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
             }
         }
 
-        CAmount nValue = out.tx->vout[out.i].nValue;
+        CAmount nValue = out.tx->getVout()[out.i].nValue;
         balance += nValue;
     }
     return balance;
@@ -5131,7 +5131,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         CTxDestination address;
-        if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
+        if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
             continue;
         }
         // If taddr is not wildcard "*", filter utxos
@@ -5144,7 +5144,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         utxoCounter++;
-        CAmount nValue = out.tx->vout[out.i].nValue;
+        CAmount nValue = out.tx->getVout()[out.i].nValue;
 
         if (!maxedOutFlag) {
             CBitcoinAddress ba(address);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -89,8 +89,8 @@ void TxExpandedToJSON(const CWalletObjBase& tx, const std::vector<CWalletObjBase
     tx.AddVinExpandedToJSON(entry, vtxIn);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.getVout().size(); i++) {
-        const CTxOut& txout = tx.getVout()[i];
+    for (unsigned int i = 0; i < tx.GetVouts().size(); i++) {
+        const CTxOut& txout = tx.GetVouts()[i];
         UniValue out(UniValue::VOBJ);
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("valueZat", txout.nValue));
@@ -265,7 +265,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 #else
             const CWalletObjBase& wtx = *((*it).second);
 #endif
-            BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
+            BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
             {
                 /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
                  * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1432,7 +1432,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
         {
             /* Check that txout.scriptPubKey starts with scriptPubKey instead of full match,
              * cause we cant compare OP_CHECKBLOCKATHEIGHT arguments, they are different all the time */
@@ -1499,7 +1499,7 @@ UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
 #endif
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
         {
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
@@ -2001,7 +2001,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
         if (nDepth < nMinDepth)
             continue;
 
-        BOOST_FOREACH(const CTxOut& txout, wtx.getVout())
+        BOOST_FOREACH(const CTxOut& txout, wtx.GetVouts())
         {
             CTxDestination address;
             if (!ExtractDestination(txout.scriptPubKey, address))
@@ -3446,15 +3446,15 @@ UniValue listunspent(const UniValue& params, bool fHelp)
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address))
+            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address))
                 continue;
 
             if (!setAddress.count(address))
                 continue;
         }
 
-        CAmount nValue = out.tx->getVout()[out.i].nValue;
-        const CScript& pk = out.tx->getVout()[out.i].scriptPubKey;
+        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
+        const CScript& pk = out.tx->GetVouts()[out.i].scriptPubKey;
         UniValue entry(UniValue::VOBJ);
 #if 1
         if (out.tx->IsCoinCertified() )
@@ -3475,7 +3475,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
         entry.push_back(Pair("generated", out.tx->IsCoinBase()));
 #endif
         CTxDestination address;
-        if (ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
+        if (ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
             entry.push_back(Pair("address", CBitcoinAddress(address).ToString()));
             if (pwalletMain->mapAddressBook.count(address))
                 entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));
@@ -4106,7 +4106,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
 
         if (setAddress.size()) {
             CTxDestination address;
-            if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
+            if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
                 continue;
             }
 
@@ -4115,7 +4115,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
             }
         }
 
-        CAmount nValue = out.tx->getVout()[out.i].nValue;
+        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
         balance += nValue;
     }
     return balance;
@@ -5172,7 +5172,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         CTxDestination address;
-        if (!ExtractDestination(out.tx->getVout()[out.i].scriptPubKey, address)) {
+        if (!ExtractDestination(out.tx->GetVouts()[out.i].scriptPubKey, address)) {
             continue;
         }
         // If taddr is not wildcard "*", filter utxos
@@ -5185,7 +5185,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
         }
 
         utxoCounter++;
-        CAmount nValue = out.tx->getVout()[out.i].nValue;
+        CAmount nValue = out.tx->GetVouts()[out.i].nValue;
 
         if (!maxedOutFlag) {
             CBitcoinAddress ba(address);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2861,7 +2861,7 @@ CAmount CWallet::GetUnconfirmedData(const CScript& scriptToMatch, int& numbOfUnc
         {
             const CWalletObjBase* pcoin = it->second.get();
 
-            for(const auto& txout : pcoin->vout)
+            for(const auto& txout : pcoin->getVout())
             {
                 auto res = std::search(txout.scriptPubKey.begin(), txout.scriptPubKey.end(), scriptToMatch.begin(), scriptToMatch.end());
                 if (res == txout.scriptPubKey.begin())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -80,7 +80,7 @@ std::string JSOutPoint::ToString() const
 
 std::string COutput::ToString() const
 {
-    return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->GetVouts()[i].nValue));
+    return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->GetVout()[i].nValue));
 }
 
 #if 0
@@ -504,7 +504,7 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
 #if 0
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    BOOST_FOREACH(const CTxIn& txin, wtx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, wtx.GetVin())
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -515,7 +515,7 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
 
     std::pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range_n;
 
-    for (const JSDescription& jsdesc : wtx.GetJoinSplits()) {
+    for (const JSDescription& jsdesc : wtx.GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             if (mapTxNullifiers.count(nullifier) <= 1) {
                 continue;  // No conflict if zero or one spends
@@ -725,10 +725,10 @@ void CWallet::AddToSpends(const uint256& wtxid)
     if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : thisTx.GetVins()) {
+    for (const CTxIn& txin : thisTx.GetVin()) {
         AddToSpends(txin.prevout, wtxid);
     }
-    for (const JSDescription& jsdesc : thisTx.GetJoinSplits()) {
+    for (const JSDescription& jsdesc : thisTx.GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             AddToSpends(nullifier, wtxid);
         }
@@ -746,12 +746,12 @@ void CWalletTx::AddToSpends(CWallet* pw)
     if (IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : GetVins()) {
+    for (const CTxIn& txin : GetVin()) {
         LogPrint("cert", "%s():%d - obj[%s] spends out %d of [%s]\n", __func__, __LINE__,
             GetHash().ToString(), txin.prevout.n, txin.prevout.hash.ToString());
         pw->AddToSpends(txin.prevout, GetHash());
     }
-    for (const JSDescription& jsdesc : GetJoinSplits()) {
+    for (const JSDescription& jsdesc : GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             pw->AddToSpends(nullifier, GetHash());
         }
@@ -909,8 +909,8 @@ void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
         for (const CTransaction& tx : pblock->vtx) {
             auto hash = tx.GetHash();
             bool txIsOurs = mapWallet.count(hash);
-            for (size_t i = 0; i < tx.GetJoinSplits().size(); i++) {
-                const JSDescription& jsdesc = tx.GetJoinSplits()[i];
+            for (size_t i = 0; i < tx.GetVjoinsplit().size(); i++) {
+                const JSDescription& jsdesc = tx.GetVjoinsplit()[i];
                 for (uint8_t j = 0; j < jsdesc.commitments.size(); j++) {
                     const uint256& note_commitment = jsdesc.commitments[j];
                     tree.append(note_commitment);
@@ -1147,7 +1147,7 @@ TxItems CWallet::OrderedTxItems(std::list<CAccountingEntry>& acentries, const st
             // search in the tx outputs
             bool outputFound = false;
 
-            for(const CTxOut& txout : wtx->GetVouts()) {
+            for(const CTxOut& txout : wtx->GetVout()) {
                 auto res = std::search(txout.scriptPubKey.begin(), txout.scriptPubKey.end(), scriptPubKey.begin(), scriptPubKey.end());
                 if (res == txout.scriptPubKey.begin()) {
                     txOrdered.insert(make_pair(wtx->nOrderPos, TxPair(wtx, (CAccountingEntry*)0)));
@@ -1200,7 +1200,7 @@ MapTxWithInputs CWallet::OrderedTxWithInputsMap(const std::string& address)
         bool outputFound = false;
         bool inputFound = false;
 
-        for(const auto& txout : wtx.GetVouts())
+        for(const auto& txout : wtx.GetVout())
         {
             auto res = std::search(txout.scriptPubKey.begin(), txout.scriptPubKey.end(), scriptPubKey.begin(), scriptPubKey.end());
             if (res == txout.scriptPubKey.begin())
@@ -1273,10 +1273,10 @@ void CWalletTx::UpdateNullifierMap(CWallet* pw)
         if (!item.second.nullifier) {
             if (pw->GetNoteDecryptor(item.second.address, dec)) {
                 auto i = item.first.js;
-                auto hSig = GetJoinSplits()[i].h_sig(
+                auto hSig = GetVjoinsplit()[i].h_sig(
                     *pzcashParams, joinSplitPubKey);
                 item.second.nullifier = pw->GetNoteNullifier(
-                    GetJoinSplits()[i],
+                    GetVjoinsplit()[i],
                     item.second.address,
                     dec,
                     hSig,
@@ -1632,7 +1632,7 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
     // If a transaction changes 'conflicted' state, that changes the balance
     // available of the outputs it spends. So force those to be
     // recomputed, also:
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
     {
         if (mapWallet.count(txin.prevout.hash))
 #if 0
@@ -1641,7 +1641,7 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
             mapWallet[txin.prevout.hash]->MarkDirty();
 #endif
     }
-    for (const JSDescription& jsdesc : tx.GetJoinSplits()) {
+    for (const JSDescription& jsdesc : tx.GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             if (mapNullifiersToNotes.count(nullifier) &&
                     mapWallet.count(mapNullifiersToNotes[nullifier].hash)) {
@@ -1718,15 +1718,15 @@ mapNoteData_t CWallet::FindMyNotes(const CTransaction& tx) const
     uint256 hash = tx.GetHash();
 
     mapNoteData_t noteData;
-    for (size_t i = 0; i < tx.GetJoinSplits().size(); i++) {
-        auto hSig = tx.GetJoinSplits()[i].h_sig(*pzcashParams, tx.joinSplitPubKey);
-        for (uint8_t j = 0; j < tx.GetJoinSplits()[i].ciphertexts.size(); j++) {
+    for (size_t i = 0; i < tx.GetVjoinsplit().size(); i++) {
+        auto hSig = tx.GetVjoinsplit()[i].h_sig(*pzcashParams, tx.joinSplitPubKey);
+        for (uint8_t j = 0; j < tx.GetVjoinsplit()[i].ciphertexts.size(); j++) {
             for (const NoteDecryptorMap::value_type& item : mapNoteDecryptors) {
                 try {
                     auto address = item.first;
                     JSOutPoint jsoutpt {hash, i, j};
                     auto nullifier = GetNoteNullifier(
-                        tx.GetJoinSplits()[i],
+                        tx.GetVjoinsplit()[i],
                         address,
                         item.second,
                         hSig, j);
@@ -1824,8 +1824,8 @@ isminetype CWallet::IsMine(const CTxIn &txin) const
         {
             const CWalletObjBase& prev = *(mi->second);
 #endif
-            if (txin.prevout.n < prev.GetVouts().size())
-                return IsMine(prev.GetVouts()[txin.prevout.n]);
+            if (txin.prevout.n < prev.GetVout().size())
+                return IsMine(prev.GetVout()[txin.prevout.n]);
         }
     }
     return ISMINE_NO;
@@ -1846,9 +1846,9 @@ CAmount CWallet::GetDebit(const CTxIn &txin, const isminefilter& filter) const
         {
             const CWalletObjBase& prev = *(mi->second);
 #endif
-            if (txin.prevout.n < prev.GetVouts().size())
-                if (IsMine(prev.GetVouts()[txin.prevout.n]) & filter)
-                    return prev.GetVouts()[txin.prevout.n].nValue;
+            if (txin.prevout.n < prev.GetVout().size())
+                if (IsMine(prev.GetVout()[txin.prevout.n]) & filter)
+                    return prev.GetVout()[txin.prevout.n].nValue;
         }
     }
     return 0;
@@ -1897,7 +1897,7 @@ CAmount CWallet::GetChange(const CTxOut& txout) const
 
 bool CWallet::IsMine(const CTransactionBase& tx) const
 {
-    BOOST_FOREACH(const CTxOut& txout, tx.GetVouts())
+    BOOST_FOREACH(const CTxOut& txout, tx.GetVout())
         if (IsMine(txout))
             return true;
     return false;
@@ -1908,7 +1908,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
     if (GetDebit(tx, ISMINE_ALL) > 0) {
         return true;
     }
-    for (const JSDescription& jsdesc : tx.GetJoinSplits()) {
+    for (const JSDescription& jsdesc : tx.GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             if (IsFromMe(nullifier)) {
                 return true;
@@ -1921,7 +1921,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
 CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) const
 {
     CAmount nDebit = 0;
-    BOOST_FOREACH(const CTxIn& txin, tx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, tx.GetVin())
     {
         nDebit += GetDebit(txin, filter);
         if (!MoneyRange(nDebit))
@@ -1937,7 +1937,7 @@ CAmount CWallet::GetCredit(const CTransactionBase& tx, const isminefilter& filte
 #endif
 {
     CAmount nCredit = 0;
-    BOOST_FOREACH(const CTxOut& txout, tx.GetVouts())
+    BOOST_FOREACH(const CTxOut& txout, tx.GetVout())
     {
         nCredit += GetCredit(txout, filter);
         if (!MoneyRange(nCredit))
@@ -1953,7 +1953,7 @@ CAmount CWallet::GetChange(const CTransactionBase& tx) const
 #endif
 {
     CAmount nChange = 0;
-    BOOST_FOREACH(const CTxOut& txout, tx.GetVouts())
+    BOOST_FOREACH(const CTxOut& txout, tx.GetVout())
     {
         nChange += GetChange(txout);
         if (!MoneyRange(nChange))
@@ -1966,8 +1966,8 @@ void CWalletTx::SetNoteData(mapNoteData_t &noteData)
 {
     mapNoteData.clear();
     for (const std::pair<JSOutPoint, CNoteData> nd : noteData) {
-        if (nd.first.js < GetJoinSplits().size() &&
-                nd.first.n < GetJoinSplits()[nd.first.js].ciphertexts.size()) {
+        if (nd.first.js < GetVjoinsplit().size() &&
+                nd.first.n < GetVjoinsplit()[nd.first.js].ciphertexts.size()) {
             // Store the address and nullifier for the Note
             mapNoteData[nd.first] = nd.second;
         } else {
@@ -2048,7 +2048,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
 
     // Does this tx spend my notes?
     bool isFromMyZaddr = false;
-    for (const JSDescription& js : GetJoinSplits()) {
+    for (const JSDescription& js : GetVjoinsplit()) {
         for (const uint256& nullifier : js.nullifiers) {
             if (pwallet->IsFromMe(nullifier)) {
                 isFromMyZaddr = true;
@@ -2064,7 +2064,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
     if (isFromMyTaddr) {
         CAmount nValueOut = GetValueOut();  // transparent outputs plus all vpub_old
         CAmount nValueIn = 0;
-        for (const JSDescription & js : GetJoinSplits()) {
+        for (const JSDescription & js : GetVjoinsplit()) {
             nValueIn += js.vpub_new;
         }
         nFee = nDebit - nValueOut + nValueIn;
@@ -2074,7 +2074,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
     if (isFromMyTaddr) {
         CAmount myVpubOld = 0;
         CAmount myVpubNew = 0;
-        for (const JSDescription& js : GetJoinSplits()) {
+        for (const JSDescription& js : GetVjoinsplit()) {
             bool fMyJSDesc = false;
 
             // Check input side
@@ -2088,7 +2088,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
             // Check output side
             if (!fMyJSDesc) {
                 for (const std::pair<JSOutPoint, CNoteData> nd : this->mapNoteData) {
-                    if (nd.first.js < GetJoinSplits().size() && nd.first.n < GetJoinSplits()[nd.first.js].ciphertexts.size()) {
+                    if (nd.first.js < GetVjoinsplit().size() && nd.first.n < GetVjoinsplit()[nd.first.js].ciphertexts.size()) {
                         fMyJSDesc = true;
                         break;
                     }
@@ -2229,7 +2229,7 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
 
         BOOST_FOREACH(const CTransaction& tx, block.vtx)
         {
-            BOOST_FOREACH(const JSDescription& jsdesc, tx.GetJoinSplits())
+            BOOST_FOREACH(const JSDescription& jsdesc, tx.GetVjoinsplit())
             {
                 BOOST_FOREACH(const uint256 &note_commitment, jsdesc.commitments)
                 {
@@ -2434,7 +2434,7 @@ void CWalletTx::GetConflicts(std::set<uint256>& result) const
 
     std::pair<CWallet::TxSpends::const_iterator, CWallet::TxSpends::const_iterator> range;
 
-    BOOST_FOREACH(const CTxIn& txin, GetVins())
+    BOOST_FOREACH(const CTxIn& txin, GetVin())
     {
         if (pwallet->mapTxSpends.count(txin.prevout) <= 1)
             continue;  // No conflict if zero or one spends
@@ -2445,7 +2445,7 @@ void CWalletTx::GetConflicts(std::set<uint256>& result) const
 
     std::pair<CWallet::TxNullifiers::const_iterator, CWallet::TxNullifiers::const_iterator> range_n;
 
-    for (const JSDescription& jsdesc : GetJoinSplits()) {
+    for (const JSDescription& jsdesc : GetVjoinsplit()) {
         for (const uint256& nullifier : jsdesc.nullifiers) {
             if (pwallet->mapTxNullifiers.count(nullifier) <= 1) {
                 continue;  // No conflict if zero or one spends
@@ -2460,7 +2460,7 @@ void CWalletTx::GetConflicts(std::set<uint256>& result) const
 
 void CWalletTx::addOrderedInputTx(TxItems& txOrdered, const CScript& scriptPubKey) const
 {
-    for(const CTxIn& txin: GetVins())
+    for(const CTxIn& txin: GetVin())
     {
         auto mi = pwallet->mapWallet.find(txin.prevout.hash);
         if (mi == pwallet->mapWallet.end())
@@ -2469,12 +2469,12 @@ void CWalletTx::addOrderedInputTx(TxItems& txOrdered, const CScript& scriptPubKe
         }
 
         const auto& inputTx = (*mi).second;
-        if (txin.prevout.n >= inputTx->GetVouts().size())
+        if (txin.prevout.n >= inputTx->GetVout().size())
         {
             continue;
         }
 
-        const CTxOut& utxo = inputTx->GetVouts()[txin.prevout.n];
+        const CTxOut& utxo = inputTx->GetVout()[txin.prevout.n];
 
         auto res = std::search(utxo.scriptPubKey.begin(), utxo.scriptPubKey.end(), scriptPubKey.begin(), scriptPubKey.end());
         if (res == utxo.scriptPubKey.begin()) {
@@ -2487,7 +2487,7 @@ void CWalletTx::addOrderedInputTx(TxItems& txOrdered, const CScript& scriptPubKe
 
 CAmount CWalletTx::GetDebit(const isminefilter& filter) const
 {
-    if (GetVins().empty())
+    if (GetVin().empty())
         return 0;
 
     CAmount debit = 0;
@@ -2719,7 +2719,7 @@ bool CWalletTx::IsTrusted() const
         return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    BOOST_FOREACH(const CTxIn& txin, GetVins())
+    BOOST_FOREACH(const CTxIn& txin, GetVin())
     {
         // Transactions not sent by us: not trusted
 #if 0
@@ -2729,7 +2729,7 @@ bool CWalletTx::IsTrusted() const
 #endif
         if (parent == NULL)
             return false;
-        const CTxOut& parentOut = parent->GetVouts()[txin.prevout.n];
+        const CTxOut& parentOut = parent->GetVout()[txin.prevout.n];
         if (pwallet->IsMine(parentOut) != ISMINE_SPENDABLE)
             return false;
     }
@@ -2861,7 +2861,7 @@ CAmount CWallet::GetUnconfirmedData(const CScript& scriptToMatch, int& numbOfUnc
         {
             const CWalletObjBase* pcoin = it->second.get();
 
-            for(const auto& txout : pcoin->GetVouts())
+            for(const auto& txout : pcoin->GetVout())
             {
                 auto res = std::search(txout.scriptPubKey.begin(), txout.scriptPubKey.end(), scriptToMatch.begin(), scriptToMatch.end());
                 if (res == txout.scriptPubKey.begin())
@@ -2999,10 +2999,10 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
             if (nDepth < 0)
                 continue;
 
-            for (unsigned int i = 0; i < pcoin->GetVouts().size(); i++) {
-                isminetype mine = IsMine(pcoin->GetVouts()[i]);
+            for (unsigned int i = 0; i < pcoin->GetVout().size(); i++) {
+                isminetype mine = IsMine(pcoin->GetVout()[i]);
                 if (!(IsSpent(wtxid, i)) && mine != ISMINE_NO &&
-                    !IsLockedCoin((*it).first, i) && (pcoin->GetVouts()[i].nValue > 0 || fIncludeZeroValue) &&
+                    !IsLockedCoin((*it).first, i) && (pcoin->GetVout()[i].nValue > 0 || fIncludeZeroValue) &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->fAllowOtherInputs || coinControl->IsSelected((*it).first, i)))
                 {
                     if (pcoin->IsCoinBase())
@@ -3024,7 +3024,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                     if (pcoin->IsCoinCertified() )
                     {
                         LogPrint("cert", "%s():%d - cert[%s] out[%d], amount=%s, spendable[%s]\n", __func__, __LINE__,
-                            pcoin->GetHash().ToString(), i, FormatMoney(pcoin->GetVouts()[i].nValue), ((mine & ISMINE_SPENDABLE) != ISMINE_NO)?"Y":"N");
+                            pcoin->GetHash().ToString(), i, FormatMoney(pcoin->GetVout()[i].nValue), ((mine & ISMINE_SPENDABLE) != ISMINE_NO)?"Y":"N");
                     }
                     vCoins.push_back(COutput(pcoin, i, nDepth, (mine & ISMINE_SPENDABLE) != ISMINE_NO));
                 }
@@ -3129,7 +3129,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
             continue;
 
         int i = output.i;
-        CAmount n = pcoin->GetVouts()[i].nValue;
+        CAmount n = pcoin->GetVout()[i].nValue;
 
 #if 0
         pair<CAmount,pair<const CWalletTx*,unsigned int> > coin = make_pair(n,make_pair(pcoin, i));
@@ -3237,7 +3237,7 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletObj
             if (!out.fSpendable) {
                 continue;
             }
-            value += out.tx->GetVouts()[out.i].nValue;
+            value += out.tx->GetVout()[out.i].nValue;
         }
         if (value <= nTargetValue) {
             CAmount valueWithCoinbase = 0;
@@ -3245,7 +3245,7 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletObj
                 if (!out.fSpendable) {
                     continue;
                 }
-                valueWithCoinbase += out.tx->GetVouts()[out.i].nValue;
+                valueWithCoinbase += out.tx->GetVout()[out.i].nValue;
             }
             fNeedCoinbaseCoinsRet = (valueWithCoinbase >= nTargetValue);
         }
@@ -3258,7 +3258,7 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletObj
         {
             if (!out.fSpendable)
                  continue;
-            nValueRet += out.tx->GetVouts()[out.i].nValue;
+            nValueRet += out.tx->GetVout()[out.i].nValue;
             setCoinsRet.insert(make_pair(out.tx, out.i));
         }
         return (nValueRet >= nTargetValue);
@@ -3289,9 +3289,9 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletObj
             const CWalletObjBase* pcoin = it->second.get();
 #endif
             // Clearly invalid input, fail
-            if (pcoin->GetVouts().size() <= outpoint.n)
+            if (pcoin->GetVout().size() <= outpoint.n)
                 return false;
-            nValueFromPresetInputs += pcoin->GetVouts()[outpoint.n].nValue;
+            nValueFromPresetInputs += pcoin->GetVout()[outpoint.n].nValue;
             setPresetCoins.insert(make_pair(pcoin, outpoint.n));
         } else
             return false; // TODO: Allow non-wallet inputs
@@ -3346,10 +3346,10 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount &nFeeRet, int& nC
         return false;
 
     if (nChangePosRet != -1)
-        tx.vout.insert(tx.vout.begin() + nChangePosRet, wtx.GetVouts()[nChangePosRet]);
+        tx.vout.insert(tx.vout.begin() + nChangePosRet, wtx.GetVout()[nChangePosRet]);
 
     // Add new txins (keeping original txin scriptSig/order)
-    BOOST_FOREACH(const CTxIn& txin, wtx.GetVins())
+    BOOST_FOREACH(const CTxIn& txin, wtx.GetVin())
     {
         bool found = false;
         BOOST_FOREACH(const CTxIn& origTxIn, tx.vin)
@@ -3517,7 +3517,7 @@ bool CWallet::CreateTransaction(
                 for (auto& pcoin : setCoins)
 #endif
                 {
-                    CAmount nCredit = pcoin.first->GetVouts()[pcoin.second].nValue;
+                    CAmount nCredit = pcoin.first->GetVout()[pcoin.second].nValue;
                     //The coin age after the next block (depth+1) is used instead of the current,
                     //reflecting an assumption the user would accept a bit more delay for
                     //a chance at a free transaction.
@@ -3636,7 +3636,7 @@ bool CWallet::CreateTransaction(
 #endif
                 {
                     bool signSuccess;
-                    const CScript& scriptPubKey = coin.first->GetVouts()[coin.second].scriptPubKey;
+                    const CScript& scriptPubKey = coin.first->GetVout()[coin.second].scriptPubKey;
                     CScript& scriptSigRes = txNew.vin[nIn].scriptSig;
                     if (sign)
                         signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, SIGHASH_ALL), scriptPubKey, scriptSigRes);
@@ -3730,7 +3730,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
             AddToWallet(wtxNew, false, pwalletdb);
 
             // Notify that old coins are spent
-            BOOST_FOREACH(const CTxIn& txin, wtxNew.GetVins())
+            BOOST_FOREACH(const CTxIn& txin, wtxNew.GetVin())
             {
 #if 0
                 CWalletTx &coin = mapWallet[txin.prevout.hash];
@@ -4065,15 +4065,15 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
             if (nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? 0 : 1))
                 continue;
 
-            for (unsigned int i = 0; i < pcoin->GetVouts().size(); i++)
+            for (unsigned int i = 0; i < pcoin->GetVout().size(); i++)
             {
                 CTxDestination addr;
-                if (!IsMine(pcoin->GetVouts()[i]))
+                if (!IsMine(pcoin->GetVout()[i]))
                     continue;
-                if(!ExtractDestination(pcoin->GetVouts()[i].scriptPubKey, addr))
+                if(!ExtractDestination(pcoin->GetVout()[i].scriptPubKey, addr))
                     continue;
 
-                CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->GetVouts()[i].nValue;
+                CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->GetVout()[i].nValue;
 
                 if (!balances.count(addr))
                     balances[addr] = 0;
@@ -4095,16 +4095,16 @@ void CWalletTx::HandleInputGrouping(std::set< std::set<CTxDestination> >& groupi
     // TODO pass as param insted
     CWallet* p = const_cast<CWallet*>(pwallet);
 
-    if (GetVins().size() > 0)
+    if (GetVin().size() > 0)
     {
         bool any_mine = false;
         // group all input addresses with each other
-        BOOST_FOREACH(CTxIn txin, GetVins())
+        BOOST_FOREACH(CTxIn txin, GetVin())
         {
             CTxDestination address;
             if(!pwallet->IsMine(txin)) /* If this input isn't mine, ignore it */
                 continue;
-            if(!ExtractDestination(p->mapWallet[txin.prevout.hash]->GetVouts()[txin.prevout.n].scriptPubKey, address))
+            if(!ExtractDestination(p->mapWallet[txin.prevout.hash]->GetVout()[txin.prevout.n].scriptPubKey, address))
                 continue;
             grouping.insert(address);
             any_mine = true;
@@ -4157,9 +4157,9 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
                 if(!IsMine(txin)) /* If this input isn't mine, ignore it */
                     continue;
 #if 0
-                if(!ExtractDestination(mapWallet[txin.prevout.hash].GetVouts()[txin.prevout.n].scriptPubKey, address))
+                if(!ExtractDestination(mapWallet[txin.prevout.hash].GetVout()[txin.prevout.n].scriptPubKey, address))
 #else
-                if(!ExtractDestination(mapWallet[txin.prevout.hash]->GetVouts()[txin.prevout.n].scriptPubKey, address))
+                if(!ExtractDestination(mapWallet[txin.prevout.hash]->GetVout()[txin.prevout.n].scriptPubKey, address))
 #endif
                     continue;
                 grouping.insert(address);
@@ -4169,7 +4169,7 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
             // group change with input addresses
             if (any_mine)
             {
-               BOOST_FOREACH(CTxOut txout, pcoin->GetVouts())
+               BOOST_FOREACH(CTxOut txout, pcoin->GetVout())
                    if (IsChange(txout))
                    {
                        CTxDestination txoutAddr;
@@ -4189,11 +4189,11 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
 #endif
 
         // group lone addrs by themselves
-        for (unsigned int i = 0; i < pcoin->GetVouts().size(); i++)
-            if (IsMine(pcoin->GetVouts()[i]))
+        for (unsigned int i = 0; i < pcoin->GetVout().size(); i++)
+            if (IsMine(pcoin->GetVout()[i]))
             {
                 CTxDestination address;
-                if(!ExtractDestination(pcoin->GetVouts()[i].scriptPubKey, address))
+                if(!ExtractDestination(pcoin->GetVout()[i].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 groupings.insert(grouping);
@@ -4428,7 +4428,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
         if (blit != mapBlockIndex.end() && chainActive.Contains(blit->second)) {
             // ... which are already in a block
             int nHeight = blit->second->nHeight;
-            BOOST_FOREACH(const CTxOut &txout, wtx.GetVouts()) {
+            BOOST_FOREACH(const CTxOut &txout, wtx.GetVout()) {
                 // iterate over all their outputs
                 CAffectedKeysVisitor(*this, vAffected).Process(txout.scriptPubKey);
                 BOOST_FOREACH(const CKeyID &keyid, vAffected) {
@@ -4689,12 +4689,12 @@ void CWallet::GetFilteredNotes(std::vector<CNotePlaintextEntry> & outEntries, st
             }
 
             // determine amount of funds in the note
-            auto hSig = wtx.GetJoinSplits()[i].h_sig(*pzcashParams, wtx.joinSplitPubKey);
+            auto hSig = wtx.GetVjoinsplit()[i].h_sig(*pzcashParams, wtx.joinSplitPubKey);
             try {
                 NotePlaintext plaintext = NotePlaintext::decrypt(
                         decryptor,
-                        wtx.GetJoinSplits()[i].ciphertexts[j],
-                        wtx.GetJoinSplits()[i].ephemeralKey,
+                        wtx.GetVjoinsplit()[i].ciphertexts[j],
+                        wtx.GetVjoinsplit()[i].ephemeralKey,
                         hSig,
                         (unsigned char) j);
 
@@ -4761,13 +4761,13 @@ void CWalletTx::GetNotesAmount(
         }
 
         // determine amount of funds in the note
-        auto hSig = GetJoinSplits()[i].h_sig(*pzcashParams, joinSplitPubKey);
+        auto hSig = GetVjoinsplit()[i].h_sig(*pzcashParams, joinSplitPubKey);
         try
         {
             NotePlaintext plaintext = NotePlaintext::decrypt(
                     decryptor,
-                    GetJoinSplits()[i].ciphertexts[j],
-                    GetJoinSplits()[i].ephemeralKey,
+                    GetVjoinsplit()[i].ciphertexts[j],
+                    GetVjoinsplit()[i].ephemeralKey,
                     hSig,
                     (unsigned char) j);
  
@@ -4788,7 +4788,7 @@ void CWalletTx::AddVinExpandedToJSON(UniValue& entry, const std::vector<CWalletO
 {
     entry.push_back(Pair("locktime", (int64_t)nLockTime));
     UniValue vinArr(UniValue::VARR);
-    for (const CTxIn& txin : GetVins())
+    for (const CTxIn& txin : GetVin())
     {
         UniValue in(UniValue::VOBJ);
         if (IsCoinBase())
@@ -4805,10 +4805,10 @@ void CWalletTx::AddVinExpandedToJSON(UniValue& entry, const std::vector<CWalletO
             {
                 if (inputTx->GetHash() == inputTxHash)
                 {
-                    if (txin.prevout.n >= inputTx->GetVouts().size())
+                    if (txin.prevout.n >= inputTx->GetVout().size())
                         break;
 
-                    const CTxOut& txout = inputTx->GetVouts()[txin.prevout.n];
+                    const CTxOut& txout = inputTx->GetVout()[txin.prevout.n];
 
                     UniValue vout(UniValue::VARR);
                     UniValue out(UniValue::VOBJ);
@@ -4841,7 +4841,7 @@ void CWalletTx::AddVinExpandedToJSON(UniValue& entry, const std::vector<CWalletO
 
 void CWalletTx::addInputTx(std::pair<int64_t, TxWithInputsPair>& entry, const CScript& scriptPubKey, bool& inputFound) const 
 {
-    for(const auto& txin: GetVins())
+    for(const auto& txin: GetVin())
     {
         const auto mi = pwallet->mapWallet.find(txin.prevout.hash);
         if (mi == pwallet->mapWallet.end())
@@ -4850,12 +4850,12 @@ void CWalletTx::addInputTx(std::pair<int64_t, TxWithInputsPair>& entry, const CS
         }
 
         const auto& inputTx = (*mi).second;
-        if (txin.prevout.n >= inputTx->GetVouts().size())
+        if (txin.prevout.n >= inputTx->GetVout().size())
         {
             continue;
         }
 
-        const CTxOut& utxo = inputTx->GetVouts()[txin.prevout.n];
+        const CTxOut& utxo = inputTx->GetVout()[txin.prevout.n];
  
         auto res = std::search(utxo.scriptPubKey.begin(), utxo.scriptPubKey.end(), scriptPubKey.begin(), scriptPubKey.end());
         if (res == utxo.scriptPubKey.begin())

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -275,7 +275,7 @@ double benchmark_large_tx()
     timer_start(tv_start);
     for (size_t i = 0; i < NUM_INPUTS; i++) {
         ScriptError serror = SCRIPT_ERR_OK;
-        assert(VerifyScript(final_spending_tx.GetVins()[i].scriptSig,
+        assert(VerifyScript(final_spending_tx.GetVin()[i].scriptSig,
                             prevPubKey,
                             STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS,
                             TransactionSignatureChecker(&final_spending_tx, i, nullptr),

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -275,7 +275,7 @@ double benchmark_large_tx()
     timer_start(tv_start);
     for (size_t i = 0; i < NUM_INPUTS; i++) {
         ScriptError serror = SCRIPT_ERR_OK;
-        assert(VerifyScript(final_spending_tx.getVins()[i].scriptSig,
+        assert(VerifyScript(final_spending_tx.GetVins()[i].scriptSig,
                             prevPubKey,
                             STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS,
                             TransactionSignatureChecker(&final_spending_tx, i, nullptr),

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -275,7 +275,7 @@ double benchmark_large_tx()
     timer_start(tv_start);
     for (size_t i = 0; i < NUM_INPUTS; i++) {
         ScriptError serror = SCRIPT_ERR_OK;
-        assert(VerifyScript(final_spending_tx.vin[i].scriptSig,
+        assert(VerifyScript(final_spending_tx.getVins()[i].scriptSig,
                             prevPubKey,
                             STANDARD_NONCONTEXTUAL_SCRIPT_VERIFY_FLAGS,
                             TransactionSignatureChecker(&final_spending_tx, i, nullptr),


### PR DESCRIPTION
I have introduced getters for `vin`, `vout `and `vjoinsplits `attributes of transactions and certs.
I have given these attributes the strictest access privilege possible (private or protected) and made sure getters are used through the codebase.
I have refactored `CheckCertificate `and `CheckTransactionWithoutProofVerification `to demonstrate how validations of certificates and transaction can be performed polymorphically. 