### PR TITLE
Added nFirstBwtPos in CCoins

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -30,7 +30,7 @@ std::string CCoins::ToString() const
     return ret;
 }
 
-CCoins::CCoins() : fCoinBase(false), vout(0), nHeight(0), nVersion(0), nFirstBwtPos(-1), nBwtMaturityHeight(0) { }
+CCoins::CCoins() : fCoinBase(false), vout(0), nHeight(0), nVersion(0), nFirstBwtPos(BWT_POS_UNSET), nBwtMaturityHeight(0) { }
 
 CCoins::CCoins(const CTransaction &tx, int nHeightIn) { From(tx, nHeightIn); }
 
@@ -41,7 +41,7 @@ void CCoins::From(const CTransaction &tx, int nHeightIn) {
     vout               = tx.GetVout();
     nHeight            = nHeightIn;
     nVersion           = tx.nVersion;
-    nFirstBwtPos       = -1;
+    nFirstBwtPos       = BWT_POS_UNSET;
     nBwtMaturityHeight = 0;
     ClearUnspendable();
 }
@@ -54,7 +54,7 @@ void CCoins::From(const CScCertificate &cert, int nHeightIn, int bwtMaturityHeig
     nBwtMaturityHeight = bwtMaturityHeight;
     ClearUnspendable();
     nFirstBwtPos = vout.size();
-    for(int idx = 0; idx < this->vout.size(); ++idx) {
+    for(unsigned int idx = 0; idx < this->vout.size(); ++idx) {
         if (this->vout[idx].isFromBackwardTransfer) {
             nFirstBwtPos = idx;
             break;
@@ -67,7 +67,7 @@ void CCoins::Clear() {
     std::vector<CTxOut>().swap(vout);
     nHeight = 0;
     nVersion = 0;
-    nFirstBwtPos = -1;
+    nFirstBwtPos = BWT_POS_UNSET;
     nBwtMaturityHeight = 0;
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -30,7 +30,7 @@ std::string CCoins::ToString() const
     return ret;
 }
 
-CCoins::CCoins() : fCoinBase(false), vout(0), nHeight(0), nVersion(0), nFirstBwtPos(0), nBwtMaturityHeight(0) { }
+CCoins::CCoins() : fCoinBase(false), vout(0), nHeight(0), nVersion(0), nFirstBwtPos(-1), nBwtMaturityHeight(0) { }
 
 CCoins::CCoins(const CTransaction &tx, int nHeightIn) { From(tx, nHeightIn); }
 
@@ -41,7 +41,7 @@ void CCoins::From(const CTransaction &tx, int nHeightIn) {
     vout               = tx.GetVout();
     nHeight            = nHeightIn;
     nVersion           = tx.nVersion;
-    nFirstBwtPos       = 0;
+    nFirstBwtPos       = -1;
     nBwtMaturityHeight = 0;
     ClearUnspendable();
 }
@@ -67,7 +67,7 @@ void CCoins::Clear() {
     std::vector<CTxOut>().swap(vout);
     nHeight = 0;
     nVersion = 0;
-    nFirstBwtPos = 0;
+    nFirstBwtPos = -1;
     nBwtMaturityHeight = 0;
 }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -250,7 +250,7 @@ public:
         // coinbase height
         ::Unserialize(s, VARINT(nHeight), nType, nVersion);
 
-        nFirstBwtPos = 0;
+        nFirstBwtPos = -1;
         if (this->IsFromCert()) {
             ::Unserialize(s, nFirstBwtPos, nType,nVersion);
             ::Unserialize(s, nBwtMaturityHeight, nType,nVersion);

--- a/src/coins.h
+++ b/src/coins.h
@@ -99,7 +99,7 @@ public:
 
     //| If coins comes from a certificate, nFirstBwtPos represents the position of the first backward transfer;
     //! All outputs after nFirstBwtPos, including nFirstBwtPos, are backward transfers
-    //! If coins comes from a tx, it is currently set to zero and not used
+    //! If coins comes from a tx, it is currently set to BWT_POS_UNSET and not used
     int nFirstBwtPos;
 
     //! if coin comes from a certificate, nBwtMaturityHeight signals the height at which these output will be mature
@@ -250,7 +250,7 @@ public:
         // coinbase height
         ::Unserialize(s, VARINT(nHeight), nType, nVersion);
 
-        nFirstBwtPos = -1;
+        nFirstBwtPos = BWT_POS_UNSET;
         if (this->IsFromCert()) {
             ::Unserialize(s, nFirstBwtPos, nType,nVersion);
             ::Unserialize(s, nBwtMaturityHeight, nType,nVersion);

--- a/src/gtest/test_sidechain_ceased.cpp
+++ b/src/gtest/test_sidechain_ceased.cpp
@@ -1140,7 +1140,7 @@ TEST_F(CeasedSidechainsTestSuite, SpendFullCoinsByChangeOutput_CoinReconstructio
     //Checks
     CCoins reconstructedCoinFromCert;
     EXPECT_TRUE(view->GetCoins(cert.GetHash(),reconstructedCoinFromCert));
-    EXPECT_TRUE(coinFromCert == reconstructedCoinFromCert);
+    EXPECT_TRUE(coinFromCert == reconstructedCoinFromCert)<<coinFromCert.ToString() << "|||" << reconstructedCoinFromCert.ToString();
 }
 
 TEST_F(CeasedSidechainsTestSuite, SpendFullCoinsByBwt_CoinReconstructionFromBlockUndo)

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -46,6 +46,8 @@ static_assert(TRANSPARENT_TX_VERSION >= MIN_OLD_TX_VERSION,
 //Many static casts to int * of Tx nVersion (int32_t *) are performed. Verify at compile time that they are equivalent.
 static_assert(sizeof(int32_t) == sizeof(int), "int size differs from 4 bytes. This may lead to unexpected behaviors on static casts");
 
+static const int BWT_POS_UNSET = -1;
+
 template <typename Stream>
 class SproutProofSerializer : public boost::static_visitor<>
 {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -885,6 +885,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization_from_certs)
     originalCoin.vout[2].isFromBackwardTransfer = true;
     originalCoin.nHeight = 220;
     originalCoin.nVersion = SC_CERT_VERSION;
+    originalCoin.nFirstBwtPos = 2;
     originalCoin.nBwtMaturityHeight = 250;
 
     CDataStream ss1(SER_DISK, CLIENT_VERSION);
@@ -906,6 +907,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization_from_certs)
     BOOST_CHECK(retrievedCoin.nHeight                        == originalCoin.nHeight);
     BOOST_CHECK(retrievedCoin.nVersion                       != originalCoin.nVersion);
     BOOST_CHECK( (retrievedCoin.nVersion & 0x7f)             == (originalCoin.nVersion & 0x7f));
+    BOOST_CHECK(retrievedCoin.nFirstBwtPos                   == originalCoin.nFirstBwtPos);
     BOOST_CHECK(retrievedCoin.nBwtMaturityHeight             == originalCoin.nBwtMaturityHeight);
 }
 
@@ -921,11 +923,12 @@ BOOST_AUTO_TEST_CASE(Certificate_CTxInUndo_serialization)
     coinFromCert.vout[0].isFromBackwardTransfer = true;
     coinFromCert.nHeight = 220;
     coinFromCert.nVersion = SC_CERT_VERSION;
+    coinFromCert.nFirstBwtPos = 0;
     coinFromCert.nBwtMaturityHeight = 230;
 
     //if the vin about to be written in undo is the last one, all metadata (fCoinBase, version, originScId) are noted
     CTxInUndo fullCertInUndo(coinFromCert.vout[0], coinFromCert.fCoinBase,
-                             coinFromCert.nHeight, coinFromCert.nVersion, coinFromCert.nBwtMaturityHeight);
+                             coinFromCert.nHeight, coinFromCert.nVersion, coinFromCert.nFirstBwtPos, coinFromCert.nBwtMaturityHeight);
     CDataStream ssFullCert(SER_DISK, CLIENT_VERSION);
 
     ssFullCert << fullCertInUndo;
@@ -935,8 +938,9 @@ BOOST_AUTO_TEST_CASE(Certificate_CTxInUndo_serialization)
     BOOST_CHECK(retrievedFullCertIn.fCoinBase                  == coinFromCert.fCoinBase);
     BOOST_CHECK_MESSAGE((retrievedFullCertIn.nVersion & 0x7f)  == (coinFromCert.nVersion & 0x7f),   retrievedFullCertIn.nVersion);
     BOOST_CHECK_MESSAGE(retrievedFullCertIn.nHeight            == coinFromCert.nHeight,             retrievedFullCertIn.nHeight);
+    BOOST_CHECK_MESSAGE(retrievedFullCertIn.nFirstBwtPos       == coinFromCert.nFirstBwtPos,        retrievedFullCertIn.nFirstBwtPos);
     BOOST_CHECK_MESSAGE(retrievedFullCertIn.nBwtMaturityHeight == coinFromCert.nBwtMaturityHeight,  retrievedFullCertIn.nBwtMaturityHeight);
-    BOOST_CHECK(retrievedFullCertIn.txout == coinFromCert.vout[0]);
+    BOOST_CHECK_MESSAGE(retrievedFullCertIn.txout.isFromBackwardTransfer == 0, "isFromBwt flag is not serialized. It must be reconstructed from nFirstBwtPos");
 
     //if the vin about to be written in undo is NOT the last one only vout is noted
     CTxInUndo partialCertInUndo(coinFromCert.vout[0]);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -316,16 +316,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
 
                 if (coins.IsFromCert()) {
                     ss << coins.nBwtMaturityHeight;
-
-                    unsigned int changeOutputCounter = 0;
-                    for(const CTxOut& out: coins.vout) {
-                        if (!out.isFromBackwardTransfer)
-                            ++changeOutputCounter;
-                        else
-                            break;
-                    }
-
-                    ss << changeOutputCounter;
+                    ss << coins.nBwtMaturityHeight;;
                 }
                 stats.nSerializedSize += 32 + slValue.size();
                 ss << VARINT(0);

--- a/src/undo.h
+++ b/src/undo.h
@@ -26,13 +26,13 @@ public:
     bool fCoinBase;         // if the outpoint was the last unspent: whether it belonged to a coinbase
     unsigned int nHeight;   // if the outpoint was the last unspent: its height
     int nVersion;           // if the outpoint was the last unspent: its version
-    int nFirstBwtPos;       // if the outpoint was the last unspent: its nFirstBwtPos, introduced with certificates
+    int nFirstBwtPos;       // if the outpoint was the last unspent: its nFirstBwtPos, serialized only for certificates
     int nBwtMaturityHeight; // if the outpoint was the last unspent: its nBwtMaturityHeight, introduced with certificates
 
-    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nFirstBwtPos(0), nBwtMaturityHeight(0) {}
+    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nFirstBwtPos(-1), nBwtMaturityHeight(0) {}
     CTxInUndo(const CTxOut &txoutIn, bool fCoinBaseIn = false,
               unsigned int nHeightIn = 0, int nVersionIn = 0,
-              int firstBwtPos = 0, int bwtMaturityHeight = 0):
+              int firstBwtPos = -1, int bwtMaturityHeight = 0):
         txout(txoutIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn), nVersion(nVersionIn),
         nFirstBwtPos(firstBwtPos), nBwtMaturityHeight(bwtMaturityHeight) {}
 

--- a/src/undo.h
+++ b/src/undo.h
@@ -29,10 +29,10 @@ public:
     int nFirstBwtPos;       // if the outpoint was the last unspent: its nFirstBwtPos, serialized only for certificates
     int nBwtMaturityHeight; // if the outpoint was the last unspent: its nBwtMaturityHeight, introduced with certificates
 
-    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nFirstBwtPos(-1), nBwtMaturityHeight(0) {}
+    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nFirstBwtPos(BWT_POS_UNSET), nBwtMaturityHeight(0) {}
     CTxInUndo(const CTxOut &txoutIn, bool fCoinBaseIn = false,
               unsigned int nHeightIn = 0, int nVersionIn = 0,
-              int firstBwtPos = -1, int bwtMaturityHeight = 0):
+              int firstBwtPos = BWT_POS_UNSET, int bwtMaturityHeight = 0):
         txout(txoutIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn), nVersion(nVersionIn),
         nFirstBwtPos(firstBwtPos), nBwtMaturityHeight(bwtMaturityHeight) {}
 

--- a/src/undo.h
+++ b/src/undo.h
@@ -95,16 +95,14 @@ class CVoidedCertUndo {
 public:
     std::vector<CTxInUndo> voidedOuts;
     uint256 voidedCertHash;
-    int firstBwtPos;
 
-    CVoidedCertUndo(): voidedOuts(), voidedCertHash(), firstBwtPos(-1) {};
+    CVoidedCertUndo(): voidedOuts(), voidedCertHash() {};
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(voidedOuts);
         READWRITE(voidedCertHash);
-        READWRITE(firstBwtPos);
     }
 
     std::string ToString() const
@@ -114,7 +112,6 @@ public:
         for (unsigned int i = 0; i < voidedOuts.size(); i++)
             str += "        " + voidedOuts[i].ToString() + "\n";
         str += strprintf("    refTx       %s\n", voidedCertHash.ToString());
-        str += strprintf("    firstBwtPos %u\n", firstBwtPos);
         return str;
     }
 };

