### PR TITLE
Further cleanup by getters

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -395,7 +395,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins,
                 ); //A fresh entry should not exist in localCache or be already erased
                 cacheSidechains[entryToWrite.first] = entryToWrite.second;
                 break;
-            case CSidechainsCacheEntry::Flags::DIRTY:               //A dirty entry may or may not exist in localCache
+            case CSidechainsCacheEntry::Flags::DIRTY: //A dirty entry may or may not exist in localCache
                     cacheSidechains[entryToWrite.first] = entryToWrite.second;
                 break;
             case CSidechainsCacheEntry::Flags::ERASED:

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1064,8 +1064,8 @@ CAmount CCoinsViewCache::GetValueIn(const CTransactionBase& txBase) const
         return 0;
 
     CAmount nResult = 0;
-    for (const CTxIn& vin : txBase.GetVin())
-        nResult += GetOutputFor(vin).nValue;
+    for (const CTxIn& in : txBase.GetVin())
+        nResult += GetOutputFor(in).nValue;
 
     nResult += txBase.GetJoinSplitValueIn();
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1058,16 +1058,16 @@ const CTxOut &CCoinsViewCache::GetOutputFor(const CTxIn& input) const
     return coins->vout[input.prevout.n];
 }
 
-CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
+CAmount CCoinsViewCache::GetValueIn(const CTransactionBase& txBase) const
 {
-    if (tx.IsCoinBase())
+    if (txBase.IsCoinBase())
         return 0;
 
     CAmount nResult = 0;
-    for (unsigned int i = 0; i < tx.GetVin().size(); i++)
-        nResult += GetOutputFor(tx.GetVin()[i]).nValue;
+    for (const CTxIn& vin : txBase.GetVin())
+        nResult += GetOutputFor(vin).nValue;
 
-    nResult += tx.GetJoinSplitValueIn();
+    nResult += txBase.GetJoinSplitValueIn();
 
     return nResult;
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -574,7 +574,7 @@ public:
      * @param[in] tx    transaction for which we are checking input total
      * @return    Sum of value of all inputs (scriptSigs)
      */
-    CAmount GetValueIn(const CTransaction& tx) const;
+    CAmount GetValueIn(const CTransactionBase& tx) const;
 
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1208,10 +1208,21 @@ bool AcceptCertificateToMemoryPool(CTxMemPool& pool, CValidationState &state, co
 
     // is it already in the memory pool?
     uint256 certHash = cert.GetHash();
-    if (pool.existsCert(certHash))
+
+    // Check if cert is already in mempool or if there are conflicts with in-memory certs
     {
-        LogPrint("mempool", "Dropping certificateId %s : already in mempool\n", certHash.ToString());
-        return false;
+        LOCK(pool.cs);
+        if (pool.mapCertificate.count(certHash) != 0) {
+            LogPrint("mempool", "Dropping cert %s : already in mempool\n", certHash.ToString());
+            return false;
+        }
+
+        if ((pool.mapSidechains.count(cert.scId) != 0) &&
+            (!pool.mapSidechains.at(cert.scId).backwardCertificate.IsNull())) {
+            LogPrint("mempool", "Dropping cert %s : another cert for same sc is already in mempool\n", certHash.ToString());
+            return false;
+        }
+
     }
 
     {
@@ -1223,10 +1234,11 @@ bool AcceptCertificateToMemoryPool(CTxMemPool& pool, CValidationState &state, co
             CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
             view.SetBackend(viewMemPool);
 
-            if(!viewMemPool.IsCertAllowedInMempool(cert, state))
+            if(viewMemPool.HaveCertForEpoch(cert.scId, cert.epochNumber))
             {
-                LogPrint("sc", "%s():%d - cert [%s] is not allowed in mempool\n", __func__, __LINE__, certHash.ToString());
-                return false;
+                LogPrint("mempool", "Dropping cert %s : already have cert for same sc and epoch\n", certHash.ToString());
+                return state.DoS(0, error("AcceptCertificateToMemoryPool: certificate for same sc and epoch already received"),
+                            REJECT_INVALID, "bad-sc-cert-not-applicable");
             }
 
             int sgHeight = (epochSafeGuardHeight > 0) ? epochSafeGuardHeight : nextBlockHeight;   
@@ -1337,16 +1349,14 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
     }
 
-
     auto verifier = libzcash::ProofVerifier::Strict();
     if (!CheckTransaction(tx, state, verifier))
         return error("AcceptToMemoryPool: CheckTransaction failed");
 
-
-        // DoS level set to 10 to be more forgiving.
-        // Check transaction contextually against the set of consensus rules which apply in the next block to be mined.
-        if (!ContextualCheckTransaction(tx, state, nextBlockHeight, 10)) {
-            return error("AcceptToMemoryPool: ContextualCheckTransaction failed");
+    // DoS level set to 10 to be more forgiving.
+    // Check transaction contextually against the set of consensus rules which apply in the next block to be mined.
+    if (!ContextualCheckTransaction(tx, state, nextBlockHeight, 10)) {
+        return error("AcceptToMemoryPool: ContextualCheckTransaction failed");
     }
 
     // Silently drop pre-chainsplit transactions
@@ -1375,43 +1385,42 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     if (!CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
         return state.DoS(0, false, REJECT_NONSTANDARD, "non-final");
 
-    // is it already in the memory pool?
+
     uint256 hash = tx.GetHash();
-    if (pool.exists(hash))
-    {
-        LogPrint("mempool", "Dropping txid %s : already in mempool\n", hash.ToString());
-        return false;
-    }
 
-    // Check for conflicts with in-memory transactions
+    // Check if tx is already in mempool or if there are conflicts with in-memory transactions
     {
-        LOCK(pool.cs); // protect pool.mapNextTx
-        for (unsigned int i = 0; i < tx.GetVin().size(); i++)
-        {
+        LOCK(pool.cs);
+
+        if (pool.mapTx.count(hash) != 0) {
+            LogPrint("mempool", "Dropping txid %s : already in mempool\n", hash.ToString());
+            return false;
+        }
+
+        for (unsigned int i = 0; i < tx.GetVin().size(); i++) {
             COutPoint outpoint = tx.GetVin()[i].prevout;
-            if (pool.mapNextTx.count(outpoint))
-            {
-                // Disable replacement feature for now
-                return false;
+            if (pool.mapNextTx.count(outpoint)) {
+                LogPrint("mempool", "Dropping txid %s : it double spends another tx in mempool\n", hash.ToString());
+                return false; // Disable replacement feature for now
             }
         }
 
-        for(const CTxScCreationOut& sc: tx.vsc_ccout) { // If this tx creates a sc, no other tx must be doing the same in the mempool
+        // If this tx creates a sc, no other tx must be doing the same in the mempool
+        for(const CTxScCreationOut& sc: tx.vsc_ccout) {
             if ((pool.mapSidechains.count(sc.scId) != 0) && (!pool.mapSidechains.at(sc.scId).scCreationTxHash.IsNull())) {
+                LogPrint("sc", "%s():%d - Dropping txid [%s]: it tries to redeclare another sc in mempool\n",
+                        __func__, __LINE__, hash.ToString());
                 return false;
-            } else {
-                LogPrint("sc", "%s():%d - tx [%s] has no conflicts in mempool\n", __func__, __LINE__, hash.ToString());
             }
         }
 
-        BOOST_FOREACH(const JSDescription &joinsplit, tx.GetVjoinsplit()) {
-            BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {
+        for(const JSDescription &joinsplit: tx.GetVjoinsplit()) {
+            for(const uint256 &nf: joinsplit.nullifiers) {
                 if (pool.mapNullifiers.count(nf))
-                {
                     return false;
-                }
             }
         }
+
     }
 
     {

--- a/src/main.h
+++ b/src/main.h
@@ -388,7 +388,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
 /** Check for standard transaction types
  * @return True if all outputs (scriptPubKeys) use only standard transaction forms
  */
-bool IsStandardTx(const CTransaction& tx, std::string& reason, int nHeight);
+bool IsStandardTx(const CTransactionBase& txBase, std::string& reason, int nHeight);
 
 /**
  * Check if transaction is final and can be included in a block with the

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -518,7 +518,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 #if 0
             CAmount nTxFees = view.GetValueIn(tx)-tx.GetValueOut();
 #else
-            CAmount valueIn = tx.GetValueIn(view);
+            CAmount valueIn = view.GetValueIn(tx);
             CAmount nTxFees = tx.GetFeeAmount(valueIn);
             if (nTxFees < 0)
             {

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -64,6 +64,16 @@ bool CScCertificate::CheckVersionBasic(CValidationState &state) const
     return true;
 }
 
+bool CScCertificate::CheckVersionIsStandard(std::string& reason, const int nHeight) const {
+    if (!zen::ForkManager::getInstance().areSidechainsSupported(nHeight))
+    {
+        reason = "version";
+        return false;
+    }
+
+    return true;
+}
+
 bool CScCertificate::CheckInputsAvailability(CValidationState &state) const
 {
     //Currently there are no inputs for certificates
@@ -184,7 +194,6 @@ double CScCertificate::GetPriority(const CCoinsViewCache &view, int nHeight) con
 bool CScCertificate::TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee) {return true;}
 
 bool CScCertificate::IsApplicableToState(CValidationState& state, int nHeight) const { return true; }
-bool CScCertificate::IsStandard(std::string& reason, int nHeight) const { return true; }
 unsigned int CScCertificate::GetLegacySigOpCount() const { return 0; }
 #else
 bool CScCertificate::TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee)
@@ -198,17 +207,6 @@ bool CScCertificate::IsApplicableToState(CValidationState& state, int nHeight) c
     LogPrint("cert", "%s():%d - cert [%s]\n", __func__, __LINE__, GetHash().ToString());
     CCoinsViewCache view(pcoinsTip);
     return view.IsCertApplicableToState(*this, nHeight, state);
-}
-    
-bool CScCertificate::IsStandard(std::string& reason, int nHeight) const
-{
-    if (!zen::ForkManager::getInstance().areSidechainsSupported(nHeight))
-    {
-        reason = "version";
-        return false;
-    }
-
-    return CheckOutputsAreStandard(nHeight, reason);
 }
 
 unsigned int CScCertificate::GetLegacySigOpCount() const 

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -64,7 +64,7 @@ bool CScCertificate::CheckVersionBasic(CValidationState &state) const
     return true;
 }
 
-bool CScCertificate::CheckVersionIsStandard(std::string& reason, const int nHeight) const {
+bool CScCertificate::CheckVersionIsStandard(std::string& reason, int nHeight) const {
     if (!zen::ForkManager::getInstance().areSidechainsSupported(nHeight))
     {
         reason = "version";

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -74,7 +74,7 @@ public:
 
     //CHECK FUNCTIONS
     bool CheckVersionBasic        (CValidationState &state) const override;
-    bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const override;
+    bool CheckVersionIsStandard   (std::string& reason, int nHeight) const override;
     bool CheckInputsAvailability  (CValidationState &state) const override;
     bool CheckOutputsAvailability (CValidationState &state) const override;
     bool CheckSerializedSize      (CValidationState &state) const override;

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -74,6 +74,7 @@ public:
 
     //CHECK FUNCTIONS
     bool CheckVersionBasic        (CValidationState &state) const override;
+    bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const override;
     bool CheckInputsAvailability  (CValidationState &state) const override;
     bool CheckOutputsAvailability (CValidationState &state) const override;
     bool CheckSerializedSize      (CValidationState &state) const override;
@@ -108,8 +109,6 @@ public:
     bool ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const override;
     bool CheckFinal(int flags) const override;
     bool IsApplicableToState(CValidationState& state, int nHeight = -1) const override;
-
-    bool IsStandard(std::string& reason, int nHeight) const override;
 
     bool TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee) override final;
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -723,15 +723,13 @@ void CTransaction::addToScCommitment(std::map<uint256, std::vector<uint256> >& m
 // need linking all of the related symbols. We use this macro as it is already defined with a similar purpose
 // in zen-tx binary build configuration
 #ifdef BITCOIN_TX
-bool CTransactionBase::CheckOutputsAreStandard(int nHeight, std::string& reason) const { return true; }
 bool CTransactionBase::CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const { return true; }
-
+bool CTransaction::CheckVersionIsStandard(std::string& reason, const int nHeight) const {return true;}
 
 bool CTransaction::TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee) {return true;}
 void CTransaction::AddToBlock(CBlock* pblock) const { return; }
 void CTransaction::AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount fee, unsigned int sigops) const {return; }
 bool CTransaction::ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const { return true; }
-bool CTransaction::IsStandard(std::string& reason, int nHeight) const { return true; }
 bool CTransaction::CheckFinal(int flags) const { return true; }
 bool CTransaction::IsApplicableToState(CValidationState& state, int nHeight) const { return true; }
 void CTransaction::HandleJoinSplitCommittments(ZCIncrementalMerkleTree& tree) const { return; };
@@ -755,67 +753,6 @@ bool CTransaction::TryPushToMempool(bool fLimitFree, bool fRejectAbsurdFee)
     return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, nullptr, fRejectAbsurdFee);
 };
 
-bool CTransactionBase::CheckOutputsAreStandard(int nHeight, std::string& reason) const
-{
-    unsigned int nDataOut = 0;
-    txnouttype whichType;
-
-    BOOST_FOREACH(const CTxOut& txout, vout)
-    {
-        CheckBlockResult checkBlockResult;
-        if (!::IsStandard(txout.scriptPubKey, whichType, checkBlockResult))
-        {
-            reason = "scriptpubkey";
-            return false;
-        }
-
-        if (checkBlockResult.referencedHeight > 0)
-        {
-            if ( (nHeight - checkBlockResult.referencedHeight) < ::getCheckBlockAtHeightMinAge())
-            {
-                LogPrintf("%s():%d - referenced block h[%d], chain.h[%d], minAge[%d]\n",
-                    __func__, __LINE__, checkBlockResult.referencedHeight, nHeight, ::getCheckBlockAtHeightMinAge() );
-                reason = "scriptpubkey checkblockatheight: referenced block too recent";
-                return false;
-            }
-        }
-
-        // provide temporary replay protection for two minerconf windows during chainsplit
-        if ((!IsCoinBase()) && (!ForkManager::getInstance().isTransactionTypeAllowedAtHeight(chainActive.Height(), whichType))) {
-            reason = "op-checkblockatheight-needed";
-            return false;
-        }
-
-        if (whichType == TX_NULL_DATA || whichType == TX_NULL_DATA_REPLAY)
-            nDataOut++;
-        else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
-            reason = "bare-multisig";
-            return false;
-        } else if (txout.IsDust(::minRelayTxFee)) {
-            if (Params().NetworkIDString() == "regtest")
-            {
-                // do not reject this tx in regtest, there are py tests intentionally using zero values
-                // and expecting this to be processable
-                LogPrintf("%s():%d - txout is dust, ignoring it because we are in regtest\n",
-                    __func__, __LINE__);
-            }
-            else
-            {
-                reason = "dust";
-                return false;
-            }
-        }
-    }
-
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
-        reason = "multi-op-return";
-        return false;
-    }
-
-    return true;
-}
-
 bool CTransactionBase::CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const
 {
     // Check for vout's without OP_CHECKBLOCKATHEIGHT opcode
@@ -829,6 +766,46 @@ bool CTransactionBase::CheckOutputsCheckBlockAtHeightOpCode(CValidationState& st
         {
             return state.DoS(0, error("%s: %s: %s is not activated at this block height %d. Transaction rejected. Tx id: %s", __FILE__, __func__, ::GetTxnOutputType(whichType), chainActive.Height(), GetHash().ToString()),
                 REJECT_CHECKBLOCKATHEIGHT_NOT_FOUND, "op-checkblockatheight-needed");
+        }
+    }
+
+    return true;
+}
+
+bool CTransaction::CheckVersionIsStandard(std::string& reason, const int nHeight) const {
+    // sidechain fork (happens after groth fork)
+    int sidechainVersion = 0;
+    bool areSidechainsSupported = ForkManager::getInstance().areSidechainsSupported(nHeight);
+    if (areSidechainsSupported)
+    {
+        sidechainVersion = ForkManager::getInstance().getSidechainTxVersion(nHeight);
+    }
+
+    // groth fork
+    const int shieldedTxVersion = ForkManager::getInstance().getShieldedTxVersion(nHeight);
+    bool isGROTHActive = (shieldedTxVersion == GROTH_TX_VERSION);
+
+    if(!isGROTHActive)
+    {
+        // sidechain fork is after groth one
+        assert(!areSidechainsSupported);
+
+        if (nVersion > CTransaction::MAX_OLD_VERSION || nVersion < CTransaction::MIN_OLD_VERSION)
+        {
+            reason = "version";
+            return false;
+        }
+    }
+    else
+    {
+        if (nVersion != TRANSPARENT_TX_VERSION && nVersion != GROTH_TX_VERSION)
+        {
+            // check sidechain tx
+            if ( !(areSidechainsSupported && (nVersion == sidechainVersion)) )
+            {
+                reason = "version";
+                return false;
+            }
         }
     }
 
@@ -867,11 +844,6 @@ void CTransaction::AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount fe
 bool CTransaction::ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const
 {
     return ::ContextualCheckTransaction(*this, state, nHeight, dosLevel);
-}
-
-bool CTransaction::IsStandard(std::string& reason, int nHeight) const
-{
-    return ::IsStandardTx(*this, reason, nHeight);
 }
 
 bool CTransaction::CheckFinal(int flags) const

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -772,7 +772,7 @@ bool CTransactionBase::CheckOutputsCheckBlockAtHeightOpCode(CValidationState& st
     return true;
 }
 
-bool CTransaction::CheckVersionIsStandard(std::string& reason, const int nHeight) const {
+bool CTransaction::CheckVersionIsStandard(std::string& reason, int nHeight) const {
     // sidechain fork (happens after groth fork)
     int sidechainVersion = 0;
     bool areSidechainsSupported = ForkManager::getInstance().areSidechainsSupported(nHeight);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -695,11 +695,15 @@ public:
 
     bool CheckOutputsAreStandard(int nHeight, std::string& reason) const;
     bool CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const;
+
+    bool CheckInputsLimit() const;
     //END OF CHECK FUNCTIONS
 
     // Return sum of txouts.
     virtual CAmount GetValueOut() const;
 
+    // Return sum of JoinSplit vpub_new if supported
+    virtual CAmount GetJoinSplitValueIn() const;
     //-----------------
     // pure virtual interfaces 
     virtual bool IsNull() const = 0;
@@ -735,9 +739,6 @@ public:
     virtual bool IsCoinBase() const { return false; }
     virtual bool IsCoinCertified() const { return false; }
 
-    // Return sum of JoinSplit vpub_new if supported
-    virtual CAmount GetJoinSplitValueIn() const { return 0; }
-
     virtual void HandleJoinSplitCommittments(ZCIncrementalMerkleTree& tree) const { return; }
     virtual void AddJoinSplitToJSON(UniValue& entry) const { return; }
     virtual void AddSidechainOutsToJSON(UniValue& entry) const {return; }
@@ -751,12 +752,6 @@ public:
     virtual unsigned int GetP2SHSigOpCount(CCoinsViewCache& view) const { return 0; }
     virtual const uint256 getJoinSplitPubKey() const { return uint256(); }
     virtual int GetComplexity() const { return 0; }
-
-    // return sum of txins, and needs CCoinsViewCache, because
-    // inputs must be known to compute value in.
-    virtual CAmount GetValueIn(const CCoinsViewCache& view) const { return 0; }
-
-    virtual bool CheckInputsLimit(size_t limit, size_t& n) const { return true; }
 };
 
 struct CMutableTransaction;
@@ -880,8 +875,7 @@ public:
 
     // Return sum of txouts.
     CAmount GetValueOut() const override;
-    // Return sum of tx ins
-    CAmount GetValueIn(const CCoinsViewCache& view) const override;
+
     // value in should be computed via the method above using a proper coin view
     CAmount GetFeeAmount(CAmount valueIn) const override { return (valueIn - GetValueOut() ); }
 
@@ -976,8 +970,6 @@ public:
   public:
     void AddToBlock(CBlock* pblock) const override;
     void AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount fee, unsigned int sigops) const override;
-    CAmount GetJoinSplitValueIn() const override;
-    bool CheckInputsLimit(size_t limit, size_t& n) const override;
     bool ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const override;
     bool IsStandard(std::string& reason, int nHeight) const override;
     bool CheckFinal(int flags = -1) const override;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -684,6 +684,7 @@ public:
 
     //CHECK FUNCTIONS
     virtual bool CheckVersionBasic        (CValidationState &state) const = 0;
+    virtual bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const = 0;
     virtual bool CheckInputsAvailability  (CValidationState &state) const = 0;
     virtual bool CheckOutputsAvailability (CValidationState &state) const = 0;
     virtual bool CheckSerializedSize      (CValidationState &state) const = 0;
@@ -693,7 +694,6 @@ public:
     bool CheckInputsDuplication(CValidationState &state) const;
     bool CheckInputsInteraction(CValidationState &state) const;
 
-    bool CheckOutputsAreStandard(int nHeight, std::string& reason) const;
     bool CheckOutputsCheckBlockAtHeightOpCode(CValidationState& state) const;
 
     bool CheckInputsLimit() const;
@@ -724,7 +724,6 @@ public:
     virtual void AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount fee, unsigned int sigops) const = 0;
 
     virtual bool ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const = 0;
-    virtual bool IsStandard(std::string& reason, int nHeight) const = 0;
     virtual bool CheckFinal(int flags = -1) const = 0;
     virtual bool IsApplicableToState(CValidationState& state, int nHeight = -1) const = 0;
 
@@ -868,6 +867,7 @@ public:
 
     //CHECK FUNCTIONS
     bool CheckVersionBasic        (CValidationState &state) const override;
+    bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const override;
     bool CheckInputsAvailability  (CValidationState &state) const override;
     bool CheckOutputsAvailability (CValidationState &state) const override;
     bool CheckSerializedSize      (CValidationState &state) const override;
@@ -971,7 +971,6 @@ public:
     void AddToBlock(CBlock* pblock) const override;
     void AddToBlockTemplate(CBlockTemplate* pblocktemplate, CAmount fee, unsigned int sigops) const override;
     bool ContextualCheck(CValidationState& state, int nHeight, int dosLevel) const override;
-    bool IsStandard(std::string& reason, int nHeight) const override;
     bool CheckFinal(int flags = -1) const override;
     bool IsApplicableToState(CValidationState& state, int nHeight = -1) const override;
     void HandleJoinSplitCommittments(ZCIncrementalMerkleTree& tree) const override;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -684,7 +684,7 @@ public:
 
     //CHECK FUNCTIONS
     virtual bool CheckVersionBasic        (CValidationState &state) const = 0;
-    virtual bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const = 0;
+    virtual bool CheckVersionIsStandard   (std::string& reason, int nHeight) const = 0;
     virtual bool CheckInputsAvailability  (CValidationState &state) const = 0;
     virtual bool CheckOutputsAvailability (CValidationState &state) const = 0;
     virtual bool CheckSerializedSize      (CValidationState &state) const = 0;
@@ -867,7 +867,7 @@ public:
 
     //CHECK FUNCTIONS
     bool CheckVersionBasic        (CValidationState &state) const override;
-    bool CheckVersionIsStandard   (std::string& reason, const int nHeight) const override;
+    bool CheckVersionIsStandard   (std::string& reason, int nHeight) const override;
     bool CheckInputsAvailability  (CValidationState &state) const override;
     bool CheckOutputsAvailability (CValidationState &state) const override;
     bool CheckSerializedSize      (CValidationState &state) const override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -861,6 +861,7 @@ bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
         coins = CCoins(tx, MEMPOOL_HEIGHT);
         return true;
     }
+
     CScCertificate cert;
     if (mempool.lookup(txid, cert)) {
         LogPrint("cert", "%s():%d - making coins for cert [%s]\n", __func__, __LINE__, txid.ToString() );
@@ -913,30 +914,6 @@ bool CCoinsViewMemPool::GetSidechain(const uint256& scId, CSidechain& info) cons
 
 bool CCoinsViewMemPool::HaveSidechain(const uint256& scId) const {
     return mempool.hasSidechainCreationTx(scId) || base->HaveSidechain(scId);
-}
-
-
-bool CCoinsViewMemPool::IsCertAllowedInMempool(const CScCertificate& cert, CValidationState& state)
-{
-    if (!HaveCertForEpoch(cert.scId, cert.epochNumber))
-        return true;
-
-    // when called for checking the contents of mempool we can find the certificate itself, which is OK
-    if (mempool.mapSidechains.count(cert.scId)) {
-        const uint256 & conflictingCertHash = mempool.mapSidechains.at(cert.scId).backwardCertificate;
-        if (conflictingCertHash == cert.GetHash()) //This currently happens with mempool.check
-            return true;
-
-        LogPrintf("ERROR: certificate %s for epoch %d is already in mempool\n",
-            conflictingCertHash.ToString(), cert.epochNumber);
-        return state.Invalid(error("A certificate with the same scId/epoch is already in mempool"),
-             REJECT_INVALID, "sidechain-certificate-epoch");
-    }
-
-    LogPrintf("ERROR: certificate for epoch %d is already confirmed\n",
-        cert.epochNumber);
-    return state.Invalid(error("A certificate with the same scId/epoch is already confirmed"),
-         REJECT_INVALID, "sidechain-certificate-epoch");
 }
 
 bool CCoinsViewMemPool::HaveCertForEpoch(const uint256& scId, int epochNumber) const {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -284,10 +284,9 @@ public:
     bool GetNullifier(const uint256 &txid) const;
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
-    bool GetSidechain(const uint256& scId, CSidechain& info) const override;
-    bool HaveSidechain(const uint256& scId) const override;
-    bool IsCertAllowedInMempool(const CScCertificate& cert, CValidationState& state);
-    bool HaveCertForEpoch(const uint256& scId, int epochNumber) const override;
+    bool GetSidechain(const uint256& scId, CSidechain& info)      const override;
+    bool HaveSidechain(const uint256& scId)                       const override;
+    bool HaveCertForEpoch(const uint256& scId, int epochNumber)   const override;
 };
 
 #endif // BITCOIN_TXMEMPOOL_H


### PR DESCRIPTION
Following introduction of getters for vin/vout/vjoinsplit in tx, a whole bunch of transaction/certs methods introduced for polymorphism can be aggregated into a single method processing a TransactionBase. I have done that for some of them, in order to eliminate some code duplication and improve readability.

I have also made some minor changes in Accept*ToMemoryPool implementation so to highlight similarities between transactions and certificates processing