### PR TITLE
Consider spent tx in p2p

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -136,6 +136,7 @@ testScripts=(
   'sc_rpc_cmds_json_output.py'
   'sc_getscgenesisinfo.py'
   'fundaddresses.py'
+  'p2p_ignore_spent_tx.py'
 );
 testScriptsExt=(
   'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/p2p_ignore_spent_tx.py
+++ b/qa/rpc-tests/p2p_ignore_spent_tx.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
+    wait_and_assert_operationid_status
+import os
+import time
+from decimal import Decimal
+
+DEBUG_MODE = 1
+NUMB_OF_NODES = 3
+FEE = Decimal("0.0001")
+
+class old_tx_ignored(BitcoinTestFramework):
+    alert_filename = None
+
+    def setup_chain(self, split=False):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
+        with open(self.alert_filename, 'w'):
+            pass  # Just open then close to create zero-length file
+
+    def setup_network(self, split=False):
+        self.nodes = []
+
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args=
+            [['-debug=mempool', '-debug=net', '-forcelocalban']] * NUMB_OF_NODES)
+
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        sync_blocks(self.nodes[1:NUMB_OF_NODES])
+        sync_mempools(self.nodes[1:NUMB_OF_NODES])
+        self.sync_all()
+
+    def run_test(self):
+        '''
+        This test checks that nodes do not ask for tx that they already received in the past, if such tx have been already spent.
+        Such scenario not only incurs unnecessary overhead, with extra p2p messages being sent for no reason,
+        but may even lead to honest nodes being banned, in case a tx is re-sent after a fork change.
+        This is a corner case which should be extremely unlikely in real world, but reproducible in tests.
+
+        CHECKLIST:
+        - when multiple peers send inv for a tx, make sure that even if tx is spent after it has been received, later
+        requests for the same tx are blocked before any p2p msg is sent
+        '''
+
+        z_addr_node0 = self.nodes[0].z_getnewaddress()
+        z_addr_node2 = self.nodes[2].z_getnewaddress()
+
+        mark_logs("Node0 generates {} blocks".format(101), self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        mark_logs("Node0 creates and confirms tx0", self.nodes, DEBUG_MODE)
+        opid = self.nodes[0].z_shieldcoinbase("*", z_addr_node0)['opid']
+        txid = wait_and_assert_operationid_status(self.nodes[0], opid)
+        mark_logs("tx0_id: {}".format(txid), self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        mark_logs("Node1 and Node2 receive inv for tx0 from their peers, scheduling getdata at times now and now+2min", self.nodes, DEBUG_MODE)
+
+        mark_logs("Node0 creates another tx (to Node2) to spend tx0 completely", self.nodes, DEBUG_MODE)
+        available = self.nodes[0].z_getbalance(z_addr_node0)
+        print(available)
+        opid = self.nodes[0].z_sendmany(z_addr_node0, [{"address": z_addr_node2, "amount": available-FEE}], 1, FEE)
+        wait_and_assert_operationid_status(self.nodes[0], opid)
+        self.sync_all()
+        
+        mark_logs("Node0 generates {} blocks to reach GROTH height".format(100), self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(100)
+        self.sync_all()
+
+        mark_logs("Sleep for 2min to let Node1 and Node2 reach the second scheduled event to ask for tx0 data", self.nodes, DEBUG_MODE)
+        time.sleep(120)
+
+        mark_logs("Check ban scores", self.nodes, DEBUG_MODE)
+        for p in self.nodes[1].getpeerinfo():
+            assert_equal(p['banscore'], 0)
+
+if __name__ == '__main__':
+    old_tx_ignored().main()
+

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -46,20 +46,22 @@ public:
         }
         return;
     }
-    void erase(const key_type& k)
+    size_t erase(const key_type& k)
     {
         iterator itTarget = map.find(k);
         if (itTarget == map.end())
-            return;
+            return 0;
         std::pair<rmap_iterator, rmap_iterator> itPair = rmap.equal_range(itTarget->second);
-        for (rmap_iterator it = itPair.first; it != itPair.second; ++it)
+        for (rmap_iterator it = itPair.first; it != itPair.second; ++it) {
             if (it->second == itTarget) {
                 rmap.erase(it);
                 map.erase(itTarget);
-                return;
+                return 1; // be consistent with std::map return value
             }
+        }
         // Shouldn't ever get here
         assert(0);
+        return 0;
     }
     void update(const_iterator itIn, const mapped_type& v)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6792,6 +6792,7 @@ void ProcessTxBaseMsg(const CTransactionBase& txBase, CNode* pfrom)
 
     pfrom->setAskFor.erase(inv.hash);
     mapAlreadyAskedFor.erase(inv);
+    mapAlreadyReceived.insert(std::make_pair(inv, GetTimeMicros()));
 
     MempoolReturnValue res = MempoolReturnValue::INVALID;
     CValidationState state;
@@ -8150,7 +8151,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
         {
             const CInv& inv = (*pto->mapAskFor.begin()).second;
-            if (!AlreadyHave(inv))
+            if (!AlreadyHave(inv) && mapAlreadyReceived.find(inv) == mapAlreadyReceived.end())
             {
                 if (fDebug)
                     LogPrint("net", "%s():%d - Requesting %s peer=%d\n", __func__, __LINE__, inv.ToString(), pto->id);

--- a/src/net.h
+++ b/src/net.h
@@ -66,6 +66,8 @@ static const bool DEFAULT_LISTEN = true;
 static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 /** The maximum number of entries in setAskFor (larger due to getdata latency)*/
 static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
+/** The maximum number of entries in mapAlreadyReceived (8 peers * 2min additional delay each * 100tx/s)*/
+static const size_t MAPRECEIVED_MAX_SZ = 8 * 120 * 100;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 
@@ -169,6 +171,7 @@ extern std::map<CInv, CDataStream> mapRelay;
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
 extern limitedmap<CInv, int64_t> mapAlreadyAskedFor;
+extern limitedmap<CInv, int64_t> mapAlreadyReceived;
 
 extern std::vector<std::string> vAddedNodes;
 extern CCriticalSection cs_vAddedNodes;


### PR DESCRIPTION
This patch makes sure that zend does not ask for tx data to its peers for tx which have already been received and spent.