--- a/src/undo.h
+++ b/src/undo.h
@@ -26,13 +26,15 @@ public:
     bool fCoinBase;         // if the outpoint was the last unspent: whether it belonged to a coinbase
     unsigned int nHeight;   // if the outpoint was the last unspent: its height
     int nVersion;           // if the outpoint was the last unspent: its version
+    int nFirstBwtPos;       // if the outpoint was the last unspent: its nFirstBwtPos, introduced with certificates
     int nBwtMaturityHeight; // if the outpoint was the last unspent: its nBwtMaturityHeight, introduced with certificates
 
-    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nBwtMaturityHeight(0) {}
+    CTxInUndo() : txout(), fCoinBase(false), nHeight(0), nVersion(0), nFirstBwtPos(0), nBwtMaturityHeight(0) {}
     CTxInUndo(const CTxOut &txoutIn, bool fCoinBaseIn = false,
               unsigned int nHeightIn = 0, int nVersionIn = 0,
-              int bwtMaturityHeight = 0):
-        txout(txoutIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn), nVersion(nVersionIn), nBwtMaturityHeight(bwtMaturityHeight) { }
+              int firstBwtPos = 0, int bwtMaturityHeight = 0):
+        txout(txoutIn), fCoinBase(fCoinBaseIn), nHeight(nHeightIn), nVersion(nVersionIn),
+        nFirstBwtPos(firstBwtPos), nBwtMaturityHeight(bwtMaturityHeight) {}
 
     unsigned int GetSerializeSize(int nType, int nVersion) const {
         unsigned int totalSize = 0;
@@ -40,8 +42,8 @@ public:
                (nHeight > 0 ? ::GetSerializeSize(VARINT(this->nVersion), nType, nVersion) : 0) +
                ::GetSerializeSize(CTxOutCompressor(REF(txout)), nType, nVersion);
         if ((nHeight > 0) && ((this->nVersion & 0x7f) == (SC_CERT_VERSION & 0x7f))) {
+            totalSize += ::GetSerializeSize(nFirstBwtPos, nType,nVersion);
             totalSize += ::GetSerializeSize(nBwtMaturityHeight, nType,nVersion);
-            totalSize += ::GetSerializeSize(txout.isFromBackwardTransfer, nType,nVersion);
         }
         return totalSize;
     }
