### PR TITLE
Ap/sc fees list with pointers

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1826,7 +1826,6 @@ bool CCoinsViewCache::UpdateSidechain(const CScCertificate& cert, CBlockUndo& bl
         if (isFirstCertInBlock) {
             scUndoData.pastEpochTopQualityCertView = currentSc.pastEpochTopQualityCertView;
             scUndoData.scFees                      = currentSc.scFees;
-            scUndoData.scFees_v2                   = currentSc.scFees_v2;
             scUndoData.contentBitMask |= CSidechainUndoData::AvailableSections::CROSS_EPOCH_CERT_DATA;
         }
 
@@ -2084,7 +2083,6 @@ bool CCoinsViewCache::RestoreSidechain(const CScCertificate& certToRevert, const
     {
         assert(sidechainUndo.contentBitMask & CSidechainUndoData::AvailableSections::CROSS_EPOCH_CERT_DATA);
         currentSc.scFees                      = sidechainUndo.scFees;
-        currentSc.scFees_v2                   = sidechainUndo.scFees_v2;
         currentSc.pastEpochTopQualityCertView = sidechainUndo.pastEpochTopQualityCertView;
     }
     else if (!currentSc.isNonCeasing() && certToRevert.epochNumber == sidechainUndo.prevTopCommittedCertReferencedEpoch)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1660,8 +1660,8 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             UniValue o(UniValue::VOBJ);
             o.pushKV("forwardTxScFee", ValueFromAmount(entry->forwardTxScFee));
             o.pushKV("mbtrTxScFee", ValueFromAmount(entry->mbtrTxScFee));
-            Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
-            if (casted_entry != nullptr) {
+            std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
+            if (casted_entry) {
                 o.pushKV("submissionHeight", casted_entry->submissionHeight);
             }
             sf.push_back(std::move(o));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1654,26 +1654,19 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
         sc.pushKV("immatureAmounts", ia);
 
         UniValue sf(UniValue::VARR);
-        // v2 non-ceasable sc
-        if (info.isNonCeasing()) {
-            for(const auto& entry: info.scFees_v2)
-            {
-                UniValue o(UniValue::VOBJ);
-                o.pushKV("forwardTxScFee", ValueFromAmount(entry.forwardTxScFee));
-                o.pushKV("mbtrTxScFee", ValueFromAmount(entry.mbtrTxScFee));
-                o.pushKV("submissionHeight", entry.submissionHeight);
-                sf.push_back(std::move(o));
+
+        for(const auto& entry: info.scFees)
+        {
+            UniValue o(UniValue::VOBJ);
+            o.pushKV("forwardTxScFee", ValueFromAmount(entry->forwardTxScFee));
+            o.pushKV("mbtrTxScFee", ValueFromAmount(entry->mbtrTxScFee));
+            Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
+            if (casted_entry != nullptr) {
+                o.pushKV("submissionHeight", casted_entry->submissionHeight);
             }
+            sf.push_back(std::move(o));
         }
-        else {
-            for(const auto& entry: info.scFees)
-            {
-                UniValue o(UniValue::VOBJ);
-                o.pushKV("forwardTxScFee", ValueFromAmount(entry.forwardTxScFee));
-                o.pushKV("mbtrTxScFee", ValueFromAmount(entry.mbtrTxScFee));
-                sf.push_back(std::move(o));
-            }
-        }
+
         sc.pushKV("scFees", sf);
 
         // get unconfirmed data if any

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -782,8 +782,8 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
         while (scFees.size() > max_size)
         {
             const auto& entry = scFees.front();
-            LogPrint("sc", "%s():%d - popping f=%d, m=%d from list, as scFees maxsize has been reached\n",
-                __func__, __LINE__, entry->forwardTxScFee, entry->mbtrTxScFee);
+            LogPrint("sc", "%s():%d - popping %s from list, as scFees maxsize has been reached\n",
+                __func__, __LINE__, entry->ToString().c_str());
             scFees.pop_front();
         }
     }
@@ -796,18 +796,17 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
 
         // We have not found a scFeeData for the current height, so we add a new one and perform all the checks
         // on the container size / element age
-        if (scFeeIt->get() == scFees.end()->get()) {
-           scFees.emplace_back(new Sidechain::ScFeeData_v2(ftScFee, mbtrScFee, blockHeight));
+        if (scFeeIt == scFees.end()) {
+            scFees.emplace_back(new Sidechain::ScFeeData_v2(ftScFee, mbtrScFee, blockHeight));
 
             // as for v1 sidechains
             const size_t max_size { static_cast<size_t>(maxSizeOfScFeesContainers) };
 
             while (scFees.size() > max_size)
             {
-                const std::shared_ptr<Sidechain::ScFeeData_v2> entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(scFees.front());
-
-                LogPrint("sc", "%s():%d - popping f=%d, m=%d, h=%d from list, as scFees maxsize has been reached\n",
-                    __func__, __LINE__, entry->forwardTxScFee, entry->mbtrTxScFee, entry->submissionHeight);
+                const auto& entry = scFees.front();
+                LogPrint("sc", "%s():%d - popping %s from list, as scFees maxsize has been reached\n",
+                    __func__, __LINE__, entry->ToString().c_str());
                 scFees.pop_front();
             }
 
@@ -817,9 +816,8 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
                 const std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
                 const bool testCondition = (casted_entry->submissionHeight <= threshold);
                 if (testCondition)
-                    LogPrint("sc", "%s():%d - popping f=%d, m=%d, h=%d from list, as entry is too old (threshold height was %d)\n",
-                        __func__, __LINE__, casted_entry->forwardTxScFee, casted_entry->mbtrTxScFee,
-                        casted_entry->submissionHeight, threshold);
+                    LogPrint("sc", "%s():%d - popping %s from list, as entry is too old (threshold height was %d)\n",
+                        __func__, __LINE__, casted_entry->ToString().c_str(), threshold);
                 return testCondition;
             });
 
@@ -839,13 +837,7 @@ void CSidechain::DumpScFees() const
 {
 
     for (const auto& entry : scFees) {
-        std::cout << "[" << std::setw(2) << entry->forwardTxScFee
-                  << "/" << std::setw(2) << entry->mbtrTxScFee;
-        const std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
-        if (casted_entry) {
-            std::cout << "/" << std::setw(2) << casted_entry->submissionHeight;
-        }
-        std::cout << "]" << std::endl;
+        std::cout << entry->ToString() << std::endl;
     }
 
 }

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -842,7 +842,7 @@ void CSidechain::DumpScFees() const
         std::cout << "[" << std::setw(2) << entry->forwardTxScFee
                   << "/" << std::setw(2) << entry->mbtrTxScFee;
         const std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
-        if (casted_entry != nullptr) {
+        if (casted_entry) {
             std::cout << "/" << std::setw(2) << casted_entry->submissionHeight;
         }
         std::cout << "]" << std::endl;

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -791,7 +791,9 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
     else {
         auto scFeeIt = std::find_if(scFees.begin(), scFees.end(),
             [&blockHeight](const std::shared_ptr<Sidechain::ScFeeData> & scFeeElem) {
-                return std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(scFeeElem)->submissionHeight == blockHeight;
+                const std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(scFeeElem);
+                assert(casted_entry);
+                return casted_entry->submissionHeight == blockHeight;
             });
 
         // We have not found a scFeeData for the current height, so we add a new one and perform all the checks
@@ -806,6 +808,7 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
             const auto threshold{blockHeight - this->maxSizeOfScFeesContainers};
             scFees.remove_if([threshold](std::shared_ptr<Sidechain::ScFeeData> entry) {
                 const std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
+                assert(casted_entry);
                 const bool testCondition = (casted_entry->submissionHeight <= threshold);
                 if (testCondition)
                     LogPrint("sc", "%s():%d - popping %s from list, as entry is too old (threshold height was %d)\n",
@@ -828,11 +831,9 @@ void CSidechain::UpdateScFees(const CScCertificateView& certView, int blockHeigh
 
 void CSidechain::DumpScFees() const
 {
-
     for (const auto& entry : scFees) {
         std::cout << entry->ToString() << std::endl;
     }
-
 }
 
 CAmount CSidechain::GetMinFtScFee() const

--- a/src/sc/sidechain.h
+++ b/src/sc/sidechain.h
@@ -198,7 +198,7 @@ public:
             if (isNonCeasing()) {
                 std::list<Sidechain::ScFeeData_v2> tempList;
                 for (const auto& entry : scFees) {
-                    Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
+                    std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
                     tempList.emplace_back(casted_entry->forwardTxScFee, casted_entry->mbtrTxScFee, casted_entry->submissionHeight);
                 }
                 READWRITE(tempList);

--- a/src/sc/sidechaintypes.h
+++ b/src/sc/sidechaintypes.h
@@ -508,7 +508,7 @@ struct ScFeeData_v2 : public ScFeeData {
         return ScFeeData::operator==(rhs) && submissionHeight == rhs.submissionHeight;
     }
 
-    virtual std::string ToString() const
+    std::string ToString() const override
     {
         std::stringstream res;
         res << ScFeeData::ToString();

--- a/src/sc/sidechaintypes.h
+++ b/src/sc/sidechaintypes.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <mutex>
+#include <iomanip> // std::setw
 
 #include <boost/unordered_map.hpp>
 #include <boost/variant.hpp>
@@ -480,6 +481,13 @@ struct ScFeeData
     {
         return (forwardTxScFee == rhs.forwardTxScFee && mbtrTxScFee == rhs.mbtrTxScFee);
     }
+
+    virtual std::string ToString() const
+    {
+        std::stringstream res;
+        res << "[" << std::setw(2) << forwardTxScFee << "/" << std::setw(2) << mbtrTxScFee << "]";
+        return res.str();
+    }
 };
 
 struct ScFeeData_v2 : public ScFeeData {
@@ -498,6 +506,15 @@ struct ScFeeData_v2 : public ScFeeData {
     inline bool operator==(const ScFeeData_v2& rhs) const
     {
         return ScFeeData::operator==(rhs) && submissionHeight == rhs.submissionHeight;
+    }
+
+    virtual std::string ToString() const
+    {
+        std::stringstream res;
+        res << ScFeeData::ToString();
+        res.seekp(-1, std::ios_base::end); // overwrite closing ]
+        res << " /" << std::setw(2) << submissionHeight << "]";
+        return res.str();
     }
 };
 

--- a/src/sc/sidechaintypes.h
+++ b/src/sc/sidechaintypes.h
@@ -461,12 +461,12 @@ enum class ScFeeCheckFlag {
     MINIMUM_IN_A_RANGE
 };
 
-typedef struct sScFeeData_tag
+struct ScFeeData
 {
     CAmount forwardTxScFee;
     CAmount mbtrTxScFee;
-    sScFeeData_tag(): forwardTxScFee(0), mbtrTxScFee(0) {}
-    sScFeeData_tag(CAmount f, CAmount m): forwardTxScFee(f), mbtrTxScFee(m) {}
+    ScFeeData(): forwardTxScFee(0), mbtrTxScFee(0) {}
+    ScFeeData(CAmount f, CAmount m): forwardTxScFee(f), mbtrTxScFee(m) {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -476,12 +476,11 @@ typedef struct sScFeeData_tag
         READWRITE(mbtrTxScFee);
     }
 
-    inline bool operator==(const sScFeeData_tag& rhs) const
+    virtual inline bool operator==(const ScFeeData& rhs) const
     {
         return (forwardTxScFee == rhs.forwardTxScFee && mbtrTxScFee == rhs.mbtrTxScFee);
     }
-
-} ScFeeData;
+};
 
 struct ScFeeData_v2 : public ScFeeData {
     int submissionHeight;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <utility>
 #include <vector>
+#include <memory>
+#include <type_traits> // void_t
 
 #include <boost/array.hpp>
 #include <boost/optional.hpp>
@@ -189,7 +191,8 @@ enum
     SER_GETHASH         = (1 << 2),
 };
 
-#define READWRITE(obj)      (::SerReadWrite(s, (obj), nType, nVersion, ser_action))
+#define READWRITE(obj)                      (::SerReadWrite(s, (obj), nType, nVersion, ser_action))
+#define READWRITE_POLYMORPHIC(obj, b, d)    (::SerReadWrite<decltype(s), b, decltype(obj), d>(s, (obj), nType, nVersion, ser_action))
 
 #define READWRITE_VARINT_WITH_SIGN(obj)                                             \
     if (ser_action.ForRead()) {                                                     \
@@ -524,6 +527,34 @@ template<typename I>
 CVarInt<I> WrapVarInt(I& n) { return CVarInt<I>(n); }
 
 /**
+ * Smart pointers, optionally used for polymorphic types
+ */
+
+template<typename Stream, typename T, typename D>
+void Unserialize(Stream& os, const std::shared_ptr<T>& p, int nType, int nVersion)
+{
+    std::shared_ptr<D> d = std::dynamic_pointer_cast<D>(p);
+    if (d) {
+        Unserialize(os, *d, nType, nVersion);
+    }
+    else {
+        Unserialize(os, *p, nType, nVersion);
+    }
+}
+
+template<typename Stream, typename T, typename D>
+void Serialize(Stream& os, const std::shared_ptr<T>& p, int nType, int nVersion)
+{
+    std::shared_ptr<D> d = std::dynamic_pointer_cast<D>(p);
+    if (d) {
+        Serialize(os, *d, nType, nVersion);
+    }
+    else {
+        Serialize(os, *p, nType, nVersion);
+    }
+}
+
+/**
  * Forward declarations
  */
 
@@ -543,7 +574,7 @@ template<typename T, typename A, typename V> unsigned int GetSerializeSize_impl(
 template<typename T, typename A> inline unsigned int GetSerializeSize(const std::vector<T, A>& v, int nType, int nVersion);
 template<typename Stream, typename T, typename A> void Serialize_impl(Stream& os, const std::vector<T, A>& v, int nType, int nVersion, const unsigned char&);
 template<typename Stream, typename T, typename A, typename V> void Serialize_impl(Stream& os, const std::vector<T, A>& v, int nType, int nVersion, const V&);
-template<typename Stream, typename T, typename A> inline void Serialize(Stream& os, const std::vector<T, A>& v, int nType, int nVersion);
+template<typename Stream, typename T, typename A> inline std::enable_if_t<std::is_same_v<typename A::value_type,T>> Serialize(Stream& os, const std::vector<T, A>& v, int nType, int nVersion);
 template<typename Stream, typename T, typename A> void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const unsigned char&);
 template<typename Stream, typename T, typename A, typename V> void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const V&);
 template<typename Stream, typename T, typename A> inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion);
@@ -591,14 +622,14 @@ template<typename Stream, typename K, typename T, typename Pred, typename A> voi
  * set
  */
 template<typename K, typename Pred, typename A> unsigned int GetSerializeSize(const std::set<K, Pred, A>& m, int nType, int nVersion);
-template<typename Stream, typename K, typename Pred, typename A> void Serialize(Stream& os, const std::set<K, Pred, A>& m, int nType, int nVersion);
+template<typename Stream, typename K, typename Pred, typename A> std::enable_if_t<std::is_same_v<typename A::value_type,K>> Serialize(Stream& os, const std::set<K, Pred, A>& m, int nType, int nVersion);
 template<typename Stream, typename K, typename Pred, typename A> void Unserialize(Stream& is, std::set<K, Pred, A>& m, int nType, int nVersion);
 
 /**
  * list
  */
 template<typename T, typename A> unsigned int GetSerializeSize(const std::list<T, A>& m, int nType, int nVersion);
-template<typename Stream, typename T, typename A> void Serialize(Stream& os, const std::list<T, A>& m, int nType, int nVersion);
+template<typename Stream, typename T, typename A> std::enable_if_t<std::is_same_v<typename A::value_type,T>> Serialize(Stream& os, const std::list<T, A>& m, int nType, int nVersion);
 template<typename Stream, typename T, typename A> void Unserialize(Stream& is, std::list<T, A>& m, int nType, int nVersion);
 
 
@@ -707,7 +738,7 @@ void Serialize_impl(Stream& os, const std::vector<T, A>& v, int nType, int nVers
 }
 
 template<typename Stream, typename T, typename A>
-inline void Serialize(Stream& os, const std::vector<T, A>& v, int nType, int nVersion)
+inline std::enable_if_t<std::is_same_v<typename A::value_type,T>> Serialize(Stream& os, const std::vector<T, A>& v, int nType, int nVersion)
 {
     Serialize_impl(os, v, nType, nVersion, T());
 }
@@ -962,7 +993,7 @@ unsigned int GetSerializeSize(const std::set<K, Pred, A>& m, int nType, int nVer
 }
 
 template<typename Stream, typename K, typename Pred, typename A>
-void Serialize(Stream& os, const std::set<K, Pred, A>& m, int nType, int nVersion)
+std::enable_if_t<std::is_same_v<typename A::value_type,K>> Serialize(Stream& os, const std::set<K, Pred, A>& m, int nType, int nVersion)
 {
     WriteCompactSize(os, m.size());
     for (typename std::set<K, Pred, A>::const_iterator it = m.begin(); it != m.end(); ++it)
@@ -998,7 +1029,8 @@ unsigned int GetSerializeSize(const std::list<T, A>& l, int nType, int nVersion)
 }
 
 template<typename Stream, typename T, typename A>
-void Serialize(Stream& os, const std::list<T, A>& l, int nType, int nVersion)
+std::enable_if_t<std::is_same_v<typename A::value_type,T>> // try to enforce that A is an allocator for type T
+Serialize(Stream& os, const std::list<T, A>& l, int nType, int nVersion)
 {
     WriteCompactSize(os, l.size());
     for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
@@ -1019,6 +1051,34 @@ void Unserialize(Stream& is, std::list<T, A>& l, int nType, int nVersion)
     }
 }
 
+
+/**
+ * Collections w/ iterators (vector, list, dequeue...) with type casting.
+ * For example, this is useful in combination with smart pointers for polymorphism.
+ */
+
+template<typename Stream, typename T, typename C, typename D>
+void Serialize(Stream& os, const C& l, int nType, int nVersion)
+{
+    WriteCompactSize(os, l.size());
+    for (typename C::const_iterator it = l.begin(); it != l.end(); ++it) {
+        Serialize<Stream, T, D>(os, (*it), nType, nVersion);
+    }
+}
+
+template<typename Stream, typename T, typename C, typename D>
+std::void_t<typename C::value_type> // enforce that C has member value_type, as it happens for STL collections
+Unserialize(Stream& is, C& l, int nType, int nVersion)
+{
+    l.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    typename C::iterator it = l.begin();
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        l.emplace_back(new D());
+        Unserialize<Stream, T, D>(is, l.back(), nType, nVersion);
+    }
+}
 
 
 /**
@@ -1043,6 +1103,19 @@ template<typename Stream, typename T>
 inline void SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSerActionUnserialize ser_action)
 {
     ::Unserialize(s, obj, nType, nVersion);
+}
+
+
+template<typename Stream, typename T, typename C, typename D>
+inline void SerReadWrite(Stream& s, const C& obj, int nType, int nVersion, CSerActionSerialize ser_action)
+{
+    ::Serialize<Stream, T, C, D>(s, obj, nType, nVersion);
+}
+
+template<typename Stream, typename T, typename C, typename D>
+inline void SerReadWrite(Stream& s, C& obj, int nType, int nVersion, CSerActionUnserialize ser_action)
+{
+    ::Unserialize<Stream, T, C, D>(s, obj, nType, nVersion);
 }
 
 

--- a/src/undo.h
+++ b/src/undo.h
@@ -310,6 +310,7 @@ struct CSidechainUndoData
              res += strprintf("appliedMaturedAmount=%d.%08d\n", appliedMaturedAmount / COIN, appliedMaturedAmount % COIN);
 
         if (contentBitMask & AvailableSections::CROSS_EPOCH_CERT_DATA)
+        {
             res += strprintf("pastEpochTopQualityCertView=%s\n", pastEpochTopQualityCertView.ToString());
             res += strprintf("scFees.size()=%u\n", scFees.size());
             for(const auto& entry: scFees) {
@@ -321,6 +322,7 @@ struct CSidechainUndoData
                     res += strprintf("submissionHeight=%d\n", casted_entry->submissionHeight);
                 }
             }
+        }
 
         if (contentBitMask & AvailableSections::ANY_EPOCH_CERT_DATA)
         {

--- a/src/undo.h
+++ b/src/undo.h
@@ -226,25 +226,10 @@ struct CSidechainUndoData
         {
             ::Serialize(s, pastEpochTopQualityCertView, nType, nVersion);
             // Manually serialize scFees list
-/*
-            WriteCompactSize(s, scFees.size());
-            for (const auto& entry : scFees) {
-                Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
-                if (casted_entry == nullptr) {
-                    ::Serialize(s, (entry.get()->forwardTxScFee), nType, nVersion);
-                    ::Serialize(s, (entry.get()->mbtrTxScFee), nType, nVersion);
-                }
-                else {
-                    ::Serialize(s, (casted_entry->forwardTxScFee), nType, nVersion);
-                    ::Serialize(s, (casted_entry->mbtrTxScFee), nType, nVersion);
-                    ::Serialize(s, (casted_entry->submissionHeight), nType, nVersion);
-                }
-            }
-*/
             if (contentBitMask & AvailableSections::NONCEASING_CERT_DATA) {
                 std::list<Sidechain::ScFeeData_v2> tempList;
                 for (const auto& entry : scFees) {
-                    Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
+                    std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
                     tempList.emplace_back(casted_entry->forwardTxScFee, casted_entry->mbtrTxScFee, casted_entry->submissionHeight);
                 }
                 ::Serialize(s, tempList, nType, nVersion);
@@ -294,27 +279,6 @@ struct CSidechainUndoData
         {
             ::Unserialize(s, pastEpochTopQualityCertView, nType, nVersion);
             // Manually deserialize scFees list
-/*
-            scFees.clear();
-            unsigned int nSize = ReadCompactSize(s);
-            for (unsigned int i = 0; i < nSize; i++) {
-                if (contentBitMask & AvailableSections::NONCEASING_CERT_DATA) {
-                    Sidechain::ScFeeData_v2 item;
-                    ::Unserialize(s, item.forwardTxScFee, nType, nVersion);
-                    ::Unserialize(s, item.mbtrTxScFee, nType, nVersion);
-                    ::Unserialize(s, item.submissionHeight, nType, nVersion);
-                    scFees.emplace_back(new Sidechain::ScFeeData_v2(item.forwardTxScFee,
-                                item.mbtrTxScFee, item.submissionHeight));
-                }
-                else {
-                    Sidechain::ScFeeData item;
-                    ::Unserialize(s, item.forwardTxScFee, nType, nVersion);
-                    ::Unserialize(s, item.mbtrTxScFee, nType, nVersion);
-                    scFees.emplace_back(new Sidechain::ScFeeData(item.forwardTxScFee,
-                                item.mbtrTxScFee));
-                }
-            }
-*/
             if (contentBitMask & AvailableSections::NONCEASING_CERT_DATA) {
                 std::list<Sidechain::ScFeeData_v2> tempList;
                 ::Unserialize(s, tempList, nType, nVersion);
@@ -373,8 +337,8 @@ struct CSidechainUndoData
                 res += strprintf("scFtFee=%d.%08d - ", entry->forwardTxScFee / COIN, entry->forwardTxScFee % COIN);
                 res += strprintf("scMbtrFee=%d.%08d\n", entry->mbtrTxScFee / COIN, entry->mbtrTxScFee % COIN);
                 // Only for v2 non-ceasable sidechains
-                Sidechain::ScFeeData_v2 *casted_entry = dynamic_cast<Sidechain::ScFeeData_v2*>(entry.get());
-                if (casted_entry != nullptr) {
+                std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
+                if (casted_entry) {
                     res += strprintf("submissionHeight=%d\n", casted_entry->submissionHeight);
                 }
             }

--- a/src/undo.h
+++ b/src/undo.h
@@ -225,20 +225,11 @@ struct CSidechainUndoData
         if (contentBitMask & AvailableSections::CROSS_EPOCH_CERT_DATA)
         {
             ::Serialize(s, pastEpochTopQualityCertView, nType, nVersion);
-            // Manually serialize scFees list
             if (contentBitMask & AvailableSections::NONCEASING_CERT_DATA) {
-                std::list<Sidechain::ScFeeData_v2> tempList;
-                for (const auto& entry : scFees) {
-                    std::shared_ptr<Sidechain::ScFeeData_v2> casted_entry = std::dynamic_pointer_cast<Sidechain::ScFeeData_v2>(entry);
-                    tempList.emplace_back(casted_entry->forwardTxScFee, casted_entry->mbtrTxScFee, casted_entry->submissionHeight);
-                }
-                ::Serialize(s, tempList, nType, nVersion);
-            } else {
-                std::list<Sidechain::ScFeeData> tempList;
-                for (const auto& entry : scFees) {
-                    tempList.emplace_back(entry->forwardTxScFee, entry->mbtrTxScFee);
-                }
-                ::Serialize(s, tempList, nType, nVersion);
+                ::Serialize<decltype(s), Sidechain::ScFeeData, decltype(scFees), Sidechain::ScFeeData_v2>(s, scFees, nType, nVersion);
+            }
+            else {
+                ::Serialize<decltype(s), Sidechain::ScFeeData, decltype(scFees), Sidechain::ScFeeData>(s, scFees, nType, nVersion);
             }
         }
         if (contentBitMask & AvailableSections::ANY_EPOCH_CERT_DATA)
@@ -278,23 +269,11 @@ struct CSidechainUndoData
         if (contentBitMask & AvailableSections::CROSS_EPOCH_CERT_DATA)
         {
             ::Unserialize(s, pastEpochTopQualityCertView, nType, nVersion);
-            // Manually deserialize scFees list
             if (contentBitMask & AvailableSections::NONCEASING_CERT_DATA) {
-                std::list<Sidechain::ScFeeData_v2> tempList;
-                ::Unserialize(s, tempList, nType, nVersion);
-                scFees.clear();
-                for (const auto& entry : tempList) {
-                    scFees.emplace_back(new Sidechain::ScFeeData_v2(entry.forwardTxScFee,
-                        entry.mbtrTxScFee, entry.submissionHeight));
-                }
-            } else {
-                std::list<Sidechain::ScFeeData> tempList;
-                ::Unserialize(s, tempList, nType, nVersion);
-                scFees.clear();
-                for (const auto& entry : tempList) {
-                    scFees.emplace_back(new Sidechain::ScFeeData(entry.forwardTxScFee,
-                        entry.mbtrTxScFee));
-                }
+                ::Unserialize<decltype(s), Sidechain::ScFeeData, decltype(scFees), Sidechain::ScFeeData_v2>(s, scFees, nType, nVersion);
+            }
+            else {
+                ::Unserialize<decltype(s), Sidechain::ScFeeData, decltype(scFees), Sidechain::ScFeeData>(s, scFees, nType, nVersion);
             }
 
         }


### PR DESCRIPTION
This pull request updates the previous one dealing with the management of scFees list for v2 non-ceasible sidechains.
The major updates deals with getting rid of the duplicate `scFees_v2` list, in favor of using a unified container for all the sidechains, regardless of their version.
The scFees list now cointains pointers to `Sidechain::ScFeeData` structs, which can be polymorphically instantiated as `Sidechain::ScFeeData_v2` elements at runtime, depending on the sidechain version.