### PR TITLE
Fixed BlockchainTestManager transaction generation

### DIFF
--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -57,7 +57,8 @@ zen_gtest_SOURCES += \
 	gtest/test_sidechain_blocks.cpp \
 	gtest/test_libzendoo.cpp \
 	gtest/test_reindex.cpp \
-	gtest/test_asyncproofverifier.cpp
+	gtest/test_asyncproofverifier.cpp \
+    gtest/test_utils.cpp
 
 if ENABLE_WALLET
 zen_gtest_SOURCES += \

--- a/src/gtest/test_utils.cpp
+++ b/src/gtest/test_utils.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "tx_creation_utils.h"
+#include "zen/forks/fork9_sidechainversionfork.h"
+
+using namespace blockchain_test_utils;
+
+class BlockchainHelperTest: public ::testing::Test
+{
+protected:
+
+    int sidechainForkHeight;
+
+    BlockchainHelperTest()
+    {
+        SidechainFork sidechainFork = SidechainFork();
+        sidechainForkHeight = sidechainFork.getHeight(CBaseChainParams::REGTEST);
+    }
+
+    void SetUp() override
+    {
+        SelectParams(CBaseChainParams::REGTEST);
+    }
+
+    void TearDown() override
+    {
+        chainActive.SetTip(nullptr);
+    }
+};
+
+/**
+ * This test is intended to check that the BlockchainTestManager class behaves as expected
+ * also after calling the "Reset()" function.
+ * In particular, it checks that the transaction creation works when requesting to generate
+ * input coins.
+ */
+TEST_F(BlockchainHelperTest, CoinGeneration)
+{
+    BlockchainTestManager& testManager = BlockchainTestManager::GetInstance();
+
+    // Initialize the sidechain keys
+    testManager.GenerateSidechainTestParameters(ProvingSystem::CoboundaryMarlin, TestCircuitType::Certificate);
+
+    // Go to the last block before the SidechainVersionFork
+    
+    testManager.ExtendChainActiveToHeight(sidechainForkHeight);
+
+    // Create a transaction with any output
+    blockchain_test_utils::CTransactionCreationArguments args;
+    args.fGenerateValidInput = true;
+    args.nVersion = SC_TX_VERSION;
+    args.vsc_ccout.push_back(testManager.CreateScCreationOut(0, ProvingSystem::CoboundaryMarlin));
+    CMutableTransaction tx = testManager.CreateTransaction(args);
+
+    // Check that the transaction is accepted to mempool
+    CValidationState state;
+    EXPECT_EQ(MempoolReturnValue::VALID, testManager.TestAcceptTxToMemoryPool(state, tx));
+
+    // Reset the manager
+    testManager.Reset();
+
+    // Check that the transaction creation (with input coins generation) still works as expected
+    tx = testManager.CreateTransaction(args);
+
+    // Check that the transaction is accepted to mempool
+    EXPECT_EQ(MempoolReturnValue::VALID, testManager.TestAcceptTxToMemoryPool(state, tx));
+}

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -1150,6 +1150,8 @@ void BlockchainTestManager::InitCoinGeneration()
 {
     coinsKey.MakeNewKey(true);
     keystore.AddKey(coinsKey);
+
+    coinsScript.clear();
     coinsScript << OP_DUP << OP_HASH160 << ToByteVector(coinsKey.GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
 }
 


### PR DESCRIPTION
Due to a bug in the BlockchainTestManager class, it was not possible to create transaction that required an automatic input generation after calling the Reset() function.

This commit fixes the bug and adds a unit test to check that the class behaves as expected.