### PR TITLE
Allow sending to the same recipient address multiple times in z_sendm…

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5097,9 +5097,6 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     if (outputs.size()==0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, amounts array is empty.");
 
-    // Keep track of addresses to spot duplicates
-    set<std::string> setAddress;
-
     // Recipients
     std::vector<SendManyRecipient> taddrRecipients;
     std::vector<SendManyRecipient> zaddrRecipients;
@@ -5135,10 +5132,6 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, unknown address format: ")+address );
             }
         }
-
-        if (setAddress.count(address))
-            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+address);
-        setAddress.insert(address);
 
         UniValue memoValue = find_value(o, "memo");
         string memo;


### PR DESCRIPTION
…any:

* Useful for funding Secure/Super Node challenge addresses with multiple unspent notes in singe transaction

* Useful for Secure/Super Node Payment system funding which requires exact matching utxo in single transaction

* Usefuel for sending multi part messages in memo field