@@ -54,8 +56,8 @@ public:
         ::Serialize(s, CTxOutCompressor(REF(txout)), nType, nVersion);
 
         if ((nHeight > 0) && ((this->nVersion & 0x7f) == (SC_CERT_VERSION & 0x7f))) {
-            ::Serialize(s,nBwtMaturityHeight, nType, nVersion);
-            ::Serialize(s,txout.isFromBackwardTransfer? true: false, nType, nVersion);
+            ::Serialize(s, nFirstBwtPos, nType, nVersion);
+            ::Serialize(s, nBwtMaturityHeight, nType, nVersion);
         }
     }
 
@@ -70,8 +72,8 @@ public:
         ::Unserialize(s, REF(CTxOutCompressor(REF(txout))), nType, nVersion);
 
         if ((nHeight > 0) && ((this->nVersion & 0x7f) == (SC_CERT_VERSION & 0x7f))) {
+            ::Unserialize(s, nFirstBwtPos, nType, nVersion);
             ::Unserialize(s, nBwtMaturityHeight, nType, nVersion);
-            ::Unserialize(s, txout.isFromBackwardTransfer, nType, nVersion);
         }
     }
 
@@ -79,10 +81,11 @@ public:
     {
         std::string str;
         str += strprintf("txout(%s)\n", txout.ToString());
-        str += strprintf("        fCoinBase=%d\n", fCoinBase);
-        str += strprintf("        nHeight=%d\n", nHeight);
-        str += strprintf("        nVersion=%d\n", nVersion);
-        str += strprintf("        nBwtMaturityHeight=%d\n", nBwtMaturityHeight);
+        str += strprintf("        fCoinBase         = %d\n", fCoinBase);
+        str += strprintf("        nHeight           = %d\n", nHeight);
+        str += strprintf("        nVersion          = %d\n", nVersion);
+        str += strprintf("        nFirstBwtPos      = %d\n", nFirstBwtPos);
+        str += strprintf("        nBwtMaturityHeight= %d\n", nBwtMaturityHeight);
         return str;
     }
 
