### PR TITLE
update IsInitialBlockDownload in main.cpp

### DIFF
--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -57,7 +57,8 @@ zen_gtest_SOURCES += \
 	gtest/test_sidechain_blocks.cpp \
 	gtest/test_libzendoo.cpp \
 	gtest/test_reindex.cpp \
-	gtest/test_asyncproofverifier.cpp
+	gtest/test_asyncproofverifier.cpp \
+	gtest/test_blockdownload.cpp
 
 if ENABLE_WALLET
 zen_gtest_SOURCES += \

--- a/src/gtest/test_blockdownload.cpp
+++ b/src/gtest/test_blockdownload.cpp
@@ -14,8 +14,6 @@ TEST(initialblockdwnld, checkIBDState) {
     chainActive.SetTip(NULL);
     SelectParams(CBaseChainParams::MAIN);
     const CChainParams& chainParams = Params();
-    constexpr int MAIN_CHAIN_TEST_SIZE = 150000;
-    makeTemporaryMainChain(MAIN_CHAIN_TEST_SIZE);
 
     // 1.
     // fImporting, fReindex and fReindexFast supposedly initialized as false
@@ -74,7 +72,7 @@ TEST(initialblockdwnld, checkIBDState) {
     //
     // Set conditions so that all checks fail, and the end of function is reached so that:
     // - lockIBDState set to true
-    // - funciton returns false
+    // - function returns false
     pindexBestHeader->nTime = GetTime();
     EXPECT_FALSE(IsInitialBlockDownload());
 
@@ -94,30 +92,4 @@ TEST(initialblockdwnld, checkIBDState) {
 
     // Restore active chain tip
     chainActive.SetTip(originalTip);
-}
-
-
-void makeTemporaryMainChain(int trunk_size)
-{
-    // Create genesis block
-    CBlock b = Params().GenesisBlock();
-    CBlockIndex* genesis = AddToBlockIndex(b);
-    auto hashOfPrevBlock = b.GetHash();
-
-    // create the main trunk, from which some forks will possibly stem
-    for (int i = 0; i < trunk_size; i++)
-    {
-        CBlock b;
-        b.nVersion = MIN_BLOCK_VERSION;
-        b.nNonce = uint256(GetRandHash());  
-        b.nBits = arith_uint256(uint256(GetRandHash()).ToString() ).GetCompact();
-        b.hashPrevBlock = hashOfPrevBlock;
-        hashOfPrevBlock = b.GetHash();
-
-        CBlockIndex *bi = AddToBlockIndex(b);
-
-        chainActive.SetTip(bi);
-    }
-
-    return;
 }

--- a/src/gtest/test_blockdownload.cpp
+++ b/src/gtest/test_blockdownload.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "main.h"
+
+using namespace zen;
+
+// Checks IsInitialBlockDownload() conditions and lockIBDState latching to false
+TEST(initialblockdwnld, checkIBDState) {
+    SelectParams(CBaseChainParams::MAIN);
+    const CChainParams& chainParams = Params();
+
+    // 1.
+    // fImporting, fReindex and fReindexFast initialized as false
+    // Check each individual variable and restore its state
+    fImporting   = true; EXPECT_TRUE(IsInitialBlockDownload()); fImporting   = false;
+    fReindex     = true; EXPECT_TRUE(IsInitialBlockDownload()); fReindex     = false;
+    fReindexFast = true; EXPECT_TRUE(IsInitialBlockDownload()); fReindexFast = false;
+
+    // 2.
+    // Expecting that fImporting, fReindex and fReindexFast are false, check if
+    // chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints())
+    fCheckpointsEnabled = true;
+    EXPECT_TRUE(IsInitialBlockDownload());
+
+    // Setting tip of active chain lower than checkpoint
+    auto block1 = CBlockIndex();
+    block1.nHeight = Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()) - 1;
+    chainActive.SetTip(&block1);
+    EXPECT_TRUE(IsInitialBlockDownload());
+
+    // 3a.
+    // increase tip height
+    block1.nHeight = Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()) + 1;
+    chainActive.SetTip(&block1);
+    // Set pindexBestHeader as current tip
+    pindexBestHeader = chainActive.Tip();
+    pindexBestHeader->nHeight += 24 * 6 + 1;
+    pindexBestHeader->nTime = GetTime() + chainParams.MaxTipAge();
+    EXPECT_TRUE(IsInitialBlockDownload());
+
+    // 3b.
+    // restore pindexBestHeader
+    pindexBestHeader = chainActive.Tip();
+    pindexBestHeader->nHeight -= 24 * 6 + 1;
+    // and set pindexBestHeader time
+    pindexBestHeader->nTime = GetTime() - chainParams.MaxTipAge() - 1;
+    EXPECT_TRUE(IsInitialBlockDownload());
+
+    //
+    // Set conditions so that all checks fail, and the end of function is reached so that:
+    // - lockIBDState set to true
+    // - funciton returns false
+    pindexBestHeader->nTime = GetTime();
+    EXPECT_FALSE(IsInitialBlockDownload());
+
+    // Setting back each condition should still return false
+    fImporting = true;
+    EXPECT_FALSE(IsInitialBlockDownload());
+
+    fReindex = true;
+    EXPECT_FALSE(IsInitialBlockDownload());
+
+    fReindexFast = true;
+    EXPECT_FALSE(IsInitialBlockDownload());
+
+    fCheckpointsEnabled = true;
+    block1.nHeight = 0;
+    chainActive.SetTip(&block1);
+    EXPECT_FALSE(IsInitialBlockDownload());
+
+    pindexBestHeader->nTime = 0;
+    EXPECT_FALSE(IsInitialBlockDownload());
+}

