### PR TITLE
Improve private chains tracking

### DIFF
--- a/qa/rpc-tests/blockdelay.py
+++ b/qa/rpc-tests/blockdelay.py
@@ -223,8 +223,12 @@ class blockdelay(BitcoinTestFramework):
         print("Malicious blocks generated")
 
         for i in range(0, 4):
-            print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            print "Node%d  ---" % i
+            getchaintips_res = self.nodes[i].getchaintips(True)
+            self.dump_ordered_tips(getchaintips_res)
+            assert(getchaintips_res[0]["penalty-at-start"] == 0)
+            assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+            assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
             print "---"
 # 
 
@@ -246,9 +250,38 @@ class blockdelay(BitcoinTestFramework):
         print("\nNetwork joined")
 
         for i in range(0, 4):
-            print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            print "Node%d  ---" % i
+            getchaintips_res = self.nodes[i].getchaintips(True)
+            self.dump_ordered_tips(getchaintips_res)
             print "---"
+
+        print("\nTesting fork related data from getchaintips")
+        print("\nTesting Node 0")
+        getchaintips_res = self.nodes[0].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 11)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 65)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 65)
+        assert(getchaintips_res[1]["penalty-at-start"] == 0)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 1")
+        assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
+
+        print("\nTesting Node 2")
+        getchaintips_res = self.nodes[2].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 3")
+        getchaintips_res = self.nodes[3].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 12)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 78)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 82)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting if the current chain is still the honest chain")
         assert self.nodes[0].getbestblockhash() == last_main_blockhash
@@ -292,9 +325,36 @@ class blockdelay(BitcoinTestFramework):
 
         for i in range(0, 4):
             print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
+        print("\nTesting fork related data from getchaintips")
+        print("\nTesting Node 0")
+        getchaintips_res = self.nodes[0].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 11)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 1)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 1)
+        assert(getchaintips_res[1]["penalty-at-start"] == 0)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 1")
+        assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
+
+        print("\nTesting Node 2")
+        getchaintips_res = self.nodes[2].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 3")
+        getchaintips_res = self.nodes[3].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 12)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 78)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 2290)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting if the current chain is still the honest chain")
         assert self.nodes[0].getbestblockhash() == last_main_blockhash
@@ -347,10 +407,38 @@ class blockdelay(BitcoinTestFramework):
 
         for i in range(0, 4):
             print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
 #        raw_input("press enter to generate 1 more malicious blocks which will cause the attack to succeed..")
+
+        print("\nTesting fork related data from getchaintips")
+        print("\nTesting Node 0")
+        getchaintips_res = self.nodes[0].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 11)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 1)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 1)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 1")
+        assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
+
+        print("\nTesting Node 2")
+        getchaintips_res = self.nodes[2].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 3")
+        getchaintips_res = self.nodes[3].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 12)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 2158)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 2158)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nGenerating 1 more malicious block")
         self.mark_logs("Generating 1 more malicious block ")
@@ -365,8 +453,36 @@ class blockdelay(BitcoinTestFramework):
 
         for i in range(0, 4):
             print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
