### PR TITLE
Improvements of the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,9 @@ src/zendoo/mcTest
 .python-version
 # custom folders
 ./test/
+
+# Ignore configure backup files
+configure~
+
+# Ignore compilation JSON database
+compile_commands.json

--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -156,8 +156,9 @@ if test "x$want_boost" = "xyes"; then
     LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
     export LDFLAGS
 
-    CXXFLAGS_SAVED="$CPPFLAGS"
+    CXXFLAGS_SAVED="$CXXFLAGS"
     CXXFLAGS=
+    export CXXFLAGS
 
     AC_REQUIRE([AC_PROG_CXX])
     AC_LANG_PUSH(C++)
@@ -184,6 +185,7 @@ if test "x$want_boost" = "xyes"; then
     if test "x$succeeded" != "xyes"; then
         CPPFLAGS="$CPPFLAGS_SAVED"
         LDFLAGS="$LDFLAGS_SAVED"
+        CXXFLAGS="$CXXFLAGS_SAVED"
         BOOST_CPPFLAGS=
         BOOST_LDFLAGS=
         _version=0

--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -156,6 +156,9 @@ if test "x$want_boost" = "xyes"; then
     LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
     export LDFLAGS
 
+    CXXFLAGS_SAVED="$CPPFLAGS"
+    CXXFLAGS=
+
     AC_REQUIRE([AC_PROG_CXX])
     AC_LANG_PUSH(C++)
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -286,6 +289,7 @@ if test "x$want_boost" = "xyes"; then
 
     CPPFLAGS="$CPPFLAGS_SAVED"
     LDFLAGS="$LDFLAGS_SAVED"
+    CXXFLAGS="$CXXFLAGS_SAVED"
 fi
 
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,7 @@ AC_ARG_ENABLE([address-indexing],
     [enable_address_indexing=no])
 
 AC_LANG_PUSH([C++])
+AX_CHECK_COMPILE_FLAG([-Wall],[CXXFLAG_WALL="-Wall"],[CXXFLAG_WALL=""])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 if test "x$enable_debug" = xyes; then
@@ -217,7 +218,7 @@ fi
 ERROR_CXXFLAGS=
 
 if test "x$enable_wall" = "xyes"; then
-  if test "x$CXXFLAG_WERROR" = "x"; then
+  if test "x$CXXFLAG_WALL" = "x"; then
     AC_MSG_ERROR("enable-wall set but -Wall is not usable")
   fi
   ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Wall"

--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,13 @@ AC_ARG_ENABLE([debug],
     [enable_debug=$enableval],
     [enable_debug=no])
 
