### PR TITLE
listtransactions.py test sporadic failure

### DIFF
--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -10,7 +10,7 @@ from test_framework.test_framework import ForkHeights
 from decimal import Decimal
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_true, assert_equal
-from test_framework.mc_test.mc_test import *
+from test_framework.mc_test.mc_test import CertTestUtils, generate_random_field_element_hex
 
 
 def check_array_result(object_array, to_match, expected):
@@ -29,11 +29,10 @@ def check_array_result(object_array, to_match, expected):
             continue
         for key, value in expected.items():
             if item[key] != value:
-                raise AssertionError("%s : expected %s=%s" % (str(item), str(key), str(value)))
+                raise AssertionError(f"{str(item)} : expected {str(key)}={str(value)}")
             num_matched = num_matched + 1
     if num_matched == 0:
-        raise AssertionError("No objects matched %s" % (str(to_match)))
-
+        raise AssertionError(f"No objects matched {str(to_match)}")
 
 class ListTransactionsTest(BitcoinTestFramework):
 
@@ -350,7 +349,7 @@ class ListTransactionsTest(BitcoinTestFramework):
                     break
 
         assert_true(len(fromaddr))
-        result_node1_latest = self.nodes[1].listtransactions("*", 1, 0, False, fromaddr)
+        self.nodes[1].listtransactions("*", 1, 0, False, fromaddr)
         
         sidechain_address = "0000000000000000000000000000000000000000000000000000000051dec4a1"
         fee = 0.00025

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -59,6 +59,7 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
+        self.sync_all()
         check_array_result(self.nodes[0].listtransactions(),
                            {"txid": txid, "category": "send"},
                            {"amount": Decimal("-0.2")})
@@ -100,6 +101,7 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         # Below tests about filtering by address
         self.nodes[0].generate(10)
+        self.sync_all()
         address = self.nodes[1].getnewaddress()
 
         # simple send 1 to address and verify listtransaction returns this tx with address in input

--- a/qa/rpc-tests/run_until_fails.py
+++ b/qa/rpc-tests/run_until_fails.py
@@ -8,10 +8,10 @@
 # Example usage:
 # python run_until_fails.py addressindex.py
 
-import os.path
 import subprocess
 import sys
 
+from datetime import datetime
 from os import path
 
 if len(sys.argv) != 2:
@@ -21,13 +21,13 @@ if len(sys.argv) != 2:
 test_file = sys.argv[1]
 
 if not path.isfile(test_file):
-    print("Test file does not exist: " + test_file)
+    print(f"Test file does not exist: {test_file}")
     sys.exit(1)
 
 error_occurred = False
 
 while not error_occurred:
-    print("Running test: " + test_file)
+    print(f"Running test: {test_file} - {datetime.now().strftime('%H:%M:%S')}")
     command_call = subprocess.Popen(["python", test_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output, errors = command_call.communicate()
     error_occurred = command_call.returncode != 0


### PR DESCRIPTION
The Python test `listtransactions.py` started sporadically hanging on the CI.
This PR fixes the issue by adding the proper calls to `sync_all()` to be sure that all the nodes are aligned in terms of blocks and mempool.