@@ -165,6 +168,14 @@ public:
         else
             ::AddEntriesInVector(s, vprevout, nType, nVersion, nSize);
     };
+
+    std::string ToString() const
+    {
+        std::string str;
+        for(const CTxInUndo& in: vprevout)
+            str += strprintf("\n[%s]", in.ToString());
+        return str;
+    }
 
 private:
     static const uint16_t certAttributesMarker = 0xffff;
@@ -265,9 +276,12 @@ public:
     {
         std::string str = "\n=== CBlockUndo START ===========================================================================\n";
         str += strprintf("includesSidechainAttributes=%u (mem only)\n", includesSidechainAttributes);
-        str += strprintf("vVoidedCertUndo.size %u\n", vtxundo.size());
-        for (unsigned int i = 0; i < vVoidedCertUndo.size(); i++)
-            str += vVoidedCertUndo[i].ToString() + "\n";
+        str += strprintf("vtxundo.size %u\n", vtxundo.size());
+        for(const CTxUndo& txUndo: vtxundo)
+            str += txUndo.ToString() + "\n";
+        str += strprintf("vVoidedCertUndo.size %u\n", vVoidedCertUndo.size());
+        for(const CVoidedCertUndo& voidCertUndo: vVoidedCertUndo)
+            str += voidCertUndo.ToString() + "\n";
         str += strprintf("old_tree_root %s\n", old_tree_root.ToString().substr(0,10));
         str += strprintf("msc_iaundo.size %u\n", scUndoMap.size());
         for (auto entry : scUndoMap)


### PR DESCRIPTION
The attribute nFirstBwtPos is used only for certificates, while it is set to -1 for coins from ordinary transactions.
Removal of IsFromBackwardTransfer for CTxOut is ongoing and will be subject of different pull request