### PR TITLE
Renamed "version" field in getscinfo RPC command

### DIFF
--- a/qa/rpc-tests/sc_getscinfo.py
+++ b/qa/rpc-tests/sc_getscinfo.py
@@ -139,7 +139,7 @@ class sc_getscinfo(BitcoinTestFramework):
 
         # Check that all the sidechains have the correct version
         for item in sc_info_all['items']:
-            assert_equal(item['sidechainVersion'], 0)
+            assert_equal(item['version'], 0)
 
         # check all of them have right block creation hash which is part of verbose output
         # and fill the ordered scids lists
@@ -331,16 +331,16 @@ class sc_getscinfo(BitcoinTestFramework):
         mark_logs("Check info for v0 and v1 sidechains (unconfirmed)", self.nodes, DEBUG_MODE)
         v0_sc_id = test_helper.get_sidechain_id("v0")
         v1_sc_id = test_helper.get_sidechain_id("v1")
-        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['unconfSidechainVersion'], 0)
-        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['unconfSidechainVersion'], 1)
+        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['unconfVersion'], 0)
+        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['unconfVersion'], 1)
 
         mark_logs("Node 0 generates a block to confirm the creation of sidechains v0 and v1", self.nodes, DEBUG_MODE);
         self.nodes[0].generate(1)
         self.sync_all()
 
         mark_logs("Check info for v0 and v1 sidechains (confirmed)", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['sidechainVersion'], 0)
-        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['sidechainVersion'], 1)
+        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['version'], 0)
+        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['version'], 1)
 
         mark_logs("Checking persistance, stopping and restarting nodes", self.nodes, DEBUG_MODE)
         stop_nodes(self.nodes)
@@ -348,8 +348,8 @@ class sc_getscinfo(BitcoinTestFramework):
         self.setup_network(False)
 
         mark_logs("Check info persistance for v0 and v1 sidechains", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['sidechainVersion'], 0)
-        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['sidechainVersion'], 1)
+        assert_equal(self.nodes[0].getscinfo(v0_sc_id)['items'][0]['version'], 0)
+        assert_equal(self.nodes[0].getscinfo(v1_sc_id)['items'][0]['version'], 1)
 
 if __name__ == '__main__':
     sc_getscinfo().main()

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1600,7 +1600,7 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
         // creation parameters
         sc.pushKV("mbtrRequestDataLength", info.fixedParams.mainchainBackwardTransferRequestDataLength);
         sc.pushKV("withdrawalEpochLength", info.fixedParams.withdrawalEpochLength);
-        sc.pushKV("sidechainVersion", info.fixedParams.version);
+        sc.pushKV("version", info.fixedParams.version);
         sc.pushKV("certSubmissionWindowLength", info.GetCertSubmissionWindowLength());
  
         if (bVerbose)
@@ -1707,7 +1707,7 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             sc.pushKV("state", CSidechain::stateToString(CSidechain::State::UNCONFIRMED));
             sc.pushKV("unconfCreatingTxHash", info.creationTxHash.GetHex());
             sc.pushKV("unconfWithdrawalEpochLength", info.fixedParams.withdrawalEpochLength);
-            sc.pushKV("unconfSidechainVersion", info.fixedParams.version);
+            sc.pushKV("unconfVersion", info.fixedParams.version);
             sc.pushKV("unconfCertSubmissionWindowLength", info.GetCertSubmissionWindowLength());
 
             if (bVerbose)
@@ -1912,7 +1912,7 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
             "                                                              it can be either pastMbtrScFee or lastMbtrScFee value depending on the current block height, current epoch and last received top quality certificate\n"
             "     \"mbtrRequestDataLength\":              xxxxx,   (numeric) The size of the MBTR request data length\n"
             "     \"withdrawalEpochLength\":              xxxxx,   (numeric) length in blocks of the withdrawal epoch\n"
-            "     \"sidechainVersion\":                   xxxxx,   (numeric) version of the sidechain\n"
+            "     \"version\":                            xxxxx,   (numeric) version of the sidechain\n"
             "     \"certSubmissionWindowLength\":         xxxxx,   (numeric) length in blocks of the submission window for certificates\n"
             "     \"certProvingSystem\"                   xxxxx,   (numeric) The type of proving system used for certificate verification\n"
             "     \"wCertVk\":                            xxxxx,   (string)  The verification key needed to verify a Withdrawal Certificate Proof, set at sc creation\n"


### PR DESCRIPTION
The version field was initially named "sidechainVersion", now it has been renamed as "version" to be consistent with other RPC commands (e.g. sc_create, decoderawtransaction, etc.).