### PR TITLE
Restored the debug mode compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,7 @@ AC_LANG_PUSH([C++])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 if test "x$enable_debug" = xyes; then
+    LIBZCASH_LIBS="$LIBZCASH_LIBS -lboost_thread -lboost_filesystem -lboost_program_options -lboost_chrono"
     CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
     if test "x$GCC" = xyes; then
         CFLAGS="$CFLAGS -g3 -O0"
@@ -788,8 +789,7 @@ if test x$BUILD_OS = xdarwin; then
   AX_CHECK_COMPILE_FLAG([-Wno-undefined-var-template],[CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"],,[[$CXXFLAG_WERROR]])
 fi
 
-
-LIBZCASH_LIBS="-lgmp -lgmpxx -lboost_system -lcrypto -lsodium $RUST_LIBS"
+LIBZCASH_LIBS="-lgmp -lgmpxx -lboost_system $LIBZCASH_LIBS -lcrypto -lsodium $RUST_LIBS"
 
 AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])


### PR DESCRIPTION
The debug build was not working because the linking of some libraries
was missing. Now those libraries are conditionally included when
compiling with "--enable-debug" flag.