### PR TITLE
Cr/355 update openssl

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 This issue tracker is only for technical issues related to Zen.
 
-General Zen questions and/or support requests are best directed to the [Discord](https://horizen.global/invite/discord), or [Support Portal](https://support.horizen.global).
+General Zen questions and/or support requests are best directed to the [Discord](https://horizen.io/invite/discord), or [Support Portal](https://support.horizen.io).
 
-For reporting security vulnerabilities or for sensitive discussions with our security team, please see the [Bug Bounty Policy and Scope](https://horizenofficial.atlassian.net/wiki/spaces/ZEN/pages/136871957/Bug+Bounty+Submission+Policy+and+Scope), or send an encrypted email to security@horizen.global with information. The public key for that address is available [here](https://HorizenOfficial.github.io/keys/).
+For reporting security vulnerabilities or for sensitive discussions with our security team, please see the [Bug Bounty Policy and Scope](https://horizenofficial.atlassian.net/wiki/spaces/ZEN/pages/136871957/Bug+Bounty+Submission+Policy+and+Scope), or send an encrypted email to security@horizen.io with information. The public key for that address is available [here](https://HorizenOfficial.github.io/keys/).
 
 ### Describe the issue
 Please provide a general summary of the issue you're experiencing

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ os: linux
     osx_image: xcode9.4
     cache:
       directories:
-        - "$HOME/Library/Application\ Support/ZcashParams"
+        - "$HOME/ZcashParams"
     script:
       - bash -c "RENAME_FOLDER='true' RENAME_SUFFIX='_clean' ${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/get_archive.sh ${B2_DL_DECOMPRESS_FOLDER} ${B2_DL_FILENAME}"
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/travis_stay_alive.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 # Filing bug reports:
 
 1. Follow the github issue guide
-2. If it requires secrecy, send an email to info@horizen.global
+2. If it requires secrecy, send an email to info@horizen.io
 
 # What we're looking for:
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Copy and paste your wallet.dat from %APPDATA%/Zclassic/ to %APPDATA%/Zen. That's
 About
 --------------
 
-[Zen](https://horizen.global/) is a platform for secure communications and for deniable economic activity.
+[Zen](https://horizen.io/) is a platform for secure communications and for deniable economic activity.
 Horizen is an evolution of the Zclassic codebase aimed at primarily enabling intriniscally secure communications and
 resilient networking.
 
@@ -162,7 +162,7 @@ See important security warnings in
 
 Where do I begin?
 -----------------
-* The easiest way to get started is to download one of the available GUI wallets from [horizen.global](https://horizen.global)
+* The easiest way to get started is to download one of the available GUI wallets from [horizen.io](https://horizen.io)
 
 ### Need Help?
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -41,12 +41,12 @@ is deemed necessary and appropriate to the circumstances. Maintainers are
 obligated to maintain confidentiality with regard to the reporter of an
 incident.
 
-You may send reports to [our Conduct email](mailto:info@horizen.global).
+You may send reports to [our Conduct email](mailto:info@horizen.io).
 
 If you wish to contact specific maintainers directly, the following have made
 themselves available for conduct issues:
 
-- Jake (jake at horizen.global)
+- cronic (cronic at horizen.io)
 
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],

--- a/contrib/ci-horizen/scripts/common/setup_environment.sh
+++ b/contrib/ci-horizen/scripts/common/setup_environment.sh
@@ -80,6 +80,8 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export PIP_INSTALL="${PIP_INSTALL} pyblake2 pyzmq"
     export B2_DL_DECOMPRESS_FOLDER="${TRAVIS_BUILD_DIR}"
     export B2_DL_FILENAME="${TRAVIS_CPU_ARCH}-${TRAVIS_OS_NAME}-${TRAVIS_OSX_IMAGE}-${TRAVIS_BUILD_ID}-${TRAVIS_COMMIT}.tar.gz"
+    mkdir -p "$HOME/ZcashParams"
+    ln -sf "$HOME/ZcashParams" "$HOME/Library/Application Support/ZcashParams"
   fi
   if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Package" ]; then
     NEED_B2_CREDS="true"

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -2,4 +2,4 @@ zen (2.0.15) stable; urgency=medium
 
   * 2.0.15 release.
 
- -- Zen Blockchain Foundation <info@horizen.global>  Thu, 27 Sep 2018 23:00:00 +0200
+ -- Zen Blockchain Foundation <info@horizen.io>  Thu, 27 Sep 2018 23:00:00 +0200

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,8 +1,8 @@
 Source: zen
 Section: utils
 Priority: optional
-Maintainer: Zen Blockchain Foundation <info@horizen.global>
-Homepage: https://horizen.global
+Maintainer: Zen Blockchain Foundation <info@horizen.io>
+Homepage: https://horizen.io
 Build-Depends: autoconf, automake, bsdmainutils, build-essential,
  git, g++-multilib, libc6-dev, libtool,
  m4, ncurses-dev, pkg-config, python,
@@ -13,4 +13,4 @@ Vcs-Browser: https://github.com/HorizenOfficial/zen
 Package: zen
 Architecture: any
 Depends: ${shlibs:Depends}
-Description: Private and reliable transactions, communications, and publishing - horizen.global
+Description: Private and reliable transactions, communications, and publishing - horizen.io

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -11,7 +11,7 @@ License: Expat
 Comment: The Bitcoin Core developers encompasses the current developers listed on bitcoin.org,
  as well as the numerous contributors to the project.
  The Zcash developers are listed at https://z.cash/team.html.
- The Horizen developers are listed at https://horizen.global/team.
+ The Horizen developers are listed at https://horizen.io/team.
 
 Files: depends/sources/libsodium-*.tar.gz
 Copyright: 2013-2016 Frank Denis

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -5,7 +5,7 @@ BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_WALLET ?=
 NO_UPNP ?=
-PRIORITY_DOWNLOAD_PATH ?= https://downloads.horizen.global/file/depends-sources
+PRIORITY_DOWNLOAD_PATH ?= https://downloads.horizen.io/file/depends-sources
 
 BUILD ?= $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.1.1i
+$(package)_version=1.1.1j
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+$(package)_sha256_hash=aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.1.1g
+$(package)_version=1.1.1i
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
+$(package)_sha256_hash=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -82,7 +82,7 @@ Review the automated changes in git:
 Push the resulting branch to github:
 
     export DEBVERSION="${ZCASH_RELEASE}"
-    export DEBEMAIL="${DEBEMAIL:-info@horizen.global}"
+    export DEBEMAIL="${DEBEMAIL:-info@horizen.io}"
     export DEBFULLNAME="${DEBFULLNAME:-Zcash Company}"
 
 Then create the PR on github. Complete the standard review process,

--- a/qa/zen/test-depends-sources-mirror.py
+++ b/qa/zen/test-depends-sources-mirror.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-# This script tests that the package mirror at https://horizen.global/depends-sources/
+# This script tests that the package mirror at https://horizen.io/depends-sources/
 # contains all of the packages required to build this version of Zen.
 #
 # This script assumes you've just built Zen, and that as a result of that
@@ -12,7 +12,7 @@ import sys
 import os
 import requests
 
-MIRROR_URL_DIR="https://downloads.horizen.global/file/depends-sources/"
+MIRROR_URL_DIR="https://downloads.horizen.io/file/depends-sources/"
 DEPENDS_SOURCES_DIR=os.path.realpath(os.path.join(
     os.path.dirname(__file__),
     "..", "..", "depends", "sources"

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -9,7 +9,7 @@ Copyright Zen Blockchain Foundation, 2019
 
 The Zen Blockchain Foundation is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
 
-Please submit issues to security@horizen.global, using the following PGP key:
+Please submit issues to security@horizen.io, using the following PGP key:
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/zcutil/fetch-params.ps1
+++ b/zcutil/fetch-params.ps1
@@ -39,11 +39,11 @@ function Start-DownloadCheckFile ($url, $maxAttempts, $filepath, $hash) {
 
 # Define download URLs for file
 
-$Source_sproutprovingkey = "https://downloads.horizen.global/file/TrustedSetup/sprout-proving.key"
-$Source_sproutverifyingkey = "https://downloads.horizen.global/file/TrustedSetup/sprout-verifying.key"
-$Source_saplingspendparams = "https://downloads.horizen.global/file/TrustedSetup/sapling-spend.params"
-$Source_saplingoutputparams = "https://downloads.horizen.global/file/TrustedSetup/sapling-output.params"
-$Source_sproutgroth16params = "https://downloads.horizen.global/file/TrustedSetup/sprout-groth16.params"
+$Source_sproutprovingkey = "https://downloads.horizen.io/file/TrustedSetup/sprout-proving.key"
+$Source_sproutverifyingkey = "https://downloads.horizen.io/file/TrustedSetup/sprout-verifying.key"
+$Source_saplingspendparams = "https://downloads.horizen.io/file/TrustedSetup/sapling-spend.params"
+$Source_saplingoutputparams = "https://downloads.horizen.io/file/TrustedSetup/sapling-output.params"
+$Source_sproutgroth16params = "https://downloads.horizen.io/file/TrustedSetup/sprout-groth16.params"
 
 # Define SHA256 checksums for files
 

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -13,7 +13,7 @@ SPROUT_VKEY_NAME='sprout-verifying.key'
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
 SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
-SPROUT_URL="https://downloads.horizen.global/file/TrustedSetup"
+SPROUT_URL="https://downloads.horizen.io/file/TrustedSetup"
 SPROUT_IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"


### PR DESCRIPTION
* Updates OpenSSL to 1.1.1i, changelog https://www.openssl.org/news/changelog.html#openssl-111
* Fixup of https://github.com/HorizenOfficial/zen/commit/ffaefad8ca6794facf8dc8d289e9380a8844bb7c see https://github.com/travis-ci/travis-ci/issues/6005

tlsprotocols.py test passes and connections to TLS/non-TLS peers + sync are working.

closes #355 