--- a/src/gtest/test_blockdownload.cpp
+++ b/src/gtest/test_blockdownload.cpp
@@ -5,35 +5,45 @@
 
 using namespace zen;
 
+void makeTemporaryMainChain(int trunk_size);
+
 // Checks IsInitialBlockDownload() conditions and lockIBDState latching to false
 TEST(initialblockdwnld, checkIBDState) {
+    // Init
+    auto originalTip = chainActive.Tip();
+    chainActive.SetTip(NULL);
     SelectParams(CBaseChainParams::MAIN);
     const CChainParams& chainParams = Params();
+    constexpr int MAIN_CHAIN_TEST_SIZE = 150000;
+    makeTemporaryMainChain(MAIN_CHAIN_TEST_SIZE);
 
     // 1.
-    // fImporting, fReindex and fReindexFast initialized as false
+    // fImporting, fReindex and fReindexFast supposedly initialized as false
     // Check each individual variable and restore its state
     fImporting   = true; EXPECT_TRUE(IsInitialBlockDownload()); fImporting   = false;
     fReindex     = true; EXPECT_TRUE(IsInitialBlockDownload()); fReindex     = false;
     fReindexFast = true; EXPECT_TRUE(IsInitialBlockDownload()); fReindexFast = false;
 
     // 2.
-    // Expecting that fImporting, fReindex and fReindexFast are false, check if
+    // Expecting that fImporting, fReindex and fReindexFast are false, check if:
     // chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints())
     fCheckpointsEnabled = true;
     EXPECT_TRUE(IsInitialBlockDownload());
 
     // Setting tip of active chain lower than checkpoint
-    auto block1 = CBlockIndex();
-    block1.nHeight = Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()) - 1;
-    chainActive.SetTip(&block1);
-    EXPECT_TRUE(IsInitialBlockDownload());
+    CBlockIndex block1;
+    for (size_t blockHeight = 0; blockHeight < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()); ++blockHeight)
+    {
+        block1.nHeight = blockHeight;
+        chainActive.SetTip(&block1);
+        EXPECT_TRUE(IsInitialBlockDownload());
+    }
 
     // 3a.
     // increase tip height
     block1.nHeight = Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()) + 1;
     chainActive.SetTip(&block1);
-    // Set pindexBestHeader as current tip
+    // Set pindexBestHeader as current tip and increase height to trigger condition
     pindexBestHeader = chainActive.Tip();
     pindexBestHeader->nHeight += 24 * 6 + 1;
     pindexBestHeader->nTime = GetTime() + chainParams.MaxTipAge();
