### PR TITLE
Wait for miner threads to exit, when shutdown is requested

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <stdexcept>
 
+#include <boost/thread.hpp>
 #include <boost/optional.hpp>
 
 EhSolverCancelledException solver_cancelled;
@@ -533,6 +534,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
             // 2a) Sort the list
             LogPrint("pow", "- Sorting list\n");
             std::sort(Xt.begin(), Xt.end(), CompareSR(CollisionByteLength));
+            boost::this_thread::interruption_point();
             if (cancelled(ListSorting)) throw solver_cancelled;
 
             LogPrint("pow", "- Finding collisions\n");
@@ -590,6 +592,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
 
             hashLen -= CollisionByteLength;
             lenIndices *= 2;
+            boost::this_thread::interruption_point();
             if (cancelled(RoundEnd)) throw solver_cancelled;
         }
 
@@ -598,6 +601,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
         if (Xt.size() > 1) {
             LogPrint("pow", "- Sorting list\n");
             std::sort(Xt.begin(), Xt.end(), CompareSR(hashLen));
+            boost::this_thread::interruption_point();
             if (cancelled(FinalSorting)) throw solver_cancelled;
             LogPrint("pow", "- Finding collisions\n");
             int i = 0;
@@ -622,6 +626,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
                 i += j;
                 if (cancelled(FinalColliding)) throw solver_cancelled;
             }
+            boost::this_thread::interruption_point();
         } else
             LogPrint("pow", "- List is empty\n");
 
@@ -693,6 +698,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
                 }
                 if (cancelled(PartialSubtreeEnd)) throw solver_cancelled;
             }
+            boost::this_thread::interruption_point();
             if (cancelled(PartialIndexEnd)) throw solver_cancelled;
         }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1190,6 +1190,7 @@ void GenerateBitcoins(bool fGenerate, int nThreads)
     if (minerThreads != NULL)
     {
         minerThreads->interrupt_all();
+        minerThreads->join_all();
         delete minerThreads;
         minerThreads = NULL;
     }


### PR DESCRIPTION
This PR fixes an issue occurring during shutdown, when coin generation is enabled (-gen command line option).

If tromp Equihash solver is selected, the message `zen/depends/x86_64-unknown-linux-gnu/include/boost/thread/pthread/recursive_mutex.hpp:108: void boost::recursive_mutex::lock(): Assertion !posix::pthread_mutex_lock(&m) failed` is printed whenever Ctrl-C is keypressed / SIGINT or SIGTERM signals are received; after that, the application exits. The same behavior occurs sporadically (around once every ten times) under the same conditions when the default Equihash solver is selected.

The issue happens because the main thread ("Horizen-shutoff") ends before the mining threads terminate properly, as the call to `interrupt_all()` in `miner.cpp:GenerateBitcoins()` is non-blocking.

Commit 92a5e1b1e1132bc0b2fcfa34117608bcb80dd45e follows [ZCash PR#3647](https://github.com/zcash/zcash/pull/3647) which adds a call to `join_all()` after the `interrupt_all()`.
This fixes the issue, but quitting time is increased according to the number of threads used for mining, as the flag set by `interrupt_all()` is checked by each miner thread only at the end of each solver run (`boost::this_thread::interruption_point()` in `miner.cpp:BitcoinMiner()`). This is particularly noticeable when using the default miner, as each solver run can take a considerable amount of time. Impact on the tromp miner, instead, is negligible.

Commit dd39b17a3f4ff2a89af16f5bfe0833b876258704 fixes this issue by setting five interruption points inside `EhOptimisedSolve()`, so that mining threads can prematurely exit whenever shutdown is requested. Interruption points have been placed after profiling the function, pursuing a reasonable trade off between call overhead and waiting time.
