### PR TITLE
Fix balance computation for shielded tx

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1939,7 +1939,7 @@ UniValue getbalance(const UniValue& params, bool fHelp)
         for (auto it = pwalletMain->getMapWallet().begin(); it != pwalletMain->getMapWallet().end(); ++it)
         {
             const CWalletTransactionBase* wtx = it->second.get();
-            if (!CheckFinalTx(*wtx->getTxBase()) || !wtx->HasMatureOutputs())
+            if (!CheckFinalTx(*wtx->getTxBase()) || (wtx->getTxBase()->IsCoinBase() && !wtx->HasMatureOutputs()))
                 continue;
 
             CAmount allFee;
@@ -3005,7 +3005,7 @@ UniValue listaccounts(const UniValue& params, bool fHelp)
         list<COutputEntry> listReceived;
         list<COutputEntry> listSent;
 
-        if (!wtx.HasMatureOutputs())
+        if (wtx.getTxBase()->IsCoinBase() && !wtx.HasMatureOutputs())
             continue;
 
         wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, includeWatchonly);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1886,7 +1886,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived, list<COutputEntry>&
         }
 
         COutputEntry output = {
-            address, txout.nValue, CCoins::outputMaturity::MATURE, (int)pos, /*isBackwardTransfer*/false};
+            address, txout.nValue, IsOutputMature(pos), (int)pos, /*isBackwardTransfer*/false};
 
         // If we are debited by the transaction, add the output as a "sent" entry
         if (nDebit > 0)
@@ -2282,6 +2282,12 @@ bool CWalletTransactionBase::HasMatureOutputs() const
         default:
             return false;
         }
+    }
+
+    // Check if it is a shielded transaction
+    if (getTxBase()->GetVjoinsplit().size() > 0)
+    {
+        return true;
     }
 
     return false;


### PR DESCRIPTION
Fixed the RPC command `getbalance` when called with parameter `"*"`. This is similar to what's been reported in #409.