@@ -47,6 +57,20 @@ TEST(initialblockdwnld, checkIBDState) {
     pindexBestHeader->nTime = GetTime() - chainParams.MaxTipAge() - 1;
     EXPECT_TRUE(IsInitialBlockDownload());
 
+    // 4.
+    // pindexBestHeader nullptr check
+    auto tempPIndexPtr = pindexBestHeader;
+    pindexBestHeader = nullptr;
+    EXPECT_TRUE(IsInitialBlockDownload());
+    pindexBestHeader = tempPIndexPtr;
+
+    // 5.
+    // chainTip nullptr check
+    auto tempTip = chainActive.Tip();
+    chainActive.SetTip(nullptr);
+    EXPECT_TRUE(IsInitialBlockDownload());
+    chainActive.SetTip(tempTip);
+
     //
     // Set conditions so that all checks fail, and the end of function is reached so that:
     // - lockIBDState set to true
@@ -57,18 +81,43 @@ TEST(initialblockdwnld, checkIBDState) {
     // Setting back each condition should still return false
     fImporting = true;
     EXPECT_FALSE(IsInitialBlockDownload());
-
     fReindex = true;
     EXPECT_FALSE(IsInitialBlockDownload());
-
     fReindexFast = true;
     EXPECT_FALSE(IsInitialBlockDownload());
-
     fCheckpointsEnabled = true;
     block1.nHeight = 0;
     chainActive.SetTip(&block1);
     EXPECT_FALSE(IsInitialBlockDownload());
-
     pindexBestHeader->nTime = 0;
     EXPECT_FALSE(IsInitialBlockDownload());
+
+    // Restore active chain tip
+    chainActive.SetTip(originalTip);
+}
+
+
+void makeTemporaryMainChain(int trunk_size)
+{
+    // Create genesis block
+    CBlock b = Params().GenesisBlock();
+    CBlockIndex* genesis = AddToBlockIndex(b);
+    auto hashOfPrevBlock = b.GetHash();
+
+    // create the main trunk, from which some forks will possibly stem
+    for (int i = 0; i < trunk_size; i++)
+    {
+        CBlock b;
+        b.nVersion = MIN_BLOCK_VERSION;
+        b.nNonce = uint256(GetRandHash());  
+        b.nBits = arith_uint256(uint256(GetRandHash()).ToString() ).GetCompact();
+        b.hashPrevBlock = hashOfPrevBlock;
+        hashOfPrevBlock = b.GetHash();
+
+        CBlockIndex *bi = AddToBlockIndex(b);
+
+        chainActive.SetTip(bi);
+    }
+
+    return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2072,25 +2072,27 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
+static std::atomic<bool> lockIBDState{false};
 bool IsInitialBlockDownload()
 {
+    // Once this function has returned false, it must remain false.
+    // Optimization: pre-test latch before taking the lock.
+    if (lockIBDState.load(std::memory_order_relaxed))
+        return false;
+
     const CChainParams& chainParams = Params();
     LOCK(cs_main);
-    // from commit: https://github.com/HorizenOfficial/zen/commit/0c479520d29cae571dc531e54aa01813daacd1e1
-    if (!ForkManager::getInstance().isAfterChainsplit(chainActive.Height()))
+    if (lockIBDState.load(std::memory_order_relaxed))
         return false;
     if (fImporting || fReindex || fReindexFast)
         return true;
     if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()))
         return true;
-    static bool lockIBDState = false;
-    if (lockIBDState)
-        return false;
-    bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
-            pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
-    if (!state)
-        lockIBDState = true;
-    return state;
+    if ((chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 || pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge()))
+        return true;
+    LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
+    lockIBDState.store(true, std::memory_order_relaxed);
+    return false;
 }
 
 bool fLargeWorkForkFound = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2087,11 +2087,11 @@ bool IsInitialBlockDownload()
         return false;
     if (fImporting || fReindex || fReindexFast)
         return true;
+    if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()))
+        return true;
     if (pindexBestHeader == nullptr)
         return true;
     if (chainActive.Tip() == nullptr)
-        return true;
-    if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()))
         return true;
     if ((chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 || pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge())) 
         return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2072,7 +2072,6 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
-
 bool IsInitialBlockDownload()
 {
     static std::atomic<bool> lockIBDState{false};


### PR DESCRIPTION
modified IsInitialBlockDownload() in main.cpp:
- removed call to isAfterChainsplit() that generated a single warning "0 blocks received in the last 4 hours (96 expected)" at zend launch
- modified syntax to adhere to Zcash codebase