+
+        print("\nTesting fork related data from getchaintips")
+        print("\nTesting Node 0")
+        getchaintips_res = self.nodes[0].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 0)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 4)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 1")
+        assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
+
+        print("\nTesting Node 2")
+        getchaintips_res = self.nodes[2].getchaintips(True)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
+
+        print("\nTesting Node 3")
+        getchaintips_res = self.nodes[3].getchaintips(True)
+        assert(getchaintips_res[1]["penalty-at-start"] == 12)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 2158)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 2162)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting if all the nodes/chains have the same best tip")
         assert (self.nodes[0].getbestblockhash() == self.nodes[1].getbestblockhash()
@@ -410,7 +526,7 @@ class blockdelay(BitcoinTestFramework):
 
         for i in range(0, 5):
             print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
         print("\nNode0 generating 1 new blocks")       
@@ -421,7 +537,7 @@ class blockdelay(BitcoinTestFramework):
 
         for i in range(0, 5):
             print "Node%d  ---" % i 
-            self.dump_ordered_tips(self.nodes[i].getchaintips())
+            self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
         # check node1 balance has been restored

--- a/qa/rpc-tests/blockdelay.py
+++ b/qa/rpc-tests/blockdelay.py
@@ -87,10 +87,13 @@ class blockdelay(BitcoinTestFramework):
         c = 0
         for y in sorted_x:
             if (c == 0):
-                print y 
+                print y
             else:
-                print " ",y 
+                print " ",y
             c = 1
+
+    def order_tips(self, tip_list):
+        return sorted(tip_list, key=lambda k: k['status'])
 
     def mark_logs(self, msg):
         for x in self.nodes:
@@ -129,7 +132,7 @@ class blockdelay(BitcoinTestFramework):
                 break
 
             time.sleep(wait)
-        
+
 
     def run_test(self):
         blocks = []
@@ -206,12 +209,12 @@ class blockdelay(BitcoinTestFramework):
         assert self.nodes[0].getbestblockhash() == last_main_blockhash
 
 #   Node(0): [0]->..->[104]->[105h]...->[116h]
-#   /   
+#   /
 # Node(1): [0]->..->[104]->[105h]...->[116h]
 #
 #
 # Node(2): [0]->..->[104]
-#   \   
+#   \
 #   Node(3): [0]->..->[104]
 
         # Malicious nodes mining privately faster
@@ -230,15 +233,14 @@ class blockdelay(BitcoinTestFramework):
             assert(getchaintips_res[0]["penalty-at-tip"] == 0)
             assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
             print "---"
-# 
 
 #   Node(0): [0]->..->[104]->[105h]...->[116h]
-#   /   
+#   /
 # Node(1): [0]->..->[104]->[105h]...->[116h]
 #
 #
 # Node(2): [0]->..->[104]->[105m]...->[117m]
-#   \   
+#   \
 #   Node(3): [0]->..->[104]->[105m]...->[117m]
 
         print("\n\nJoin network")
@@ -257,25 +259,25 @@ class blockdelay(BitcoinTestFramework):
 
         print("\nTesting fork related data from getchaintips")
         print("\nTesting Node 0")
-        getchaintips_res = self.nodes[0].getchaintips(True)
-        assert(getchaintips_res[0]["penalty-at-start"] == 11)
-        assert(getchaintips_res[0]["penalty-at-tip"] == 65)
-        assert(getchaintips_res[0]["blocks-to-mainchain"] == 65)
-        assert(getchaintips_res[1]["penalty-at-start"] == 0)
-        assert(getchaintips_res[1]["penalty-at-tip"] == 0)
-        assert(getchaintips_res[1]["blocks-to-mainchain"] == 0)
+        getchaintips_res = self.order_tips(self.nodes[0].getchaintips(True))
+        assert(getchaintips_res[1]["penalty-at-start"] == 11)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 65)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 65)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 1")
         assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
 
         print("\nTesting Node 2")
-        getchaintips_res = self.nodes[2].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[2].getchaintips(True))
         assert(getchaintips_res[0]["penalty-at-start"] == 0)
         assert(getchaintips_res[0]["penalty-at-tip"] == 0)
         assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 3")
-        getchaintips_res = self.nodes[3].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[3].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 12)
         assert(getchaintips_res[1]["penalty-at-tip"] == 78)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 82)
@@ -301,14 +303,14 @@ class blockdelay(BitcoinTestFramework):
 #   +-------Node(0): [0]->..->[104]->[105h]...->[116h]   <<==ACTIVE
 #   |         /                  \
 #   |        /                    +->[105m]...->[117m]
-#   |       /   
+#   |       /
 #   |     Node(1): [0]->..->[104]->[105h]...->[116h]   <<==ACTIVE
 #   |                          \
 #   |                           +->[105m]...->[117m]
-#   |    
+#   |
 #   |     Node(2): [0]->..->[104]->[105m]...->[117m]   <<==ACTIVE
-#   |        \                
-#   |         \                
+#   |        \
+#   |         \
 #   |          \
 #   +-------Node(3): [0]->..->[104]->[105m]...->[117m]   <<==ACTIVE
 #                                \
@@ -316,7 +318,7 @@ class blockdelay(BitcoinTestFramework):
 
 #        raw_input("press enter to generate 64 malicious blocks..")
 
-        print("\nGenerating 64 malicious blocks")       
+        print("\nGenerating 64 malicious blocks")
         self.mark_logs("Generating 64 malicious blocks")
         self.nodes[3].generate(64)
         print("Malicious blocks generated")
@@ -324,31 +326,31 @@ class blockdelay(BitcoinTestFramework):
         self.sync_longest_fork(1, 10);
 
         for i in range(0, 4):
-            print "Node%d  ---" % i 
+            print "Node%d  ---" % i
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
         print("\nTesting fork related data from getchaintips")
         print("\nTesting Node 0")
