### PR TITLE
Add the dependencies list in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Building from source
     autoconf libtool ncurses-dev unzip git python \
     zlib1g-dev bsdmainutils automake curl
     ```
+    For a detailed list of dependencies, please refer to the [dependencies section](doc/dependencies.md).
+
     2. Cross compilation for Windows target
     ```{r, engine='bash'}
     sudo apt-get install \

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -15,4 +15,4 @@ These are the dependencies needed to build Zen on Linux.
 | [Automake](https://www.gnu.org/software/automake/) | [1.16.5] |
 | [Libtool](https://www.gnu.org/software/libtool/) | [2.4.6] |
 | [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) | [0.29.2] |
-| [hexdump](https://www.gnu.org/software/coreutils/) | [2.37.2] |
+| [hexdump](https://www.kernel.org/pub/linux/utils/util-linux/) | [2.37.2] |

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,0 +1,18 @@
+# Dependencies
+
+These are the dependencies needed to build Zen on Linux.
+
+| Dependency | Tested version |
+| --- | --- |
+| [Make](https://www.gnu.org/software/make/) | [4.3] |
+| [Binutils](https://www.gnu.org/software/binutils/) | [2.38] |
+| [Curl](https://curl.se/) | [7.81] |
+| [Bzip2](https://sourceware.org/bzip2/) | [1.0.8] |
+| [GCC](https://gcc.gnu.org) | [11.2.0] |
+| [Patch](https://savannah.gnu.org/projects/patch/) | [2.7.6] |
+| [Perl](https://www.perl.org/) | [5.34.0] |
+| [Autoconf](https://www.gnu.org/software/autoconf/) | [2.71] |
+| [Automake](https://www.gnu.org/software/automake/) | [1.16.5] |
+| [Libtool](https://www.gnu.org/software/libtool/) | [2.4.6] |
+| [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) | [0.29.2] |
+| [hexdump](https://www.gnu.org/software/coreutils/) | [2.37.2] |


### PR DESCRIPTION
This PR adds a new `dependencies` file in the `doc` section, listing the dependencies needed to build Zen on Linux platforms.

It close #436.