### PR TITLE
Cache built dependencies for faster CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,8 @@ os: linux
         - depends/sources
         - depends/work
         - depends/x86_64-linux-gnu
-        - depends/x86_64-unknown-linux.gnu
+        - depends/x86_64-unknown-linux-gnu
+        - depends/x86_64-w64-mingw32
     script:
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/build/build_${TRAVIS_CPU_ARCH}_${DOCKER_TARGET_OS}_${DOCKER_FROM}.sh"
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/push_archive.sh ${B2_UL_COMPRESS_FOLDER} ${B2_UL_FILENAME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,6 +264,11 @@ os: linux
     cache:
       directories:
         - "$HOME/.ccache"
+        - depends/built
+        - depends/sources
+        - depends/work
+        - depends/x86_64-linux-gnu
+        - depends/x86_64-unknown-linux.gnu
     script:
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/build/build_${TRAVIS_CPU_ARCH}_${DOCKER_TARGET_OS}_${DOCKER_FROM}.sh"
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/push_archive.sh ${B2_UL_COMPRESS_FOLDER} ${B2_UL_FILENAME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ os: linux
       - DOCKER_FROM=ubuntu_bionic
       - DOCKER_IS_DEB=true
       - MAKEFLAGS="--legacy-cpu"
-
   - &docker_amd64_linux_ubuntu_jammy
     env:
       - DOCKER_ARCH=amd64
@@ -30,7 +29,6 @@ os: linux
       - DOCKER_FROM=ubuntu_jammy
       - DOCKER_IS_DEB=true
       - MAKEFLAGS="--legacy-cpu"
-
   - &docker_amd64_windows_ubuntu_bionic
     env:
       - DOCKER_ARCH=amd64
@@ -267,9 +265,7 @@ os: linux
         - depends/built
         - depends/sources
         - depends/work
-        - depends/x86_64-linux-gnu
-        - depends/x86_64-unknown-linux-gnu
-        - depends/x86_64-w64-mingw32
+        - depends/x86_64*
     script:
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/build/build_${TRAVIS_CPU_ARCH}_${DOCKER_TARGET_OS}_${DOCKER_FROM}.sh"
       - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/push_archive.sh ${B2_UL_COMPRESS_FOLDER} ${B2_UL_FILENAME}"
@@ -373,6 +369,10 @@ jobs:
       cache:
         directories:
           - "$HOME/.ccache"
+          - depends/built
+          - depends/sources
+          - depends/work
+          - depends/x86_64*
       script:
         - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/get_archive.sh ${B2_DL_DECOMPRESS_FOLDER} ${B2_DL_FILENAME}"
         - bash -c "${TRAVIS_BUILD_DIR}/contrib/ci-horizen/scripts/common/travis_stay_alive.sh"
@@ -479,4 +479,3 @@ jobs:
       if: env(SKIP_OSX) != true
       <<: *test_osx_xcode9_4
       <<: *amd64_osx_xcode9_4_rpc-tests_11
-

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ Running Regression Tests
     sudo apt-get install \
     python python-dev python-pip python-setuptools \
     python-wheel python-wheel-common python-zmq
-    sudo pip install --upgrade pyblake2 websocket-client
+    pip install --upgrade pyblake2 websocket-client requests
     ```
 
     2. MacOS
     ```{r, engine='bash'}
     brew install python@2
-    sudo pip install --upgrade pyblake2 pyzmq websocket-client
+    pip install --upgrade pyblake2 pyzmq websocket-client requests
     ```
 
 2. Start test suite


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/15280851/207834804-596fb935-3d23-49d5-bbc2-44c03c764db3.png)

After
![image](https://user-images.githubusercontent.com/15280851/207835015-cf00a501-8a84-42a1-b7d5-1acd7d0935c9.png)

Also amended README about how to run `pip install`