-        getchaintips_res = self.nodes[0].getchaintips(True)
-        assert(getchaintips_res[0]["penalty-at-start"] == 11)
-        assert(getchaintips_res[0]["penalty-at-tip"] == 1)
-        assert(getchaintips_res[0]["blocks-to-mainchain"] == 1)
-        assert(getchaintips_res[1]["penalty-at-start"] == 0)
-        assert(getchaintips_res[1]["penalty-at-tip"] == 0)
-        assert(getchaintips_res[1]["blocks-to-mainchain"] == 0)
+        getchaintips_res = self.order_tips(self.nodes[0].getchaintips(True))
+        assert(getchaintips_res[1]["penalty-at-start"] == 11)
+        assert(getchaintips_res[1]["penalty-at-tip"] == 1)
+        assert(getchaintips_res[1]["blocks-to-mainchain"] == 1)
+        assert(getchaintips_res[0]["penalty-at-start"] == 0)
+        assert(getchaintips_res[0]["penalty-at-tip"] == 0)
+        assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 1")
         assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
 
         print("\nTesting Node 2")
-        getchaintips_res = self.nodes[2].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[2].getchaintips(True))
         assert(getchaintips_res[0]["penalty-at-start"] == 0)
         assert(getchaintips_res[0]["penalty-at-tip"] == 0)
         assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 3")
-        getchaintips_res = self.nodes[3].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[3].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 12)
         assert(getchaintips_res[1]["penalty-at-tip"] == 78)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 2290)
@@ -368,14 +370,14 @@ class blockdelay(BitcoinTestFramework):
 #   +-------Node(0): [0]->..->[104]->[105h]...->[116h]                       <<==ACTIVE
 #   |         /                  \
 #   |        /                    +->[105m]...->[117m]->[118m]->..->[181m]
-#   |       /   
+#   |       /
 #   |     Node(1): [0]->..->[104]->[105h]...->[116h]                         <<==ACTIVE
 #   |                          \
 #   |                           +->[105m]...->[117m]->[118m]->..->[181m]
-#   |    
+#   |
 #   |     Node(2): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]     <<==ACTIVE
-#   |        \               
-#   |         \                
+#   |        \
+#   |         \
 #   |          \
 #   +-------Node(3): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]   <<==ACTIVE
 #                                \
@@ -392,21 +394,21 @@ class blockdelay(BitcoinTestFramework):
 #   +-------Node(0): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]   <<==ACTIVE
 #   |         /                  \
 #   |        /                    +->[105m]...->[117m]->[118m]->..->[181m]
-#   |       /   
+#   |       /
 #   |     Node(1): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]   <<==ACTIVE
 #   |                          \
 #   |                           +->[105m]...->[117m]->[118m]->..->[181m]
-#   |    
+#   |
 #   |     Node(2): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]   <<==ACTIVE
-#   |        \   
-#   |         \  
+#   |        \
+#   |         \
 #   |          \
 #   +-------Node(3): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]   <<==ACTIVE
 #                                \
 #                                 +->[105h]...->[116h]->[117h]->..->[181h]
 
         for i in range(0, 4):
-            print "Node%d  ---" % i 
+            print "Node%d  ---" % i
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
@@ -414,7 +416,7 @@ class blockdelay(BitcoinTestFramework):
 
         print("\nTesting fork related data from getchaintips")
         print("\nTesting Node 0")
-        getchaintips_res = self.nodes[0].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[0].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 11)
         assert(getchaintips_res[1]["penalty-at-tip"] == 1)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 1)
@@ -426,13 +428,13 @@ class blockdelay(BitcoinTestFramework):
         assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
 
         print("\nTesting Node 2")
-        getchaintips_res = self.nodes[2].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[2].getchaintips(True))
         assert(getchaintips_res[0]["penalty-at-start"] == 0)
         assert(getchaintips_res[0]["penalty-at-tip"] == 0)
         assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 3")
-        getchaintips_res = self.nodes[3].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[3].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 12)
         assert(getchaintips_res[1]["penalty-at-tip"] == 2158)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 2158)
@@ -452,13 +454,13 @@ class blockdelay(BitcoinTestFramework):
         print("Network nodes are synced")
 
         for i in range(0, 4):
-            print "Node%d  ---" % i 
+            print "Node%d  ---" % i
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
         print("\nTesting fork related data from getchaintips")
         print("\nTesting Node 0")
-        getchaintips_res = self.nodes[0].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[0].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 0)
         assert(getchaintips_res[1]["penalty-at-tip"] == 0)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 4)
@@ -470,13 +472,13 @@ class blockdelay(BitcoinTestFramework):
         assert(self.nodes[1].getchaintips(True).sort() == self.nodes[0].getchaintips(True).sort())
 
         print("\nTesting Node 2")
