### PR TITLE
Ap/python log improv

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -572,27 +572,28 @@ def colorize(color: str, text: str) -> str:
         return text
 
     N_C = "\033[0m"
-    colorshortcuts = ['e', 'r', 'g', 'y', 'b', 'p', 'c', 'n']
+    colorshortcuts = ['e', 'r', 'g', 'y', 'b', 'p', 'c']
     color = color[:1]   # just get the first char of 'color' input param
 
-    if color not in colorshortcuts:
+    if (color == 'n') or (color not in colorshortcuts):
         return text
 
-    COLORS = dict(zip(colorshortcuts, list(range(90, 97)) + [0]))
+    COLORS = dict(zip(colorshortcuts, range(90, 97)))
     return "\033[%d;1m" % COLORS[color] + text + N_C
 
-def mark_logs(msg, nodes, debug = 0, strip_escape = True):
+def strip_escape_seq(text: str) -> str:
+    """
+    Returns the string 'text' stripped from the escape sequences added by colorize()
+    """
+    ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
+    return ansi_escape.sub('', text)
+
+def mark_logs(msg, nodes, debug = 0, color = 'n'):
     if debug == 0:
         return
-    print(msg)
-    # This regex removes all the escape sequences introduced by the colorize function
-    if strip_escape:
-        ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
-        msg_clean = ansi_escape.sub('', msg)
-    else:
-        msg_clean = msg
+    print(colorize(color, msg))
     for node in nodes:
-        node.dbg_log(msg_clean)
+        node.dbg_log(msg)
 
 def get_end_epoch_height(scid, node, epochLen):
     sc_creating_height = node.getscinfo(scid)['items'][0]['createdAtBlockHeight']

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -443,7 +443,7 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
 
     return (txid, signresult["hex"], fee)
 
-def assert_equal(expected, actual, message = ""):
+def assert_equal(actual, expected, message = ""):
     if expected != actual:
         if message:
             message = "%s; " % message 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -447,7 +447,7 @@ def assert_equal(actual, expected, message = ""):
     if expected != actual:
         if message:
             message = "%s; " % message 
-        raise AssertionError("%sexpected: <%s> but was: <%s>" % (message, str(expected), str(actual)))
+        raise AssertionError("%scurrent value [left]: <%s>, expected [right]: <%s>" % (message, str(actual), str(expected)))
 
 def assert_true(condition, message = ""):
     if not condition:
@@ -592,8 +592,9 @@ def mark_logs(msg, nodes, debug = 0, color = 'n'):
     if debug == 0:
         return
     print(colorize(color, msg))
+    stripped_msg = strip_escape_seq(msg)
     for node in nodes:
-        node.dbg_log(msg)
+        node.dbg_log(stripped_msg)
 
 def get_end_epoch_height(scid, node, epochLen):
     sc_creating_height = node.getscinfo(scid)['items'][0]['createdAtBlockHeight']


### PR DESCRIPTION
This pull request improves the readability of logs generated by Python tests by:
- changing the order of parameters passed to assert_equal() to follow a more natural ordering
- adding support for colored log messages printed on terminal
