### PR TITLE
Update the build system to be compatible with latest Linux distributions

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -33,21 +33,23 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 11
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
-  m4_if([$1], [11], [],
-        [$1], [14], [],
-        [$1], [17], [m4_fatal([support for C++17 not yet implemented in AX_CXX_COMPILE_STDCXX])],
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -57,26 +59,13 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
-  m4_if([$4], [], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [default], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [nodefault], [ax_cxx_compile_cxx$1_try_default=false],
-        [m4_fatal([invalid fourth argument `$4' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$4], [nodefault], [], [dnl
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi])
-
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
-    for switch in -std=gnu++$1 -std=gnu++0x; do
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
@@ -102,22 +91,27 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
-    for switch in -std=c++$1 -std=c++0x +std=c++$1 "-h std=c++$1"; do
-      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
-      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
-                     $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
-         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-          [eval $cachevar=yes],
-          [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
-      if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
         fi
-        ac_success=yes
+      done
+      if test x$ac_success = xyes; then
         break
       fi
     done
@@ -154,6 +148,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
 )
 
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
 
 dnl  Tests for new features in C++11
 
@@ -191,11 +190,13 @@ namespace cxx11
 
     struct Base
     {
+      virtual ~Base() {}
       virtual void f() {}
     };
 
     struct Derived : public Base
     {
+      virtual ~Derived() override {}
       virtual void f() override {}
     };
 
@@ -524,7 +525,7 @@ namespace cxx14
 
   }
 
-  namespace test_digit_seperators
+  namespace test_digit_separators
   {
 
     constexpr auto ten_million = 100'000'000;
@@ -564,5 +565,387 @@ namespace cxx14
 }  // namespace cxx14
 
 #endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
 
 ]])

--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,8 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 

--- a/configure.ac
+++ b/configure.ac
@@ -755,7 +755,7 @@ fi
 # These packages don't provide pkgconfig config files across all
 # platforms, so we use older autoconf detection mechanisms:
 AC_CHECK_HEADER([gmp.h],,AC_MSG_ERROR(libgmp headers missing))
-AC_CHECK_LIB([gmp],[[__gmpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
+AC_CHECK_LIB([gmp],[__gmpn_sub_n],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
 
 AC_CHECK_HEADER([gmpxx.h],,AC_MSG_ERROR(libgmpxx headers missing))
 AC_CHECK_LIB([gmpxx],[main],GMPXX_LIBS=-lgmpxx, [AC_MSG_ERROR(libgmpxx missing)])

--- a/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_bionic/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_bionic/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils build-essential ca-certificates \
        cmake curl dirmngr fakeroot git g++-multilib gnupg2 help2man libc6-dev libgomp1 libtool lintian m4 ncurses-dev \
        pigz pkg-config pv python3-dev python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install b2 pyblake2 websocket-client pyzmq \
+    && pip3 install b2sdk==1.14.1 b2==3.2.1 pyblake2 websocket-client pyzmq \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/contrib/ci-horizen/dockerfiles/amd64/windows/ubuntu_bionic/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/windows/ubuntu_bionic/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils build-essential ca-certificates \
        cmake curl dirmngr git g++-multilib gnupg2 help2man libc6-dev libgomp1 libtool m4 mingw-w64 ncurses-dev pigz \
        pkg-config pv python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install b2 \
+    && pip3 install b2sdk==1.14.1 b2==3.2.1 \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -9,7 +9,7 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
-$(package)_cxxflags=-std=c++11
+$(package)_cxxflags=-std=c++17
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -21,7 +21,7 @@ $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
-$(package)_cxxflags=-std=c++11 -fvisibility=hidden
+$(package)_cxxflags=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_freebsd=-fPIC
 endef

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,13 +1,14 @@
 package=boost
-$(package)_version=1_70_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.70.0/source
+$(package)_version=1_74_0
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
+$(package)_sha256_hash=83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
+$(package)_patches=signals2-noise.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
 $(package)_config_opts_debug=variant=debug
-$(package)_config_opts=--layout=system --user-config=user-config.jam
+$(package)_config_opts=--layout=system
 $(package)_config_opts+=threading=multi link=static -sNO_BZIP2=1 -sNO_ZLIB=1
 $(package)_config_opts_linux=threadapi=pthread runtime-link=shared
 $(package)_config_opts_darwin=--toolset=darwin-4.2.1 runtime-link=shared
@@ -22,14 +23,16 @@ $(package)_archiver_darwin=$($(package)_libtool)
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
 $(package)_cxxflags=-std=c++11 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
+$(package)_cxxflags_freebsd=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  patch -p2 < $($(package)_patch_dir)/signals2-noise.patch
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --without-icu --with-libraries=$(boost_config_libraries)
+  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries) && \
+  sed -i -e "s|using gcc ;|using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;|" project-config.jam
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/crate_cc_z.mk
+++ b/depends/packages/crate_cc_z.mk
@@ -1,9 +1,9 @@
 package=crate_cc_z
 $(package)_crate_name=cc
-$(package)_version=1.0.72
+$(package)_version=1.0.71
 $(package)_download_path=https://static.crates.io/crates/$($(package)_crate_name)
 $(package)_file_name=$($(package)_crate_name)-$($(package)_version).crate
-$(package)_sha256_hash=22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee
+$(package)_sha256_hash=79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd
 $(package)_crate_versioned_name=$($(package)_crate_name)
 
 define $(package)_preprocess_cmds

--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -6,7 +6,7 @@ $(package)_download_file=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8
 
 define $(package)_set_vars
-$(package)_cxxflags+=-std=c++11
+$(package)_cxxflags+=-std=c++17
 $(package)_cxxflags_linux=-fPIC
 endef
 

--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -1,8 +1,8 @@
 package=libgmp
-$(package)_download_path=https://github.com/HorizenOfficial/$(package)/releases/download/v20170131/
-$(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=59b2c2b5d58fdf5943bfde1fa709e9eb53e7e072c9699d28dc1c2cbb3c8cc32c
-$(package)_git_commit=aece03c7b6967f91f3efdac8c673f55adff53ab1
+$(package)_version=6.2.1
+$(package)_download_path=https://gmplib.org/download/gmp/
+$(package)_file_name=gmp-$($(package)_version).tar.bz2
+$(package)_sha256_hash=eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c
 $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared
 

--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -1,10 +1,10 @@
 package=libzendoo
-$(package)_version=0.2.0
+$(package)_version=0.2.0.1
 $(package)_download_path=https://github.com/HorizenOfficial/zendoo-mc-cryptolib/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=f01a838c6b56431ab1e235ec9ffd9ed4eff136797837f4aab58ccabd37eb73e2
-$(package)_git_commit=96a723528a1d04d0ba8ccc7d9f01d7266e276122
+$(package)_sha256_hash=40dfbbc020e846f156ecb20d9d94c1f13e8d45357054abb1cd0f969f8fdb9975
+$(package)_git_commit=7a96af9aee9adbcb43666251590425d98124ee94
 $(package)_dependencies=rust $(rust_crates_z)
 $(package)_patches=cargo.config
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d83
 define $(package)_set_vars
   $(package)_config_opts=--without-documentation --disable-shared --disable-curve
   $(package)_config_opts_linux=--with-pic
-  $(package)_cxxflags=-std=c++11
+  $(package)_cxxflags=-std=c++17
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/signals2-noise.patch
+++ b/depends/patches/boost/signals2-noise.patch
@@ -1,0 +1,23 @@
+From fd27423fea5537bc857c1fa14bb0c25b994f77b3 Mon Sep 17 00:00:00 2001
+From: Frank Mori Hess <fmh6jj@gmail.com>
+Date: Mon, 20 Jul 2020 14:17:05 -0400
+Subject: [PATCH] Fix warning about deprecated
+ boost/function_output_iterator.hpp
+
+---
+ include/boost/signals2/detail/null_output_iterator.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/boost/signals2/detail/null_output_iterator.hpp b/include/boost/signals2/detail/null_output_iterator.hpp
+index 9e986959..dee4373c 100644
+--- a/include/boost/signals2/detail/null_output_iterator.hpp
++++ b/include/boost/signals2/detail/null_output_iterator.hpp
+@@ -11,7 +11,7 @@
+ #ifndef BOOST_SIGNALS2_NULL_OUTPUT_ITERATOR_HPP
+ #define BOOST_SIGNALS2_NULL_OUTPUT_ITERATOR_HPP
+ 
+-#include <boost/function_output_iterator.hpp>
++#include <boost/iterator/function_output_iterator.hpp>
+ 
+ namespace boost
+ {

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -7,6 +7,8 @@
 #include "ui_interface.h"
 #include "util.h"
 
+using namespace boost::placeholders;
+
 using ::testing::StrictMock;
 
 static const std::string CLIENT_VERSION_STR = FormatVersion(CLIENT_VERSION);

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -239,7 +239,7 @@ struct CMutableScCertificate : public CMutableTransactionBase
     CMutableScCertificate();
     CMutableScCertificate(const CScCertificate& tx);
     CMutableScCertificate(const CMutableScCertificate& tx) = default;
-    operator CScCertificate() { return CScCertificate(*this); }
+    operator CScCertificate() { return CScCertificate(static_cast<const CMutableScCertificate&>(*this)); }
     CMutableScCertificate& operator=(const CMutableScCertificate& tx);
     ~CMutableScCertificate() = default;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1091,7 +1091,7 @@ struct CMutableTransaction : public CMutableTransactionBase
 
     CMutableTransaction();
     CMutableTransaction(const CTransaction& tx);
-    operator CTransaction() { return CTransaction(*this); }
+    operator CTransaction() { return CTransaction(static_cast<const CMutableTransaction&>(*this)); }
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -13,8 +13,6 @@
 #include "util.h"             // for LogPrint()
 #include "utilstrencodings.h" // for GetTime()
 
-#include <limits>
-
 #ifndef WIN32
 #include <sys/time.h>
 #endif

--- a/src/random.h
+++ b/src/random.h
@@ -9,6 +9,7 @@
 #include "uint256.h"
 
 #include <functional>
+#include <limits>
 #include <stdint.h>
 
 /**
@@ -18,6 +19,34 @@ void GetRandBytes(unsigned char* buf, size_t num);
 uint64_t GetRand(uint64_t nMax);
 int GetRandInt(int nMax);
 uint256 GetRandHash();
+
+/**
+ * Implementation of a C++ Uniform Random Number Generator, backed by GetRandBytes.
+ */
+class ZcashRandomEngine
+{
+public:
+    typedef uint64_t result_type;
+
+    explicit ZcashRandomEngine() {}
+
+    static constexpr result_type min() {
+        return std::numeric_limits<result_type>::min();
+    }
+    static constexpr result_type max() {
+        return std::numeric_limits<result_type>::max();
+    }
+
+    result_type operator()() {
+        result_type nRand = 0;
+        GetRandBytes((unsigned char*)&nRand, sizeof(nRand));
+        return nRand;
+    }
+
+    double entropy() const noexcept {
+        return 0;
+    }
+};
 
 /**
  * Identity function for MappedShuffle, so that elements retain their original order.

--- a/src/random.h
+++ b/src/random.h
@@ -42,10 +42,6 @@ public:
         GetRandBytes((unsigned char*)&nRand, sizeof(nRand));
         return nRand;
     }
-
-    double entropy() const noexcept {
-        return 0;
-    }
 };
 
 /**

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -6,6 +6,8 @@
 #include "validationinterface.h"
 #include <primitives/certificate.h>
 
+using namespace boost::placeholders;
+
 static CMainSignals g_signals;
 
 CMainSignals& GetMainSignals()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -12,6 +12,7 @@
 #include "init.h"
 #include "main.h"
 #include "net.h"
+#include "random.h"
 #include "script/script.h"
 #include "script/sign.h"
 #include "timedata.h"
@@ -22,6 +23,7 @@
 #include "zen/forkmanager.h"
 using namespace zen;
 
+#include <algorithm>
 #include <assert.h>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -2991,7 +2993,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
     vector<pair<CAmount, pair<const CWalletTransactionBase*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    std::shuffle(vCoins.begin(), vCoins.end(), ZcashRandomEngine());
 
     BOOST_FOREACH(const COutput &output, vCoins)
     {


### PR DESCRIPTION
Zend currently fails to be compiled on the most updated Linux distributions, including Ubuntu 22.

This PR brings some changes to the build system to fix the issue, including:

- Update of the Boost dependency from v1.70 to v1.74
- Set a specific version of the `b2sdk` pip package to avoid Backblaze failured due to breaking updates
- Updated GMP lib dependency to version 6.2.1
- Added C++ 17 as default compilation version
- Updated `libzendoo` (MC Crypto Lib) to always statically include Bzip2 (it currently happens that it includes Bzip2 dynamically if it finds the related shared library installed on the system, consequently breaking the Zend linking phase)
- Fixed the syntax of the check for the presence of `libgmp` in `configure.ac` (the previous syntax was working with v2.69 but stopped from v2.71)

In the future we should discuss if it's the case to update also the continuous integration to compile on Ubuntu 22 (now it's using v18 and v20).