-        getchaintips_res = self.nodes[2].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[2].getchaintips(True))
         assert(getchaintips_res[0]["penalty-at-start"] == 0)
         assert(getchaintips_res[0]["penalty-at-tip"] == 0)
         assert(getchaintips_res[0]["blocks-to-mainchain"] == 0)
 
         print("\nTesting Node 3")
-        getchaintips_res = self.nodes[3].getchaintips(True)
+        getchaintips_res = self.order_tips(self.nodes[3].getchaintips(True))
         assert(getchaintips_res[1]["penalty-at-start"] == 12)
         assert(getchaintips_res[1]["penalty-at-tip"] == 2158)
         assert(getchaintips_res[1]["blocks-to-mainchain"] == 2162)
@@ -493,17 +495,17 @@ class blockdelay(BitcoinTestFramework):
         assert self.nodes[0].getbestblockhash() == last_malicious_blockhash
         print("Confirmed: malicious chain is the best chain")
 
-#   +-------Node(0): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h] 
+#   +-------Node(0): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]
 #   |         /                  \
 #   |        /                    +->[105m]...->[117m]->[118m]->..->[181m]->[182m]  <<==ACTIVE!
-#   |       /   
+#   |       /
 #   |     Node(1): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]
 #   |                          \
 #   |                           +->[105m]...->[117m]->[118m]->..->[181m]->[182m]    <<==ACTIVE!
-#   |    
+#   |
 #   |     Node(2): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]->[182m]    <<==ACTIVE
-#   |        \   
-#   |         \  
+#   |        \
+#   |         \
 #   |          \
 #   +-------Node(3): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]->[182m]  <<==ACTIVE
 #                                \
@@ -525,18 +527,18 @@ class blockdelay(BitcoinTestFramework):
         sync_blocks(self.nodes, 1, True, 5)
 
         for i in range(0, 5):
-            print "Node%d  ---" % i 
+            print "Node%d  ---" % i
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
-        print("\nNode0 generating 1 new blocks")       
+        print("\nNode0 generating 1 new blocks")
         self.mark_logs("Node0 generating 1 new blocks")
         self.nodes[0].generate(1)
         print("New blocks generated")
         sync_blocks(self.nodes, 1, True, 5)
 
         for i in range(0, 5):
-            print "Node%d  ---" % i 
+            print "Node%d  ---" % i
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print "---"
 
@@ -544,23 +546,23 @@ class blockdelay(BitcoinTestFramework):
         assert self.nodes[1].getbalance() == 3.0
         print "Node1 balance has been restored: ", self.nodes[1].getbalance()
 
-#   +-------Node(0): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h] 
+#   +-------Node(0): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]
 #   |         /                  \
 #   |        /                    +->[105m]...->[117m]->[118m]->..->[181m]->[182m]->[183m]  <<==ACTIVE!
-#   |       /   
+#   |       /
 #   |     Node(1): [0]->..->[104]->[105h]...->[116h]->[117h]->..->[181h]
 #   |                          \
 #   |                           +->[105m]...->[117m]->[118m]->..->[181m]->[182m]->[183m]    <<==ACTIVE!
-#   |    
+#   |
 #   |     Node(2): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]->[182m]->[183m]    <<==ACTIVE
-#   |        \   
-#   |         \  
+#   |        \
+#   |         \
 #   |          \
 #   +---------Node(3): [0]->..->[104]->[105m]...->[117m]->[118m]->..->[181m]->[182m]->[183m]  <<==ACTIVE
-#               |                  \                                                        
-#               |                   +->[105h]...->[116h]->[117h]->..->[181h]        
-#               |                                                                           
-#               |                                                                           
+#               |                  \
+#               |                   +->[105h]...->[116h]->[117h]->..->[181h]
+#               |
+#               |
 #             Node(4): [0]->..- ..     ...     ...     ...     ...     ...      ... ->[183m]  <<==ACTIVE
 
 if __name__ == '__main__':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6566,7 +6566,7 @@ std::string dbg_blk_global_tips()
         return ret;
     }
 