+# Turn on all compiler warnings
+AC_ARG_ENABLE([wall],
+    [AS_HELP_STRING([--enable-wall],
+                    [Enable all compiler warnings (default is no)])],
+    [enable_wall=$enableval],
+    [enable_wall=no])
+
 # Turn warnings into errors
 AC_ARG_ENABLE([werror],
     [AS_HELP_STRING([--enable-werror],
@@ -208,6 +215,14 @@ if test "x$enable_debug" = xyes; then
 fi
 
 ERROR_CXXFLAGS=
+
+if test "x$enable_wall" = "xyes"; then
+  if test "x$CXXFLAG_WERROR" = "x"; then
+    AC_MSG_ERROR("enable-wall set but -Wall is not usable")
+  fi
+  ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Wall"
+fi
+
 if test "x$enable_werror" = "xyes"; then
   if test "x$CXXFLAG_WERROR" = "x"; then
     AC_MSG_ERROR("enable-werror set but -Werror is not usable")
@@ -1018,6 +1033,7 @@ echo "  with proton   = $use_proton"
 echo "  with zmq      = $use_zmq"
 echo "  with test     = $use_tests"
 echo "  debug enabled = $enable_debug"
+echo "  wall          = $enable_wall"
 echo "  werror        = $enable_werror"
 echo "  addr index    = $enable_address_indexing"
 echo 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -67,7 +67,12 @@ AT:=$(AT_$(V))
 
 all: install
 
+ifeq ($(CLANG_ARG),true)
+include hosts/$(host_os)_clang.mk
+else
 include hosts/$(host_os).mk
+endif
+
 include hosts/default.mk
 include builders/$(build_os).mk
 include builders/default.mk

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -1,9 +1,9 @@
-default_build_CC = gcc
-default_build_CXX = g++
-default_build_AR = ar
-default_build_RANLIB = ranlib
-default_build_STRIP = strip
-default_build_NM = nm
+default_build_CC = $(CT_PREFIX)gcc
+default_build_CXX = $(CT_PREFIX)g++
+default_build_AR = $(CT_PREFIX)ar
+default_build_RANLIB = $(CT_PREFIX)ranlib
+default_build_STRIP = $(CT_PREFIX)strip
+default_build_NM = $(CT_PREFIX)nm
 default_build_OTOOL = otool
 default_build_INSTALL_NAME_TOOL = install_name_tool
 

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -1,3 +1,13 @@
+ifeq ($(CLANG_ARG),true)
+default_build_CC = $(CT_PREFIX)clang
+default_build_CXX = $(CT_PREFIX)clang++
+default_build_AR = $(CT_PREFIX)llvm-ar
+default_build_RANLIB = $(CT_PREFIX)llvm-ranlib
+default_build_STRIP = $(CT_PREFIX)llvm-strip
+default_build_NM = $(CT_PREFIX)llvm-nm
+default_build_OTOOL = otool
+default_build_INSTALL_NAME_TOOL = install_name_tool
+else
 default_build_CC = $(CT_PREFIX)gcc
 default_build_CXX = $(CT_PREFIX)g++
 default_build_AR = $(CT_PREFIX)ar
@@ -6,6 +16,7 @@ default_build_STRIP = $(CT_PREFIX)strip
 default_build_NM = $(CT_PREFIX)nm
 default_build_OTOOL = otool
 default_build_INSTALL_NAME_TOOL = install_name_tool
+endif
 
 define add_build_tool_func
 build_$(build_os)_$1 ?= $$(default_build_$1)

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -36,6 +36,8 @@ LDFLAGS="-L$depends_prefix/lib $LDFLAGS"
 
 CC="@CC@"
 CXX="@CXX@"
+HOST_CC="@CC@"
+CC_FOR_BUILD="@CC@"
 OBJC="${CC}"
 OBJCXX="${CXX}"
 CCACHE=$depends_prefix/native/bin/ccache

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -10,19 +10,19 @@ linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 ifeq (86,$(findstring 86,$(build_arch)))
-i686_linux_CC=gcc -m32
-i686_linux_CXX=g++ -m32
-i686_linux_AR=ar
-i686_linux_RANLIB=ranlib
-i686_linux_NM=nm
-i686_linux_STRIP=strip
+i686_linux_CC=$(CT_PREFIX)gcc -m32
+i686_linux_CXX=$(CT_PREFIX)g++ -m32
+i686_linux_AR=$(CT_PREFIX)ar
+i686_linux_RANLIB=$(CT_PREFIX)ranlib
+i686_linux_NM=$(CT_PREFIX)nm
+i686_linux_STRIP=$(CT_PREFIX)strip
 
-x86_64_linux_CC=gcc -m64
-x86_64_linux_CXX=g++ -m64
-x86_64_linux_AR=ar
-x86_64_linux_RANLIB=ranlib
-x86_64_linux_NM=nm
-x86_64_linux_STRIP=strip
+x86_64_linux_CC=$(CT_PREFIX)gcc -m64
+x86_64_linux_CXX=$(CT_PREFIX)g++ -m64
+x86_64_linux_AR=$(CT_PREFIX)ar
+x86_64_linux_RANLIB=$(CT_PREFIX)ranlib
+x86_64_linux_NM=$(CT_PREFIX)nm
+x86_64_linux_STRIP=$(CT_PREFIX)strip
 else
 i686_linux_CC=$(default_host_CC) -m32
 i686_linux_CXX=$(default_host_CXX) -m32

--- a/depends/hosts/linux_clang.mk
+++ b/depends/hosts/linux_clang.mk
@@ -1,0 +1,31 @@
+linux_CFLAGS=-pipe
+linux_CXXFLAGS=$(linux_CFLAGS)
+
+linux_release_CFLAGS=-O1
+linux_release_CXXFLAGS=$(linux_release_CFLAGS)
+
+linux_debug_CFLAGS=-O1
+linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
+
+linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
+
+ifeq (86,$(findstring 86,$(build_arch)))
+i686_linux_CC=clang -m32
+i686_linux_CXX=clang++ -m32
+i686_linux_AR=llvm-ar
+i686_linux_RANLIB=llvm-ranlib
+i686_linux_NM=nm
+i686_linux_STRIP=strip
+
+x86_64_linux_CC=clang -m64
+x86_64_linux_CXX=clang++ -m64
+x86_64_linux_AR=llvm-ar
+x86_64_linux_RANLIB=llvm-ranlib
+x86_64_linux_NM=nm
+x86_64_linux_STRIP=strip
+else
+i686_linux_CC=$(default_host_CC) -m32
+i686_linux_CXX=$(default_host_CXX) -m32
+x86_64_linux_CC=$(default_host_CC) -m64
+x86_64_linux_CXX=$(default_host_CXX) -m64
+endif

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -31,7 +31,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries) && \
+  ./bootstrap.sh --with-toolset=gcc --without-icu --with-libraries=$($(package)_config_libraries) && \
   sed -i -e "s|using gcc ;|using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
 endef
 

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -5,11 +5,11 @@ $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
 $(package)_patches=signals2-noise.patch
 
-compiler = 
+$(package)_compiler=
 ifeq ($(CLANG_ARG),true)
-compiler = clang
+$(package)_compiler=clang
 else
-compiler = gcc
+$(package)_compiler=gcc
 endif
 
 define $(package)_set_vars
@@ -23,7 +23,7 @@ $(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win3
 $(package)_config_opts_x86_64_mingw32=address-model=64
 $(package)_config_opts_i686_mingw32=address-model=32
 $(package)_config_opts_i686_linux=address-model=32 architecture=x86
-$(package)_toolset_$(host_os)=$(compiler)
+$(package)_toolset_$(host_os)=$($(package)_compiler)
 $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)
@@ -38,8 +38,8 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --with-toolset=gcc --without-icu --with-libraries=$($(package)_config_libraries) && \
-  sed -i -e "s|using gcc ;|using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
+  ./bootstrap.sh --with-toolset=$($(package)_compiler) --without-icu --with-libraries=$($(package)_config_libraries) && \
+  sed -i -e "s|using $($(package)_compiler) ;|using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\"<archiver>\"$($(package)_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -5,6 +5,13 @@ $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
 $(package)_patches=signals2-noise.patch
 
+compiler = 
+ifeq ($(CLANG_ARG),true)
+compiler = clang
+else
+compiler = gcc
+endif
+
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
 $(package)_config_opts_debug=variant=debug
@@ -16,7 +23,7 @@ $(package)_config_opts_mingw32=binary-format=pe target-os=windows threadapi=win3
 $(package)_config_opts_x86_64_mingw32=address-model=64
 $(package)_config_opts_i686_mingw32=address-model=32
 $(package)_config_opts_i686_linux=address-model=32 architecture=x86
-$(package)_toolset_$(host_os)=gcc
+$(package)_toolset_$(host_os)=$(compiler)
 $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -14,6 +14,14 @@ else
 $(package)_library_file=target/release/librustzcash.a
 endif
 
+ifeq ($(host_os),linux)
+$(package)_cargo_cc=CC=$(CT_PREFIX)gcc
+$(package)_cargo_ld=RUSTC_LINKER=$(CT_PREFIX)gcc
+else
+$(package)_cargo_cc=
+$(package)_cargo_ld=
+endif
+
 define $(package)_set_vars
 $(package)_build_opts=--frozen --release
 $(package)_build_opts_mingw32=--target=x86_64-pc-windows-gnu
@@ -28,7 +36,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-  cargo build $($(package)_build_opts)
+  $($(package)_cargo_ld) $($(package)_cargo_cc) cargo build $($(package)_build_opts)
 endef
 
 define $(package)_stage_cmds

--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -8,18 +8,20 @@ $(package)_git_commit=7a96af9aee9adbcb43666251590425d98124ee94
 $(package)_dependencies=rust $(rust_crates_z)
 $(package)_patches=cargo.config
 
-ifeq ($(host_os),mingw32)
-$(package)_library_file=target/x86_64-pc-windows-gnu/release/libzendoo_mc.a
+ifeq ($(CLANG_ARG),true)
+$(package)_compiler=$(CT_PREFIX)clang
+RUST_CC=CC=$($(package)_compiler)
 else
-$(package)_library_file=target/release/libzendoo_mc.a
+$(package)_compiler=$(CT_PREFIX)gcc
+RUST_CC=CC=$($(package)_compiler)
 endif
 
-ifeq ($(host_os),linux)
-$(package)_cargo_cc=CC=$(CT_PREFIX)gcc
-$(package)_cargo_ld=RUSTC_LINKER=$(CT_PREFIX)gcc
+ifeq ($(host_os),mingw32)
+$(package)_library_file=target/x86_64-pc-windows-gnu/release/libzendoo_mc.a
+# Unset custom CC
+RUST_CC=
 else
-$(package)_cargo_cc=
-$(package)_cargo_ld=
+$(package)_library_file=target/release/libzendoo_mc.a
 endif
 
 ifeq ($(LIBZENDOO_LEGACY_CPU),true)
@@ -35,11 +37,11 @@ endef
 
 define $(package)_preprocess_cmds
   mkdir .cargo && \
-  cat $($(package)_patch_dir)/cargo.config | sed 's|CRATE_REGISTRY|$(host_prefix)/$(CRATE_REGISTRY)|' > .cargo/config
+  cat $($(package)_patch_dir)/cargo.config | sed 's|CRATE_REGISTRY|$(host_prefix)/$(CRATE_REGISTRY)|' | sed 's|DUMMY_LINKER|$($(package)_compiler)|g' > .cargo/config
 endef
 
 define $(package)_build_cmds
-  $($(package)_cargo_ld) $($(package)_cargo_cc) RUSTFLAGS="$($(package)_target_feature)" cargo build $($(package)_build_opts)
+  $(RUST_CC) RUSTFLAGS="$($(package)_target_feature)" cargo build $($(package)_build_opts)
 endef
 
 

--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -14,6 +14,14 @@ else
 $(package)_library_file=target/release/libzendoo_mc.a
 endif
 
+ifeq ($(host_os),linux)
+$(package)_cargo_cc=CC=$(CT_PREFIX)gcc
+$(package)_cargo_ld=RUSTC_LINKER=$(CT_PREFIX)gcc
+else
+$(package)_cargo_cc=
+$(package)_cargo_ld=
+endif
+
 ifeq ($(LIBZENDOO_LEGACY_CPU),true)
 $(package)_target_feature=
 else
@@ -31,7 +39,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-  RUSTFLAGS="$($(package)_target_feature)" cargo build $($(package)_build_opts)
+  $($(package)_cargo_ld) $($(package)_cargo_cc) RUSTFLAGS="$($(package)_target_feature)" cargo build $($(package)_build_opts)
 endef
 
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,16 +1,24 @@
 package=zeromq
-$(package)_version=4.3.1
+$(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared --disable-curve
+  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf
+  $(package)_config_opts += --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
+  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
+  $(package)_config_opts += --disable-drafts --enable-option-checking
   $(package)_config_opts_linux=--with-pic
-  $(package)_cxxflags=-std=c++17
+  $(package)_config_opts_freebsd=--with-pic
+  $(package)_config_opts_mingw32=--disable-Werror
+  $(package)_cxxflags+=-std=c++17
 endef
 
+# calling autogen.sh is necessary to compile on systems with aclocal < 1.16 (e.g. Ubuntu bionic).
+# Can be removed if not needed by the CI.
 define $(package)_config_cmds
+  ./autogen.sh && \
   $($(package)_autoconf)
 endef
 
@@ -23,5 +31,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf bin share
+  rm -rf bin share lib/*.la
 endef

--- a/depends/patches/librustzcash/cargo.config
+++ b/depends/patches/librustzcash/cargo.config
@@ -22,6 +22,9 @@ directory = "CRATE_REGISTRY"
 [target.x86_64-pc-windows-gnu]
 linker = "x86_64-w64-mingw32-gcc"
 
+[target.x86_64-unknown-linux-gnu]
+linker = "DUMMY_LINKER"
+
 [profile.release]
 #panic = 'abort'
 codegen-units = 1

--- a/depends/patches/libzendoo/cargo.config
+++ b/depends/patches/libzendoo/cargo.config
@@ -3,3 +3,6 @@ replace-with = "vendored-sources"
 
 [source.vendored-sources]
 directory = "CRATE_REGISTRY"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "DUMMY_LINKER"

--- a/doc/static-code-analysis.md
+++ b/doc/static-code-analysis.md
@@ -27,6 +27,8 @@ Clang
 -----------------
 By default Zen is compiled with GCC, but it's easy to switch to Clang by calling `zcutil/build.sh` with the flag `--use-clang`. Using Clang together with `wall` or `werror` tipically generates a different set of warnings compared with GCC.
 
+Please note that `--use-clang` is only available for Linux, MacOS uses Clang by default through a different build script.
+
 scan-build
 -----------------
 In addition to the standard compilation warnings, Clang brings some useful static analysis tools like `scan-build`. This tool must be invoked as a wrapper of the `make` command (basically in the same way as **Bear**) by changing the last line of the `zcutil/build.sh` script:

--- a/doc/static-code-analysis.md
+++ b/doc/static-code-analysis.md
@@ -1,0 +1,51 @@
+Static code analysis
+====================
+
+Zen integrates some tools and build flags that can be used to perform analysis of the source code.
+
+JSON compilation database
+-----------------
+
+Some of the tools that are used to perform static code analysis require a JSON file containing the compilation commands and parameters for any source file of the project. In order to generate such file, we have to call `make` through [Bear](https://github.com/rizsotto/Bear).
+
+The easiest way to do it, is by editing the build script `zcutil/build.sh` and editing the last line as:
+
+```
+bear -- "$MAKE" "$@" V=1
+```
+
+Please note that the project folder should be cleaned before running the build script (using `make clean` or `make distclean`) otherwise the database would not be filled correctly as already compiled files are skipped.
+
+Compiler static analysis
+-----------------
+
+The first level of static code analysis is directly performed by the compiler during the build process. The default settings are quite "light", but the analysis level could be increased by adding `--enable-wall` to the `CONFIGURE_FLAGS` environment variable.
+
+It's also possible to make the compilation fail if any warning is raised by using the flag `--enable-werror`.
+
+Clang
+-----------------
+By default Zen is compiled with GCC, but it's easy to switch to Clang by calling `zcutil/build.sh` with the flag `--use-clang`. Using Clang together with `wall` or `werror` tipically generates a different set of warnings compared with GCC.
+
+scan-build
+-----------------
+In addition to the standard compilation warnings, Clang brings some useful static analysis tools like `scan-build`. This tool must be invoked as a wrapper of the `make` command (basically in the same way as **Bear**) by changing the last line of the `zcutil/build.sh` script:
+
+```
+scan-build "$MAKE" "$@" V=1
+```
+
+At the end of the build process, an HTML report is generated in a temporary folder and it can be inspected with `scan-view`.
+
+clang-tidy
+-----------------
+Another analysis tool of the Clang family is `clang-tidy`. It can be used to check single files, but the easiest way to run it is through the script `run-clang-tidy.py` which runs the analysis with parallel jobs on the whole project folder.
+
+Note that it requires the `compile_commands.json` database.
+
+Linters
+-----------------
+The folder `qa/linters` contains some scripts to run additional checks over the source code, the currently available ones are:
+
+- cppcheck
+- oclint (requires `compile_commands.json`)

--- a/qa/lint/cppcheck-suppressions-list.txt
+++ b/qa/lint/cppcheck-suppressions-list.txt
@@ -1,0 +1,2 @@
+*:depends/*
+*:src/univalue/*

--- a/qa/lint/extended-lint-all.sh
+++ b/qa/lint/extended-lint-all.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all contrib/devtools/extended-lint-*.sh files, and fails if
+# any exit with a non-zero status code.
+
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# in order to allow for the executed lint scripts to opt in or opt out of locale
+# dependence themselves.
+
+set -u
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+for f in "${SCRIPTDIR}"/extended-lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      exit 1
+    fi
+  fi
+done

--- a/qa/lint/extended-lint-cppcheck.sh
+++ b/qa/lint/extended-lint-cppcheck.sh
@@ -7,59 +7,6 @@
 
 export LC_ALL=C
 
-ENABLED_CHECKS=(
-    "Class '.*' has a constructor with 1 argument that is not explicit."
-    "Struct '.*' has a constructor with 1 argument that is not explicit."
-)
-
-IGNORED_WARNINGS=(
-    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
-    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
-    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewCursor' has a constructor with 1 argument that is not explicit."
-    "src/net.h:.* Class 'CNetMessage' has a constructor with 1 argument that is not explicit."
-    "src/policy/feerate.h:.* Class 'CFeeRate' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
-    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
-    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
-    "src/protocol.h:.* Class 'CMessageHeader' has a constructor with 1 argument that is not explicit."
-    "src/qt/guiutil.h:.* Class 'ItemDelegate' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* Struct 'RPCResults' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* style: Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'AddressDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'ComboDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'ConstPubkeyProvider' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'PKDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'PKHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'RawDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'SHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'WPKHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'WSHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/script.h:.* Class 'CScript' has a constructor with 1 argument that is not explicit."
-    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const CRPCCommand >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const char >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const std :: vector <unsigned char > >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const uint8_t >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'FailingCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'MemoryCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'UniqueCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/fuzz/util.h:.* Class 'FuzzedFileProvider' has a constructor with 1 argument that is not explicit."
-    "src/test/fuzz/util.h:.* Class 'FuzzedAutoFileProvider' has a constructor with 1 argument that is not explicit."
-    "src/wallet/db.h:.* Class 'BerkeleyEnvironment' has a constructor with 1 argument that is not explicit."
-)
-
 if ! command -v cppcheck > /dev/null; then
     echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
     exit 0
@@ -71,12 +18,8 @@ function join_array {
     echo "$*"
 }
 
-ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
-IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
-WARNINGS=$(git ls-files -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" | \
-    xargs cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++11 --template=gcc -D__cplusplus -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -I src/ -q 2>&1 | sort -u)
-    #grep -E "${ENABLED_CHECKS_REGEXP}" | \
-    #grep -vE "${IGNORED_WARNINGS_REGEXP}")
+# cppcheck-suppressions-list.txt is required since "-i" only ignores source files, but not headers, see "cppcheck --help" for further details.
+WARNINGS=$(cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++17 --template=gcc --project=compile_commands.json -q -isrc/leveldb -isrc/secp256k1 -isrc/snark -isrc/univalue --suppressions-list=qa/lint/cppcheck-suppressions-list.txt 2>&1)
 if [[ ${WARNINGS} != "" ]]; then
     echo "${WARNINGS}"
     echo

--- a/qa/lint/extended-lint-cppcheck.sh
+++ b/qa/lint/extended-lint-cppcheck.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+export LC_ALL=C
+
+ENABLED_CHECKS=(
+    "Class '.*' has a constructor with 1 argument that is not explicit."
+    "Struct '.*' has a constructor with 1 argument that is not explicit."
+)
+
+IGNORED_WARNINGS=(
+    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCursor' has a constructor with 1 argument that is not explicit."
+    "src/net.h:.* Class 'CNetMessage' has a constructor with 1 argument that is not explicit."
+    "src/policy/feerate.h:.* Class 'CFeeRate' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
+    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
+    "src/protocol.h:.* Class 'CMessageHeader' has a constructor with 1 argument that is not explicit."
+    "src/qt/guiutil.h:.* Class 'ItemDelegate' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* Struct 'RPCResults' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* style: Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'AddressDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ComboDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ConstPubkeyProvider' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'RawDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'SHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WPKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WSHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/script.h:.* Class 'CScript' has a constructor with 1 argument that is not explicit."
+    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const CRPCCommand >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const char >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const std :: vector <unsigned char > >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const uint8_t >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'FailingCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'MemoryCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'UniqueCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/fuzz/util.h:.* Class 'FuzzedFileProvider' has a constructor with 1 argument that is not explicit."
+    "src/test/fuzz/util.h:.* Class 'FuzzedAutoFileProvider' has a constructor with 1 argument that is not explicit."
+    "src/wallet/db.h:.* Class 'BerkeleyEnvironment' has a constructor with 1 argument that is not explicit."
+)
+
+if ! command -v cppcheck > /dev/null; then
+    echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
+    exit 0
+fi
+
+function join_array {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
+IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
+WARNINGS=$(git ls-files -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" | \
+    xargs cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++11 --template=gcc -D__cplusplus -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -I src/ -q 2>&1 | sort -u)
+    #grep -E "${ENABLED_CHECKS_REGEXP}" | \
+    #grep -vE "${IGNORED_WARNINGS_REGEXP}")
+if [[ ${WARNINGS} != "" ]]; then
+    echo "${WARNINGS}"
+    echo
+    echo "Advice not applicable in this specific case? Add an exception by updating"
+    echo "IGNORED_WARNINGS in $0"
+    # Uncomment to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
+    # exit 1
+fi
+exit 0

--- a/qa/lint/extended-lint-cppcheck.sh
+++ b/qa/lint/extended-lint-cppcheck.sh
@@ -12,20 +12,5 @@ if ! command -v cppcheck > /dev/null; then
     exit 0
 fi
 
-function join_array {
-    local IFS="$1"
-    shift
-    echo "$*"
-}
-
 # cppcheck-suppressions-list.txt is required since "-i" only ignores source files, but not headers, see "cppcheck --help" for further details.
-WARNINGS=$(cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++17 --template=gcc --project=compile_commands.json -q -isrc/leveldb -isrc/secp256k1 -isrc/snark -isrc/univalue --suppressions-list=qa/lint/cppcheck-suppressions-list.txt 2>&1)
-if [[ ${WARNINGS} != "" ]]; then
-    echo "${WARNINGS}"
-    echo
-    echo "Advice not applicable in this specific case? Add an exception by updating"
-    echo "IGNORED_WARNINGS in $0"
-    # Uncomment to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
-    # exit 1
-fi
-exit 0
+cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++17 --template=gcc --project=compile_commands.json -q -isrc/leveldb -isrc/secp256k1 -isrc/snark -isrc/univalue --suppressions-list=qa/lint/cppcheck-suppressions-list.txt 2>&1

--- a/qa/lint/extended-lint-oclint.sh
+++ b/qa/lint/extended-lint-oclint.sh
@@ -13,55 +13,12 @@ ENABLED_CHECKS=(
 )
 
 IGNORED_WARNINGS=(
-    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
-    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
-    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
-    "src/coins.h:.* Class 'CCoinsViewCursor' has a constructor with 1 argument that is not explicit."
-    "src/net.h:.* Class 'CNetMessage' has a constructor with 1 argument that is not explicit."
-    "src/policy/feerate.h:.* Class 'CFeeRate' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
-    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
-    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
-    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
-    "src/protocol.h:.* Class 'CMessageHeader' has a constructor with 1 argument that is not explicit."
-    "src/qt/guiutil.h:.* Class 'ItemDelegate' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* Struct 'RPCResults' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
-    "src/rpc/util.h:.* style: Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'AddressDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'ComboDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'ConstPubkeyProvider' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'PKDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'PKHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'RawDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'SHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'WPKHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/descriptor.cpp:.* Class 'WSHDescriptor' has a constructor with 1 argument that is not explicit."
-    "src/script/script.h:.* Class 'CScript' has a constructor with 1 argument that is not explicit."
-    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const CRPCCommand >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const char >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const std :: vector <unsigned char > >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span < const uint8_t >' has a constructor with 1 argument that is not explicit."
-    "src/span.h:.* Class 'Span' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
-    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'FailingCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'MemoryCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/checkqueue_tests.cpp:.* Struct 'UniqueCheck' has a constructor with 1 argument that is not explicit."
-    "src/test/fuzz/util.h:.* Class 'FuzzedFileProvider' has a constructor with 1 argument that is not explicit."
-    "src/test/fuzz/util.h:.* Class 'FuzzedAutoFileProvider' has a constructor with 1 argument that is not explicit."
-    "src/wallet/db.h:.* Class 'BerkeleyEnvironment' has a constructor with 1 argument that is not explicit."
+    ".*long line \[size\|P3\] Line with .* characters exceeds limit of .*"
+    ".*long variable name \[naming\|P3\] Length of variable name .* is .*, which is longer than the threshold of .*"
 )
 
-if ! command -v cppcheck > /dev/null; then
-    echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
+if ! command -v oclint > /dev/null; then
+    echo "Skipping oclint linting since oclint is not installed."
     exit 0
 fi
 
@@ -73,10 +30,9 @@ function join_array {
 
 ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
 IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
-WARNINGS=$(git ls-files -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" | \
-    xargs -I {} oclint {} -- -D__cplusplus -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -I src/ -I depends/work/build/x86_64-unknown-linux-gnu/ -q 2>&1 | sort -u)
-    #grep -E "${ENABLED_CHECKS_REGEXP}" | \
-    #grep -vE "${IGNORED_WARNINGS_REGEXP}")
+WARNINGS=$(oclint-json-compilation-database -e src/leveldb -e src/secp256k1 -e src/univalue -e src/snark -e depends 2>&1)
+    # grep -E "$ENABLED_CHECKS_REGEXP" | \
+    # grep -vE "${IGNORED_WARNINGS_REGEXP}")
 if [[ ${WARNINGS} != "" ]]; then
     echo "${WARNINGS}"
     echo

--- a/qa/lint/extended-lint-oclint.sh
+++ b/qa/lint/extended-lint-oclint.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+export LC_ALL=C
+
+ENABLED_CHECKS=(
+    "Class '.*' has a constructor with 1 argument that is not explicit."
+    "Struct '.*' has a constructor with 1 argument that is not explicit."
+)
+
+IGNORED_WARNINGS=(
+    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCursor' has a constructor with 1 argument that is not explicit."
+    "src/net.h:.* Class 'CNetMessage' has a constructor with 1 argument that is not explicit."
+    "src/policy/feerate.h:.* Class 'CFeeRate' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
+    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
+    "src/protocol.h:.* Class 'CMessageHeader' has a constructor with 1 argument that is not explicit."
+    "src/qt/guiutil.h:.* Class 'ItemDelegate' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* Struct 'RPCResults' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* style: Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'AddressDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ComboDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ConstPubkeyProvider' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'RawDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'SHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WPKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WSHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/script.h:.* Class 'CScript' has a constructor with 1 argument that is not explicit."
+    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const CRPCCommand >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const char >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const std :: vector <unsigned char > >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const uint8_t >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'FailingCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'MemoryCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'UniqueCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/fuzz/util.h:.* Class 'FuzzedFileProvider' has a constructor with 1 argument that is not explicit."
+    "src/test/fuzz/util.h:.* Class 'FuzzedAutoFileProvider' has a constructor with 1 argument that is not explicit."
+    "src/wallet/db.h:.* Class 'BerkeleyEnvironment' has a constructor with 1 argument that is not explicit."
+)
+
+if ! command -v cppcheck > /dev/null; then
+    echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
+    exit 0
+fi
+
+function join_array {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
+IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
+WARNINGS=$(git ls-files -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" | \
+    xargs -I {} oclint {} -- -D__cplusplus -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -I src/ -I depends/work/build/x86_64-unknown-linux-gnu/ -q 2>&1 | sort -u)
+    #grep -E "${ENABLED_CHECKS_REGEXP}" | \
+    #grep -vE "${IGNORED_WARNINGS_REGEXP}")
+if [[ ${WARNINGS} != "" ]]; then
+    echo "${WARNINGS}"
+    echo
+    echo "Advice not applicable in this specific case? Add an exception by updating"
+    echo "IGNORED_WARNINGS in $0"
+    # Uncomment to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
+    # exit 1
+fi
+exit 0

--- a/qa/lint/extended-lint-oclint.sh
+++ b/qa/lint/extended-lint-oclint.sh
@@ -7,38 +7,12 @@
 
 export LC_ALL=C
 
-ENABLED_CHECKS=(
-    "Class '.*' has a constructor with 1 argument that is not explicit."
-    "Struct '.*' has a constructor with 1 argument that is not explicit."
-)
-
-IGNORED_WARNINGS=(
-    ".*long line \[size\|P3\] Line with .* characters exceeds limit of .*"
-    ".*long variable name \[naming\|P3\] Length of variable name .* is .*, which is longer than the threshold of .*"
-)
-
 if ! command -v oclint > /dev/null; then
     echo "Skipping oclint linting since oclint is not installed."
     exit 0
 fi
 
-function join_array {
-    local IFS="$1"
-    shift
-    echo "$*"
-}
 
-ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
-IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
-WARNINGS=$(oclint-json-compilation-database -e src/leveldb -e src/secp256k1 -e src/univalue -e src/snark -e depends 2>&1)
-    # grep -E "$ENABLED_CHECKS_REGEXP" | \
-    # grep -vE "${IGNORED_WARNINGS_REGEXP}")
-if [[ ${WARNINGS} != "" ]]; then
-    echo "${WARNINGS}"
-    echo
-    echo "Advice not applicable in this specific case? Add an exception by updating"
-    echo "IGNORED_WARNINGS in $0"
-    # Uncomment to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
-    # exit 1
-fi
-exit 0
+# To disable specific rules, use "-- -disable-rule=<rule name", for example "-- -disable-rule=LongLine".
+# The list of all rules can be found by running "oclint . -list-enabled-rules".
+oclint-json-compilation-database -e src/leveldb -e src/secp256k1 -e src/univalue -e src/snark -e depends 2>&1

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -45,7 +45,7 @@ Usage:
 $0 --help
   Show this help message and exit.
 
-$0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ --disable-rust ] [ --enable-proton ] [ --disable-libs ] [ --legacy-cpu ] [ MAKEARGS... ]
+$0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ --enable-proton ] [ --legacy-cpu ] [--enable-address-indexing] [--use-clang] [ MAKEARGS... ]
     Build Zen and most of its transitive dependencies from
     source. MAKEARGS are applied to both dependencies and Zen itself.
 
@@ -56,18 +56,18 @@ $0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ --disable-rust ] 
   If --disable-mining is passed, Zen is configured to not build any mining
   code. It must be passed after the test arguments, if present.
 
-  If --disable-rust is passed, Zen is configured to not build any Rust language
-  assets. It must be passed after test/mining arguments, if present.
-
   If --enable-proton is passed, Zen is configured to build the Apache Qpid Proton
   library required for AMQP support. This library is not built by default.
   It must be passed after the test/mining/Rust arguments, if present.
 
-  If --disable-libs is passed, Zen is configured to not build any libraries like
-  'libzcashconsensus'.
-
   If --legacy-cpu is passed, libzendoo is built without bmi2 and adx compiler flags.
   These CPU flags were introduced in Intel Broadwell and AMD Excavator architectures.
+
+  If --enable-address-indexing is passed, Zen is configured to build the code related
+  to address indexing. Such feature is typically used by the Explorer to keep track
+  of additional information that are not useful for normal nodes.
+
+  If --use-clang is passed, Zen is compiled using Clang instead of GCC.
 EOF
     exit 0
 fi
@@ -151,5 +151,5 @@ ld -v
 
 HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" LIBZENDOO_LEGACY_CPU="$LIBZENDOO_LEGACY_CPU" CLANG_ARG="$CLANG_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
-CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure  "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" "$ADDRESSINDEXING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
+CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" "$ADDRESSINDEXING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
 "$MAKE" "$@" V=1

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -138,11 +138,18 @@ then
     shift
 fi
 
+# If --use-clang is true, use Clang as the compiler (instead of gcc):
+CLANG_ARG='false'
+if [ "x${1:-}" = 'x--use-clang' ]; then
+    CLANG_ARG='true'
+    shift
+fi
+
 eval "$MAKE" --version
 as --version
 ld -v
 
-HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" LIBZENDOO_LEGACY_CPU="$LIBZENDOO_LEGACY_CPU" "$MAKE" "$@" -C ./depends/ V=1
+HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" LIBZENDOO_LEGACY_CPU="$LIBZENDOO_LEGACY_CPU" CLANG_ARG="$CLANG_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
 CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure  "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" "$ADDRESSINDEXING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
 "$MAKE" "$@" V=1


### PR DESCRIPTION
- Added a new `configure` argument to enable the `-Wall` flag during the compilation
- Added the `--use-clang` argument to `build.sh` to switch the compilation from `gcc` to `clang`
- Added some scripts to perform static code analysis with `cppcheck` and `oclint` 