### PR TITLE
Always send notifications about tip updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4080,6 +4080,10 @@ void static UpdateTip(CBlockIndex *pindexNew) {
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
       syncProgress, pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
 
+    // Notify external listeners about the new tip.
+    GetMainSignals().UpdatedBlockTip(pindexNew);
+    uiInterface.NotifyBlockTip(pindexNew->GetBlockHash());
+
     cvBlockChange.notify_all();
 }
 
@@ -4498,9 +4502,6 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, bool &postponeRe
                     hashNewTip.ToString());
             }
 
-            // Notify external listeners about the new tip.
-            GetMainSignals().UpdatedBlockTip(pindexNewTip);
-            uiInterface.NotifyBlockTip(hashNewTip);
         }
         else
         {


### PR DESCRIPTION
As of today, we generate _UpdatedBlockTip_ notifications in the main loop of ActivateBestChain().
This means that we do not actually generate _UpdatedBlockTip_ notifications for every tip update, but rather for
every completion of ActivateBestChainStep(), which might perform several block connections and disconnections at once.

As a consequence, when a new best chain is selected, we skip notifications about blocks being disconnected or connected in the process.
This behavior might be related to issue https://github.com/HorizenOfficial/Sidechains-SDK/issues/138.

This PR updates the code so that we always send _UpdatedBlockTip_ notifications on every change of the tip, including when
a block is being disconnected, and a new best chain is being selected.

Also notice that as of today we check whether the initial download is finished before we send notifications. With this patch, we
ignore this condition, and always send notifications.

In future, we might implement similar checks directly in the notification managers (e.g. rpc or ui).