-    BOOST_FOREACH(auto mapPair, mGlobalForkTips)
+    for(auto mapPair: mGlobalForkTips)
     {
         const CBlockIndex* pindex = mapPair.first;
 
@@ -6603,7 +6603,7 @@ std::string dbg_blk_global_tips()
     getMostRecentGlobalForkTips(vOutput);
 
     ret += "Ordered: ---------------\n";
-    BOOST_FOREACH(const uint256& hash, vOutput)
+    for(const uint256& hash: vOutput)
     {
         ret += "  [" + hash.GetHex() + "]\n";
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -832,7 +832,7 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
     if ((params.size() >= 1) && !params[0].isBool())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "\"with-penalties\" paramenter should be boolean");
 
-    bool bShowPenaltyInfo = (params.size() >= 1)? params[0].getBool() : true;
+    bool bShowPenaltyInfo = (params.size() >= 1)? params[0].getBool() : false;
 
     /* Build up a list of chain tips.  We start with the list of all
        known blocks, and successively remove blocks that appear as pprev

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1022,14 +1022,6 @@ UniValue getblockfinalityindex(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't tell finality of a block not on main chain");
     }
 
-    std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    BOOST_FOREACH(auto mapPair, mGlobalForkTips)
-    {
-        const CBlockIndex* idx = mapPair.first;
-        setTips.insert(idx);
-    }
-    setTips.insert(chainActive.Tip());
-
     int inputHeight = pblkIndex->nHeight;
     LogPrint("forks", "%s():%d - input h(%d) [%s]\n",
         __func__, __LINE__, pblkIndex->nHeight, pblkIndex->GetBlockHash().ToString());
@@ -1039,6 +1031,14 @@ UniValue getblockfinalityindex(const UniValue& params, bool fHelp)
     {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Old block: older than 2000!");
     }
+
+    std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
+    for(auto mapPair: mGlobalForkTips)
+    {
+        const CBlockIndex* idx = mapPair.first;
+        setTips.insert(idx);
+    }
+    setTips.insert(chainActive.Tip());
 
 //    dump_global_tips();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -788,24 +788,32 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
 
 UniValue getchaintips(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
             "getchaintips\n"
             "Return information about all known tips in the block tree,"
             " including the main chain as well as orphaned branches.\n"
+            "\nArguments:\n"
+            "1. \"with-penalties\" (boolean, optional) show informations related to branches penalty\n"
             "\nResult:\n"
             "[\n"
             "  {\n"
-            "    \"height\": xxxx,         (numeric) height of the chain tip\n"
-            "    \"hash\": \"xxxx\",         (string) block hash of the tip\n"
-            "    \"branchlen\": 0          (numeric) zero for main chain\n"
-            "    \"status\": \"active\"      (string) \"active\" for the main chain\n"
+            "    \"height\": xxxx,                  (numeric) height of the chain tip\n"
+            "    \"hash\": \"xxxx\"                   (string) block hash of the tip\n"
+            "    \"branchlen\": 0                   (numeric) zero for main chain\n"
+            "    \"status\": \"active\"               (string) \"active\" for the main chain\n"
+            "    \"penalty-at-start\": \"xxxx\"       (numeric, optional) penalty of the first block in the branch\n"
+            "    \"penalty-at-tip\": \"xxxx\"         (numeric, optional) penalty of the current tip of the branch\n"
+            "    \"blocks-to-mainchain\": \"xxxx\"    (numeric, optional) confirmations needed for current branch to become the active chain (capped to 2000) \n"
             "  },\n"
             "  {\n"
             "    \"height\": xxxx,\n"
             "    \"hash\": \"xxxx\",\n"
-            "    \"branchlen\": 1          (numeric) length of branch connecting the tip to the main chain\n"
-            "    \"status\": \"xxxx\"        (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n"
+            "    \"branchlen\": 1                   (numeric) length of branch connecting the tip to the main chain\n"
+            "    \"status\": \"xxxx\"                 (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n"
+            "    \"penalty-at-start\": \"xxxx\"       (numeric, optional) penalty of the first block in the branch\n"
+            "    \"penalty-at-tip\": \"xxxx\"         (numeric, optional) penalty of the current tip of the branch\n"
+            "    \"blocks-to-mainchain\": \"xxxx\"    (numeric, optional) confirmations needed for current branch to become the active chain (capped to 2000) \n"
             "  }\n"
             "]\n"
             "Possible values for status:\n"
@@ -821,14 +829,18 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
+    if ((params.size() >= 1) && !params[0].isBool())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "\"with-penalties\" paramenter should be boolean");
+
+    bool bShowPenaltyInfo = (params.size() >= 1)? params[0].getBool() : true;
+
     /* Build up a list of chain tips.  We start with the list of all
        known blocks, and successively remove blocks that appear as pprev
        of another block. */
     std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    for(const PAIRTYPE(const uint256, CBlockIndex*)& item: mapBlockIndex)
         setTips.insert(item.second);
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
+    for(const PAIRTYPE(const uint256, CBlockIndex*)& item: mapBlockIndex) {
         const CBlockIndex* pprev = item.second->pprev;
         if (pprev)
             setTips.erase(pprev);
@@ -839,29 +851,28 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 
     /* Construct the output array.  */
     UniValue res(UniValue::VARR);
-    BOOST_FOREACH(const CBlockIndex* block, setTips)
-    {
+    for(const CBlockIndex* forkTip: setTips) {
         UniValue obj(UniValue::VOBJ);
-        obj.pushKV("height", block->nHeight);
-        obj.pushKV("hash", block->phashBlock->GetHex());
+        obj.pushKV("height", forkTip->nHeight);
+        obj.pushKV("hash", forkTip->phashBlock->GetHex());
 
-        const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
+        const int branchLen = forkTip->nHeight - chainActive.FindFork(forkTip)->nHeight;
         obj.pushKV("branchlen", branchLen);
 
         string status;
-        if (chainActive.Contains(block)) {
+        if (chainActive.Contains(forkTip)) {
             // This block is part of the currently active chain.
             status = "active";
-        } else if (block->nStatus & BLOCK_FAILED_MASK) {
+        } else if (forkTip->nStatus & BLOCK_FAILED_MASK) {
             // This block or one of its ancestors is invalid.
             status = "invalid";
-        } else if (block->nChainTx == 0) {
+        } else if (forkTip->nChainTx == 0) {
             // This block cannot be connected because full block data for it or one of its parents is missing.
             status = "headers-only";
-        } else if (block->IsValid(BLOCK_VALID_SCRIPTS)) {
+        } else if (forkTip->IsValid(BLOCK_VALID_SCRIPTS)) {
             // This block is fully validated, but no longer part of the active chain. It was probably the active block once, but was reorganized.
             status = "valid-fork";
-        } else if (block->IsValid(BLOCK_VALID_TREE)) {
+        } else if (forkTip->IsValid(BLOCK_VALID_TREE)) {
             // The headers for this block are valid, but it has not been validated. It was probably never part of the most-work chain.
             status = "valid-headers";
         } else {
@@ -869,6 +880,21 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
             status = "unknown";
         }
         obj.pushKV("status", status);
+
+        if (bShowPenaltyInfo)
+        {
+            const CBlockIndex* pFirstBlockInBranch = forkTip;
+            for(; pFirstBlockInBranch != nullptr && pFirstBlockInBranch->pprev != nullptr
+                && !chainActive.Contains(pFirstBlockInBranch->pprev);
+                pFirstBlockInBranch = pFirstBlockInBranch->pprev);
+            
+            obj.pushKV("penalty-at-start",    pFirstBlockInBranch->nChainDelay);
+            obj.pushKV("penalty-at-tip",      forkTip->nChainDelay);
+            if (forkTip == chainActive.Tip())
+                obj.pushKV("blocks-to-mainchain", 0);
+            else
+                obj.pushKV("blocks-to-mainchain", blocksToOvertakeTarget(forkTip, chainActive.Tip()));
+        }
 
         res.push_back(obj);
     }
@@ -987,57 +1013,62 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
-int64_t calculateGap(const CBlockIndex *forkTip, const CBlockIndex * targetBlock, int64_t delta)
+int64_t blocksToOvertakeTarget(const CBlockIndex* forkTip, const CBlockIndex* targetBlock)
 {
-	int64_t gap = 0;
-	const int targetBlockHeight = targetBlock->nHeight;
+    //this function assumes forkTip and targetBlock are non-null.
+    if (!chainActive.Contains(targetBlock))
+        return LLONG_MAX;
+
+    int64_t gap = 0;
+    const int targetBlockHeight = targetBlock->nHeight;
     const int selectedTipHeight = forkTip->nHeight;
     const int intersectionHeight = chainActive.FindFork(forkTip)->nHeight;
 
-	LogPrint("forks",
-			"%s():%d - processing tip h(%d) [%s] forkBaseHeight[%d]\n",
-			__func__, __LINE__, forkTip->nHeight, forkTip->GetBlockHash().ToString(),
-			intersectionHeight);
-	// during a node's life, there might be many tips in the container, it is not useful
-	// keeping all of them into account for calculating the finality, just consider the most recent ones.
-	// Blocks are ordered by heigth, stop if we exceed a safe limit in depth, lets say the max age
-	if ((chainActive.Height() - selectedTipHeight) >= MAX_BLOCK_AGE_FOR_FINALITY) {
-		LogPrint("forks",
-				"%s():%d - exiting loop on tips, max age reached: forkBaseHeight[%d], chain[%d]\n",
-				__func__, __LINE__, intersectionHeight, chainActive.Height());
-		gap = LLONG_MAX;
-	} else if (intersectionHeight < targetBlockHeight) {
-		// if the fork base is older than the input block, finality also depends on the current penalty
-		// ongoing on the fork
-		int64_t forkDelay = forkTip->nChainDelay;
-		if (selectedTipHeight >= chainActive.Height()) {
-			// if forkDelay is null one has to mine 1 block only
-			gap = forkDelay ? forkDelay : 1;
-			LogPrint("forks", "%s():%d - gap[%d], forkDelay[%d]\n", __func__,
-					__LINE__, gap, forkDelay);
-		} else {
-			int64_t dt = chainActive.Height() - selectedTipHeight + 1;
-			dt = dt * (dt + 1) / 2;
-			gap = dt + forkDelay + 1;
-			LogPrint("forks", "%s():%d - gap[%d], forkDelay[%d], dt[%d]\n",
-					__func__, __LINE__, gap, forkDelay, dt);
-		}
-	} else {
-		// this also handles the main chain tip
-		if (delta < PENALTY_THRESHOLD + 1) {
-			// an attacker can mine from previous block up to tip + 1
-			gap = delta + 1;
-			LogPrint("forks", "%s():%d - gap[%d], delta[%d]\n", __func__,
-					__LINE__, gap, delta);
-		} else {
-			// penalty applies
-			gap = (delta * (delta + 1) / 2);
-			LogPrint("forks", "%s():%d - gap[%d], delta[%d]\n", __func__,
-					__LINE__, gap, delta);
-		}
-	}
+    LogPrint("forks", "%s():%d - processing tip h(%d) [%s] forkBaseHeight[%d]\n",
+            __func__, __LINE__, forkTip->nHeight, forkTip->GetBlockHash().ToString(),
+            intersectionHeight);
 
-	return gap;
+    // during a node's life, there might be many tips in the container, it is not useful
+    // keeping all of them into account for calculating the finality, just consider the most recent ones.
+    // Blocks are ordered by height, stop if we exceed a safe limit in depth, lets say the max age
+    if ((chainActive.Height() - selectedTipHeight) >= MAX_BLOCK_AGE_FOR_FINALITY) {
+        LogPrint("forks", "%s():%d - exiting loop on tips, max age reached: forkBaseHeight[%d], chain[%d]\n",
+                __func__, __LINE__, intersectionHeight, chainActive.Height());
+        gap = LLONG_MAX;
+    } else if (intersectionHeight < targetBlockHeight) {
+        // if the fork base is older than the input block, finality also depends on the current penalty
+        // ongoing on the fork
+        int64_t forkDelay = forkTip->nChainDelay;
+        if (selectedTipHeight >= chainActive.Height()) {
+            // if forkDelay is null one has to mine 1 block only
+            gap = forkDelay ? forkDelay : 1;
+            LogPrint("forks", "%s():%d - gap[%d], forkDelay[%d]\n", __func__,
+                    __LINE__, gap, forkDelay);
+        } else {
+            int64_t dt = chainActive.Height() - selectedTipHeight + 1;
+            dt = dt * (dt + 1) / 2;
+            gap = dt + forkDelay + 1;
+            LogPrint("forks", "%s():%d - gap[%d], forkDelay[%d], dt[%d]\n",
+                    __func__, __LINE__, gap, forkDelay, dt);
+        }
+    } else {
+        int64_t targetToTipDelta = chainActive.Height() - targetBlockHeight + 1;
+
+        // this also handles the main chain tip
+        if (targetToTipDelta < PENALTY_THRESHOLD + 1) {
+            // an attacker can mine from previous block up to tip + 1
+            gap = targetToTipDelta + 1;
+            LogPrint("forks", "%s():%d - gap[%d], delta[%d]\n", __func__,
+                    __LINE__, gap, targetToTipDelta);
+        } else {
+            // penalty applies
+            gap = (targetToTipDelta * (targetToTipDelta + 1) / 2);
+            LogPrint("forks", "%s():%d - gap[%d], delta[%d]\n", __func__,
+                    __LINE__, gap, targetToTipDelta);
+        }
+    }
+
+    return gap;
 }
 
 UniValue getblockfinalityindex(const UniValue& params, bool fHelp)
@@ -1090,14 +1121,13 @@ UniValue getblockfinalityindex(const UniValue& params, bool fHelp)
 
 //    dump_global_tips();
 
-    int64_t minGap = LLONG_MAX;
-
     // For each tip find the stemming block on the main chain
     // In case of main tip such a block would be the tip itself
     //-----------------------------------------------------------------------
+    int64_t minGap = LLONG_MAX;
     for(auto selectedTip: setTips)
     {
-		int64_t gap = calculateGap(selectedTip, pTargetBlockIdx, delta);
+        int64_t gap = blocksToOvertakeTarget(selectedTip, pTargetBlockIdx);
         minGap = std::min(minGap, gap);
     }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -118,7 +118,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_importkey", 2 },
     { "z_importviewingkey", 2 },
     { "z_getpaymentdisclosure", 1},
-    { "z_getpaymentdisclosure", 2}
+    { "z_getpaymentdisclosure", 2},
+    { "getchaintips", 0}
 };
 
 class CRPCConvertTable

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -166,6 +166,7 @@ extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern double GetNetworkDifficulty(const CBlockIndex* blockindex = NULL);
+extern int64_t blocksToOvertakeTarget(const CBlockIndex* forkTip, const CBlockIndex* targetBlock);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);

--- a/src/zen/delay.cpp
+++ b/src/zen/delay.cpp
@@ -16,8 +16,12 @@ int64_t GetBlockDelay(const CBlockIndex& newBlock, const CBlockIndex& prevBlock,
     if (prevBlock.nChainDelay > 0)
     {
     	// blocks on tip get penalty reduced by 1;
-    	// others get penalty increased proportionally to distance from tip
-    	return std::max<int>((activeChainHeight - newBlock.nHeight),-1);
+    	// other blocks get penalty increased proportionally to distance from tip
+    	int64_t blockDelay =  std::max<int64_t>((activeChainHeight - newBlock.nHeight),int64_t(-1));
+
+    	LogPrintf("calculated blockDelay %d for newBlockHeight %d (activeChainHeight: %d, prevBlockChainDelay: %d)!\n",
+    			blockDelay, activeChainHeight, newBlock.nHeight, prevBlock.nChainDelay);
+    	return blockDelay;
     }
 
     // Introduce penalty in case we receive a historic block.

--- a/src/zen/delay.cpp
+++ b/src/zen/delay.cpp
@@ -2,35 +2,31 @@
 
 int64_t GetBlockDelay(const CBlockIndex& newBlock, const CBlockIndex& prevBlock, const int activeChainHeight, const bool isStartupSyncing)
 {
-
-    if(isStartupSyncing) {
+    if(isStartupSyncing)
+    {
     	return 0;
     }
 
-    if(newBlock.nHeight < activeChainHeight ) {
+    if(newBlock.nHeight < activeChainHeight )
+    {
       	LogPrintf("Received a delayed block (activeChainHeight: %d, newBlockHeight: %d)!\n", activeChainHeight, newBlock.nHeight);
     }
 
     // if the current chain is penalised.
-    if (prevBlock.nChainDelay > 0) {
-        // Positive values to increase the penalty until
-        // we reach the current active height.
-        if (activeChainHeight >= newBlock.nHeight ) {
-        	return (activeChainHeight - newBlock.nHeight);
-        } else {
-        	LogPrintf("Decreasing penalty to chain (activeChainHeight: %d, newBlockHeight: %d, prevBlockChainDelay: %d)!\n", activeChainHeight, newBlock.nHeight, prevBlock.nChainDelay);
-        	// -1 to decrease the penalty afterwards.
-            return -1;
-        } 
-    // no penalty yet, or penalty already resolved.
-    } else {
-        // Introduce penalty in case we receive a historic block.
-        // (uses a threshold value)
-        if (activeChainHeight - newBlock.nHeight > PENALTY_THRESHOLD ){
-            return (activeChainHeight - newBlock.nHeight);
-        // no delay detected.
-        } else {
-            return 0;
-        }
+    if (prevBlock.nChainDelay > 0)
+    {
+    	// blocks on tip get penalty reduced by 1;
+    	// others get penalty increased proportionally to distance from tip
+    	return std::max<int>((activeChainHeight - newBlock.nHeight),-1);
+    }
+
+    // Introduce penalty in case we receive a historic block.
+    // (uses a threshold value)
+    if (activeChainHeight - newBlock.nHeight > PENALTY_THRESHOLD )
+    {
+        return (activeChainHeight - newBlock.nHeight);
+    } else // no delay detected.
+    {
+        return 0;
     }
 }


### PR DESCRIPTION
Along @cronicc indications we are going to extend getchaintips with a --with-penalties=true/false paramenter to include, for each branch:

1. penalty-at-start of branch. A non-zero value indicates branch starts of penalized
2. penalty-at-tip of branch
3. blocks-to-mainchain, i.e. how many blocks on selected branch must be mined in order for it to become the mainchain