### PR TITLE
Gp/proof verification refactoring

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -167,6 +167,7 @@ testScripts=(
   'mempool_size_limit_more.py',103,160
   'mempool_size_limit_even_more.py',87,210
   'mempool_hard_fork_cleaning.py',34,60
+  'sc_proof_verification_manager.py',550,800
 );
 
 testScriptsExt=(

--- a/qa/rpc-tests/sc_async_proof_verifier.py
+++ b/qa/rpc-tests/sc_async_proof_verifier.py
@@ -408,8 +408,8 @@ class AsyncProofVerifierTest(BitcoinTestFramework):
         assert_true(final_raw_tx in self.nodes[1].getrawmempool())
 
         # Get the current async proof verifier statistics
-        node0_initial_stats = self.nodes[0].getproofverifierstats()
-        node1_initial_stats = self.nodes[1].getproofverifierstats()
+        node0_initial_stats = self.nodes[0].getasyncproofverifierstats()
+        node1_initial_stats = self.nodes[1].getasyncproofverifierstats()
 
         # Generate one block containing the last CSW transaction (currently in the mempool)
         mark_logs("Generate one block...", self.nodes, DEBUG_MODE)
@@ -425,8 +425,8 @@ class AsyncProofVerifierTest(BitcoinTestFramework):
         # by comparing its current statistics with the initial ones.
         # This way we are also sure that it has not been called by 'CreateNewBlock()'
         # since we generated a block to include the CSW transaction.
-        assert_equal(node0_initial_stats, self.nodes[0].getproofverifierstats())
-        assert_equal(node1_initial_stats, self.nodes[1].getproofverifierstats())
+        assert_equal(node0_initial_stats, self.nodes[0].getasyncproofverifierstats())
+        assert_equal(node1_initial_stats, self.nodes[1].getasyncproofverifierstats())
 
         # Disconnect one block
         mark_logs("Disconnect one block...", self.nodes, DEBUG_MODE)
@@ -441,8 +441,8 @@ class AsyncProofVerifierTest(BitcoinTestFramework):
 
         # Check that the async proof verifier has not been called by 'DisconnectTip()'
         # by comparing its current statistics with the initial ones.
-        assert_equal(node0_initial_stats, self.nodes[0].getproofverifierstats())
-        assert_equal(node1_initial_stats, self.nodes[1].getproofverifierstats())
+        assert_equal(node0_initial_stats, self.nodes[0].getasyncproofverifierstats())
+        assert_equal(node1_initial_stats, self.nodes[1].getasyncproofverifierstats())
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/sc_proof_verification_manager.py
+++ b/qa/rpc-tests/sc_proof_verification_manager.py
@@ -125,7 +125,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
 
         print("Waiting for the time the certificate (node1) would have required to start being verified and then to complete being verified...")
         time.sleep((BATCH_VERIFICATION_MAX_DELAY_ARG + BATCH_VERIFICATION_PROCESSING_ESTIMATION) / 1000)
-      
+
         print("Checking mempools and stats after waiting enough time")
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
         assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
@@ -134,6 +134,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
                      node1_stats["pendingCertsInVerification"] + node1_stats["pendingCSWsInVerification"], 0)
         assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
                      node1_stats["okCerts"] + node1_stats["okCSWs"], 0)
+        assert_equal(node1_stats["removedFromQueueProofs"], 1)
 
         print("Test is OK")
 
@@ -170,7 +171,8 @@ class sc_proof_verification_manager(BitcoinTestFramework):
                      node1_stats["pendingCertsInVerification"] + node1_stats["pendingCSWsInVerification"], 0)
         assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
                      node1_stats["okCerts"] + node1_stats["okCSWs"], 0)
-        
+        assert_equal(node1_stats["discardedResultsProofs"], 1)
+
         print("Test is OK")
 
 

--- a/qa/rpc-tests/sc_proof_verification_manager.py
+++ b/qa/rpc-tests/sc_proof_verification_manager.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_node, connect_nodes, get_epoch_data, \
+    swap_bytes, sync_blocks, sync_mempools, assert_greater_than
+from test_framework.mc_test.mc_test import CertTestUtils, generate_random_field_element_hex
+
+from decimal import Decimal
+import time
+
+EPOCH_LENGTH = 100
+CERT_FEE = Decimal("0.000123")
+SC_FEE = Decimal("0.000345")
+FT_SC_FEE = Decimal('0')
+MBTR_SC_FEE = Decimal('0')
+MINIMAL_SC_HEIGHT = 420
+
+BATCH_VERIFICATION_MAX_DELAY_ARG = 20000
+BATCH_VERIFICATION_PROCESSING_ESTIMATION = 2000
+
+# in order to have slower execution of proof verification
+PROOVING_SYSTEM_SLOW = "darlin"
+CERT_NUM_CONSTRAINTS_SLOW = 1 << 20
+SEGMENT_SIZE_SLOW = 1 << 18
+
+# in order to have faster execution of proof verification
+PROOVING_SYSTEM_FAST = "cob_marlin"
+CERT_NUM_CONSTRAINTS_FAST = 1 << 10
+SEGMENT_SIZE_FAST = 1 << 11
+
+# type of wait
+WAIT_ON_PENDING_PROOFS = 0
+WAIT_ON_FAIL_PROOFS = 1
+WAIT_ON_PASS_PROOFS = 2
+WAIT_ON_FAIL_PASS_PROOFS = 3
+
+class sc_proof_verification_manager(BitcoinTestFramework):
+    FEE = 0.0001
+    FT_SC_FEE = Decimal('0')
+    MBTR_SC_FEE = Decimal('0')
+    CERT_FEE = Decimal('0.00015')
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self, split=False):
+        self.nodes=[]
+        self.nodes += [start_node(0, self.options.tmpdir,extra_args=[f'-scproofverificationdelay={BATCH_VERIFICATION_MAX_DELAY_ARG}', '-logtimemicros'])]
+        self.nodes += [start_node(1, self.options.tmpdir,extra_args=[f'-scproofverificationdelay={BATCH_VERIFICATION_MAX_DELAY_ARG}', '-logtimemicros'])]
+
+        connect_nodes(self.nodes, 0, 1) # non-bidirectional connection is set in order to avoid receiving twice invs (especially when clearing mempool)
+
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test(self):
+
+        # amounts
+        creation_amount = Decimal("50")
+        bwt_amount = Decimal("5")
+        tAddr1 = self.nodes[1].getnewaddress()
+        node1Addr = self.nodes[1].validateaddress(tAddr1)['address']
+        self.nodes[0].generate(MINIMAL_SC_HEIGHT)
+        self.sync_all()
+        
+        ########### Create a sidechain ##################
+        print("########### Create a sidechain ##################")
+        
+        print(f"Using {PROOVING_SYSTEM_SLOW} proving system")
+        mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir, PROOVING_SYSTEM_SLOW)
+        vk = mcTest.generate_params("sc1", 'cert', num_constraints=CERT_NUM_CONSTRAINTS_SLOW, segment_size=SEGMENT_SIZE_SLOW)
+        constant = generate_random_field_element_hex()
+
+        cmdInput = {
+            "version": 0,
+            'withdrawalEpochLength': EPOCH_LENGTH,
+            'toaddress': "dada",
+            'amount': creation_amount,
+            'wCertVk': vk,
+            'constant': constant
+        }
+
+        ret = self.nodes[0].sc_create(cmdInput)
+        scid = ret['scid']
+        scid_swapped = str(swap_bytes(scid))
+        self.sync_all()
+
+        # Mine block creating the sidechain
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Advance for 1 Epoch
+        self.nodes[0].generate(EPOCH_LENGTH)
+        self.sync_all()
+
+
+        # ---------- TEST ----------
+        # a certificate is sent by node0 and the mempools are cleared when the proof has been scheduled for verification on
+        # node1 but has still not started being verified; even after waiting for the time that would be required for the
+        # certificate to start being verified and then to complete being verified, the mempools are empty
+
+        self.send_certificate_from_node(self.nodes[0], "sc1", scid, 1, mcTest, scid_swapped, constant, node1Addr, bwt_amount, CERT_NUM_CONSTRAINTS_SLOW, SEGMENT_SIZE_SLOW)
+
+        print("Checking mempools before clearing")
+        assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
+        # node1 has received the certificate, but it has been queued in async proof verifier
+        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+
+        print("Mempools clearing")
+        self.nodes[0].clearmempool()
+        # clear mempools with proper timing on node1
+        self.wait_for_proofs(self.nodes[1], WAIT_ON_PENDING_PROOFS, 1)
+        self.nodes[1].clearmempool()
+
+        print("Checking mempools after clearing")
+        assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+
+        print("Waiting for the time the certificate (node1) would have required to start being verified and then to complete being verified...")
+        time.sleep((BATCH_VERIFICATION_MAX_DELAY_ARG + BATCH_VERIFICATION_PROCESSING_ESTIMATION) / 1000)
+
+        print("Checking mempools and stats after waiting enough time")
+        assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
+        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+        node1_stats = self.nodes[1].getproofverifierstats()
+        assert_equal(node1_stats["pendingCerts"] + node1_stats["pendingCSWs"], 0)
+        assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
+                     node1_stats["okCerts"] + node1_stats["okCSWs"], 0)
+
+        print("Test is OK")
+
+
+    def wait_for_proofs(self, node, wait_on_type, quantity = 1):
+        for i in range(6000): # one minute at worst (0.01 * 6000 = 60)
+            node_stats = node.getproofverifierstats()
+            if (wait_on_type == WAIT_ON_PENDING_PROOFS):
+                if (node_stats["pendingCerts"] + node_stats["pendingCSWs"] == quantity):
+                    print(f"{quantity} proofs scheduled for verification on node async proof verifier")
+                    break
+            elif (wait_on_type == WAIT_ON_FAIL_PROOFS):
+                if (node_stats["failedCerts"] + node_stats["failedCSWs"] == quantity):
+                    print(f"{quantity} proofs verified (fail) on node async proof verifier")
+                    break
+            elif (wait_on_type == WAIT_ON_PASS_PROOFS):
+                if (node_stats["okCerts"] + node_stats["okCSWs"] == quantity):
+                    print(f"{quantity} proofs verified (pass) on node async proof verifier")
+                    break
+            elif (wait_on_type == WAIT_ON_FAIL_PASS_PROOFS):
+                if (node_stats["failedCerts"] + node_stats["failedCSWs"] + node_stats["okCerts"] + node_stats["okCSWs"] == quantity):
+                    print(f"{quantity} proofs verified (fail or pass) on node async proof verifier")
+                    break
+            time.sleep(0.01) # hundredth of a second
+    
+    def send_certificate_from_node(self, node, id, scid, certquality, mcTest, scid_swapped, constant, node1Addr, bwt_amount, cert_num_constraints, segment_size):
+        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
+        quality = certquality
+        proof = mcTest.create_test_proof(id, scid_swapped, epoch_number, quality, MBTR_SC_FEE, FT_SC_FEE, epoch_cum_tree_hash, None, constant, [node1Addr], [bwt_amount],
+                                         [], cert_num_constraints, segment_size)
+        amount_cert = [{"address": node1Addr, "amount": bwt_amount}]
+        print(f"########### Send a certificate with quality = {certquality} ##################")
+        node.sc_send_certificate(scid, epoch_number, quality,
+                                 epoch_cum_tree_hash, proof, amount_cert, FT_SC_FEE, MBTR_SC_FEE, CERT_FEE)
+
+
+if __name__ == '__main__':
+    sc_proof_verification_manager().main()

--- a/qa/rpc-tests/sc_proof_verification_manager.py
+++ b/qa/rpc-tests/sc_proof_verification_manager.py
@@ -129,7 +129,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
         print("Checking mempools and stats after waiting enough time")
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
         assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
-        node1_stats = self.nodes[1].getproofverifierstats()
+        node1_stats = self.nodes[1].getasyncproofverifierstats()
         assert_equal(node1_stats["pendingCerts"] + node1_stats["pendingCSWs"] +
                      node1_stats["pendingCertsInVerification"] + node1_stats["pendingCSWsInVerification"], 0)
         assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
@@ -166,7 +166,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
         print("Checking mempools and stats after waiting enough time")
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
         assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
-        node1_stats = self.nodes[1].getproofverifierstats()
+        node1_stats = self.nodes[1].getasyncproofverifierstats()
         assert_equal(node1_stats["pendingCerts"] + node1_stats["pendingCSWs"] +
                      node1_stats["pendingCertsInVerification"] + node1_stats["pendingCSWsInVerification"], 0)
         assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
@@ -195,7 +195,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
 
         print("Checking mempools and stats after waiting enough time")
         # the stats for node1 are expected to be all null because the certificate has been synchronously verified
-        node1_stats = self.nodes[1].getproofverifierstats()
+        node1_stats = self.nodes[1].getasyncproofverifierstats()
         assert_equal(node1_stats["pendingCerts"] + node1_stats["pendingCSWs"] +
                      node1_stats["pendingCertsInVerification"] + node1_stats["pendingCSWsInVerification"], 0)
         assert_equal(node1_stats["failedCerts"] + node1_stats["failedCSWs"] +
@@ -324,7 +324,7 @@ class sc_proof_verification_manager(BitcoinTestFramework):
 
     def wait_for_proofs(self, node, wait_on_type, quantity = 1):
         for i in range(6000): # one minute at worst (0.01 * 6000 = 60)
-            node_stats = node.getproofverifierstats()
+            node_stats = node.getasyncproofverifierstats()
             if (wait_on_type == WAIT_ON_PENDING_PROOFS):
                 if (node_stats["pendingCerts"] + node_stats["pendingCSWs"] == quantity):
                     print(f"{quantity} proofs scheduled for verification on node async proof verifier")

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -1091,7 +1091,7 @@ void BlockchainTestManager::ResetAsyncProofVerifier()const
     asyncProofVerifier.DisableMempoolCallback();
     asyncProofVerifier.ResetStatistics();
     asyncProofVerifier.ClearFromQueue();
-    asyncProofVerifier.DiscardFromCurrentVerification();
+    asyncProofVerifier.SetDiscardingFromCurrentVerification();
 }
 
 /**

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -1087,7 +1087,8 @@ uint32_t BlockchainTestManager::GetAsyncProofVerifierMaxBatchVerifyDelay() const
  */
 void BlockchainTestManager::ResetAsyncProofVerifier()const
 {
-    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().Reset();
+    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ResetStatistics();
+    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ClearFromQueue();
 }
 
 /**

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -1087,8 +1087,11 @@ uint32_t BlockchainTestManager::GetAsyncProofVerifierMaxBatchVerifyDelay() const
  */
 void BlockchainTestManager::ResetAsyncProofVerifier()const
 {
-    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ResetStatistics();
-    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ClearFromQueue();
+    auto& asyncProofVerifier = TEST_FRIEND_CScAsyncProofVerifier::GetInstance();
+    asyncProofVerifier.DisableMempoolCallback();
+    asyncProofVerifier.ResetStatistics();
+    asyncProofVerifier.ClearFromQueue();
+    asyncProofVerifier.DiscardFromCurrentVerification();
 }
 
 /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2520,10 +2520,14 @@ UniValue getproofverifierstats(const UniValue& params, bool fHelp)
     AsyncProofVerifierStatistics stats = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().GetStatistics();
     size_t pendingCerts = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().PendingAsyncCertProofs();
     size_t pendingCSWs = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().PendingAsyncCswProofs();
+    size_t pendingCertsInVerification = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().PendingAsyncCertProofsInVerification();
+    size_t pendingCSWsInVerification = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().PendingAsyncCswProofsInVerification();
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("pendingCerts",               pendingCerts);
     obj.pushKV("pendingCSWs",                pendingCSWs);
+    obj.pushKV("pendingCertsInVerification", pendingCertsInVerification);
+    obj.pushKV("pendingCSWsInVerification",  pendingCSWsInVerification);
     obj.pushKV("failedCerts",                static_cast<uint64_t>(stats.failedCertCounter));
     obj.pushKV("failedCSWs",                 static_cast<uint64_t>(stats.failedCswCounter));
     obj.pushKV("okCerts",                    static_cast<uint64_t>(stats.okCertCounter));
@@ -2702,6 +2706,7 @@ UniValue clearmempool(const UniValue& params, bool fHelp)
     LOCK(cs_main);
     mempool->clear();
     TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ClearFromQueue();
+    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().DiscardFromCurrentVerification();
 
     return NullUniValue;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2495,20 +2495,19 @@ UniValue dbg_do(const UniValue& params, bool fHelp)
 }
 
 /**
- * @brief Retrieves the statistics about the sidechain proof verifier, for instance
- * the number of accepted and failed verifications, the number of pending
- * proofs, etc.
+ * @brief Retrieves the statistics about the sidechain async proof verifier, for instance
+ * the number of accepted and failed verifications, the number of pending proofs, etc.
  */
-UniValue getproofverifierstats(const UniValue& params, bool fHelp)
+UniValue getasyncproofverifierstats(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
     {
         throw runtime_error(
-            "getproofverifierstats\n"
+            "getasyncproofverifierstats\n"
             "\nCollects statistics about the sidechain proof verification system.\n"
             "\nExamples:\n"
-            + HelpExampleCli("getproofverifierstats", "")
-            + HelpExampleRpc("getproofverifierstats", "")
+            + HelpExampleCli("getasyncproofverifierstats", "")
+            + HelpExampleRpc("getasyncproofverifierstats", "")
         );
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2532,6 +2532,8 @@ UniValue getproofverifierstats(const UniValue& params, bool fHelp)
     obj.pushKV("failedCSWs",                 static_cast<uint64_t>(stats.failedCswCounter));
     obj.pushKV("okCerts",                    static_cast<uint64_t>(stats.okCertCounter));
     obj.pushKV("okCSWs",                     static_cast<uint64_t>(stats.okCswCounter));
+    obj.pushKV("removedFromQueueProofs",     static_cast<uint64_t>(stats.removedFromQueueCounter));
+    obj.pushKV("discardedResultsProofs",     static_cast<uint64_t>(stats.discardedResultCounter));
 
     return obj;
 }
@@ -2704,9 +2706,10 @@ UniValue clearmempool(const UniValue& params, bool fHelp)
     }
 
     LOCK(cs_main);
-    mempool->clear();
+
     TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ClearFromQueue();
-    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().DiscardFromCurrentVerification();
+    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().SetDiscardingFromCurrentVerification();
+    mempool->clear();
 
     return NullUniValue;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2522,12 +2522,12 @@ UniValue getproofverifierstats(const UniValue& params, bool fHelp)
     size_t pendingCSWs = TEST_FRIEND_CScAsyncProofVerifier::GetInstance().PendingAsyncCswProofs();
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("pendingCerts",  pendingCerts);
-    obj.pushKV("pendingCSWs",   pendingCSWs);
-    obj.pushKV("failedCerts",   static_cast<uint64_t>(stats.failedCertCounter));
-    obj.pushKV("failedCSWs",    static_cast<uint64_t>(stats.failedCswCounter));
-    obj.pushKV("okCerts",       static_cast<uint64_t>(stats.okCertCounter));
-    obj.pushKV("okCSWs",        static_cast<uint64_t>(stats.okCswCounter));
+    obj.pushKV("pendingCerts",               pendingCerts);
+    obj.pushKV("pendingCSWs",                pendingCSWs);
+    obj.pushKV("failedCerts",                static_cast<uint64_t>(stats.failedCertCounter));
+    obj.pushKV("failedCSWs",                 static_cast<uint64_t>(stats.failedCswCounter));
+    obj.pushKV("okCerts",                    static_cast<uint64_t>(stats.okCertCounter));
+    obj.pushKV("okCSWs",                     static_cast<uint64_t>(stats.okCswCounter));
 
     return obj;
 }
@@ -2701,6 +2701,7 @@ UniValue clearmempool(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
     mempool->clear();
+    TEST_FRIEND_CScAsyncProofVerifier::GetInstance().ClearFromQueue();
 
     return NullUniValue;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -294,7 +294,7 @@ static const CRPCCommand vRPCCommands[] =
     { "control",            "getactivecertdatahash",  &getactivecertdatahash,  true  },
     { "control",            "getceasingcumsccommtreehash", &getceasingcumsccommtreehash, true  },
     { "control",            "getscgenesisinfo",       &getscgenesisinfo,       true  },
-    { "control",            "getproofverifierstats",  &getproofverifierstats,  true  },
+    { "control",            "getasyncproofverifierstats",  &getasyncproofverifierstats,  true  },
     { "control",            "setproofverifierlowpriorityguard",  &setproofverifierlowpriorityguard,  true  },
 
     /* P2P networking */

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -334,7 +334,7 @@ extern UniValue listaddresses(const UniValue& params, bool fHelp); // in rpcwall
 extern UniValue dbg_log(const UniValue &params, bool fHelp); // print a line in debug.log
 extern UniValue dbg_do(const UniValue &params, bool fHelp); // does a dbg hard coded task
 
-extern UniValue getproofverifierstats(const UniValue& params, bool fHelp); // in blockchain.cpp
+extern UniValue getasyncproofverifierstats(const UniValue& params, bool fHelp); // in blockchain.cpp
 extern UniValue setproofverifierlowpriorityguard(const UniValue& params, bool fHelp); // in blockchain.cpp
 
 bool StartRPC();

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -262,7 +262,7 @@ public:
                 if (proofsToClear.size() == 0)
                 {
                     clearedProofs = verifier.proofsQueue.size();
-                    LogPrint("cert", "%s():%d - %d proofs cleared from async verification queue\n",
+                    LogPrint("sc", "%s():%d - %d proofs cleared from async verification queue\n",
                              __func__, __LINE__, clearedProofs);
                     verifier.proofsQueue.clear();
                     verifier.proofsInsertionMillisecondsQueue.clear();
@@ -276,7 +276,7 @@ public:
                         if (verifier.proofsQueue.erase(proofToClear) > 0)
                         {
                             ++clearedProofs;
-                            LogPrint("cert", "%s():%d - %s proof cleared from async verification queue\n",
+                            LogPrint("sc", "%s():%d - %s proof cleared from async verification queue\n",
                                      __func__, __LINE__, proofToClear.ToString());
                             verifier.proofsQueue.erase(proofToClear);
                             verifier.proofsInsertionMillisecondsQueue.erase(proofToClear);
@@ -306,7 +306,7 @@ public:
             {
                 if (proofsVerificationsToDiscard.size() == 0)
                 {
-                    LogPrint("cert", "%s():%d - %d proofs verifications results will be discarded from current verification\n",
+                    LogPrint("sc", "%s():%d - %d proofs verifications results will be discarded from current verification\n",
                              __func__, __LINE__, verifier.proofsInVerificationQueue.size());
                     verifier.discardAllProofsVerifications = true;
                 }
@@ -314,7 +314,7 @@ public:
                 {
                     for (auto proofToDiscard : proofsVerificationsToDiscard)
                     {
-                        LogPrint("cert", "%s():%d - %s proof verification result will be discarded from current verification\n",
+                        LogPrint("sc", "%s():%d - %s proof verification result will be discarded from current verification\n",
                                  __func__, __LINE__, proofToDiscard.ToString());
                         verifier.proofsVerificationsToDiscard.push_back(proofToDiscard);
                     }

--- a/src/sc/proofverificationmanager.hpp
+++ b/src/sc/proofverificationmanager.hpp
@@ -1,0 +1,35 @@
+#ifndef _SC_PROOF_VERIFICATION_MANAGER_H
+#define _SC_PROOF_VERIFICATION_MANAGER_H
+
+#include "limitedmap.h"
+#include "sc/sidechaintypes.h"
+#include "proofverifier.h"
+
+constexpr int RESULTS_LIMIT = 100;
+
+/**
+ * @brief Helper class for managing proofs verifications results
+ * 
+ */
+class CScProofVerificationManager
+{
+public:
+
+    CCriticalSection cs_proofsVerificationsResults;
+
+    LimitedMap<uint256, std::pair<uint64_t, ProofVerificationResult>> mostRecentProofsVerificationsResults;
+
+    static CScProofVerificationManager& GetInstance()
+    {
+        static CScProofVerificationManager instance;
+        
+        return instance;
+    }
+
+private:
+    CScProofVerificationManager() : mostRecentProofsVerificationsResults(RESULTS_LIMIT)
+    {
+    }
+};
+
+#endif // _SC_PROOF_VERIFICATION_MANAGER_H

--- a/src/sc/proofverificationresultmanager.hpp
+++ b/src/sc/proofverificationresultmanager.hpp
@@ -11,7 +11,7 @@ constexpr int RESULTS_LIMIT = 100;
  * @brief Helper class for managing proofs verifications results
  * 
  */
-class CScProofVerificationManager
+class CScProofVerificationResultManager
 {
 public:
 
@@ -19,15 +19,15 @@ public:
 
     LimitedMap<uint256, std::pair<uint64_t, ProofVerificationResult>> mostRecentProofsVerificationsResults;
 
-    static CScProofVerificationManager& GetInstance()
+    static CScProofVerificationResultManager& GetInstance()
     {
-        static CScProofVerificationManager instance;
+        static CScProofVerificationResultManager instance;
         
         return instance;
     }
 
 private:
-    CScProofVerificationManager() : mostRecentProofsVerificationsResults(RESULTS_LIMIT)
+    CScProofVerificationResultManager() : mostRecentProofsVerificationsResults(RESULTS_LIMIT)
     {
     }
 };

--- a/src/sc/proofverifier.cpp
+++ b/src/sc/proofverifier.cpp
@@ -196,7 +196,7 @@ void CScProofVerifier::LoadDataForCswVerification(const CCoinsViewCache& view, c
         item.result = ProofVerificationResult::Unknown;
         item.node = pfrom;
         item.proofInput = cswInputProofs;
-        auto pair_ret = proofsQueue.insert(std::make_pair(scTx.GetHash(), item));
+        auto pair_ret = proofsQueue.insert({scTx.GetHash(), item});
 
         if (!pair_ret.second)
         {
@@ -266,7 +266,7 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
         {
             for (auto& cswInput : boost::get<std::vector<CCswProofVerifierInput>>(item.proofInput))
             {
-                proofIdMap.insert(std::make_pair(cswInput.proofId, proofEntry.first));
+                proofIdMap.insert({cswInput.proofId, proofEntry.first});
 
                 wrappedFieldPtr sptrScId = CFieldElement(cswInput.scId).GetFieldElement();
                 field_t* scid_fe = sptrScId.get();
@@ -311,7 +311,7 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
         else if (item.proofInput.type() == typeid(CCertProofVerifierInput))
         {
             CCertProofVerifierInput certInput = boost::get<CCertProofVerifierInput>(item.proofInput);
-            proofIdMap.insert(std::make_pair(certInput.proofId, proofEntry.first));
+            proofIdMap.insert({certInput.proofId, proofEntry.first});
 
             int custom_fields_len = certInput.vCustomFields.size(); 
             std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);

--- a/src/sc/proofverifier.cpp
+++ b/src/sc/proofverifier.cpp
@@ -1,5 +1,5 @@
 #include "sc/proofverifier.h"
-#include "sc/proofverificationmanager.hpp"
+#include "sc/proofverificationresultmanager.hpp"
 
 #include "coins.h"
 #include "main.h"
@@ -234,7 +234,7 @@ bool CScProofVerifier::BatchVerify()
  */
 bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs)
 {
-    auto proofVerificationManager = &CScProofVerificationManager::GetInstance();
+    auto proofVerificationResultManager = &CScProofVerificationResultManager::GetInstance();
 
     if (proofs.size() == 0)
     {
@@ -242,13 +242,13 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
     }
 
     {
-        LOCK(proofVerificationManager->cs_proofsVerificationsResults);
+        LOCK(proofVerificationResultManager->cs_proofsVerificationsResults);
         for (auto& [proofId, proofItem] : proofs)
         {
-            if (proofVerificationManager->mostRecentProofsVerificationsResults.find(proofId) !=
-                proofVerificationManager->mostRecentProofsVerificationsResults.end())
+            if (proofVerificationResultManager->mostRecentProofsVerificationsResults.find(proofId) !=
+                proofVerificationResultManager->mostRecentProofsVerificationsResults.end())
             {
-                proofItem.result = proofVerificationManager->mostRecentProofsVerificationsResults.find(proofId)->second.second;
+                proofItem.result = proofVerificationResultManager->mostRecentProofsVerificationsResults.find(proofId)->second.second;
                 proofItem.resultReused = true;
                 LogPrint("sc", "%s():%d - Reusing result (%d) for proof %s\n",
                          __func__, __LINE__, static_cast<std::underlying_type<ProofVerificationResult>::type>(proofItem.result), proofId.ToString());
@@ -457,11 +457,11 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
     LogPrint("bench", "%s():%d - verification completed: %.2fms\n", __func__, __LINE__, (nTime2-nTime1) * 0.001);
     
     {
-        LOCK(proofVerificationManager->cs_proofsVerificationsResults);
+        LOCK(proofVerificationResultManager->cs_proofsVerificationsResults);
         int64_t timeMillis = GetTimeMillis();
         for (auto& [proofId, proofItem] : proofs)
         {
-            proofVerificationManager->mostRecentProofsVerificationsResults.insert({proofId, {timeMillis, proofItem.result}});
+            proofVerificationResultManager->mostRecentProofsVerificationsResults.insert({proofId, {timeMillis, proofItem.result}});
         }
     }
 

--- a/src/sc/proofverifier.cpp
+++ b/src/sc/proofverifier.cpp
@@ -250,7 +250,7 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
             {
                 proofItem.result = proofVerificationManager->mostRecentProofsVerificationsResults.find(proofId)->second.second;
                 proofItem.resultReused = true;
-                LogPrint("cert", "%s():%d - Reusing result (%d) for proof %s\n",
+                LogPrint("sc", "%s():%d - Reusing result (%d) for proof %s\n",
                          __func__, __LINE__, static_cast<std::underlying_type<ProofVerificationResult>::type>(proofItem.result), proofId.ToString());
             }
         }

--- a/src/sc/proofverifier.cpp
+++ b/src/sc/proofverifier.cpp
@@ -161,7 +161,7 @@ void CScProofVerifier::LoadDataForCertVerification(const CCoinsViewCache& view, 
     item.node = pfrom;
     item.result = ProofVerificationResult::Unknown;
     item.proofInput = CertificateToVerifierItem(scCert, sidechain.fixedParams, pfrom, &view);
-    proofQueue.insert(std::make_pair(scCert.GetHash(), item));
+    proofsQueue.insert(std::make_pair(scCert.GetHash(), item));
 }
 
 /**
@@ -196,7 +196,7 @@ void CScProofVerifier::LoadDataForCswVerification(const CCoinsViewCache& view, c
         item.result = ProofVerificationResult::Unknown;
         item.node = pfrom;
         item.proofInput = cswInputProofs;
-        auto pair_ret = proofQueue.insert(std::make_pair(scTx.GetHash(), item));
+        auto pair_ret = proofsQueue.insert(std::make_pair(scTx.GetHash(), item));
 
         if (!pair_ret.second)
         {
@@ -220,7 +220,7 @@ void CScProofVerifier::LoadDataForCswVerification(const CCoinsViewCache& view, c
  */
 bool CScProofVerifier::BatchVerify()
 {
-    return BatchVerifyInternal(proofQueue);
+    return BatchVerifyInternal(proofsQueue);
 }
 
 /**

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -76,6 +76,7 @@ struct CProofVerifierItem
     std::shared_ptr<CTransactionBase> parentPtr;                                                    /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
     CNode* node;                                                                                    /**< The node that sent the parent (Transaction or Certiticate). */
     ProofVerificationResult result;                                                                 /**< The overall result of the proof(s) verification for the transaction/certificate. */
+    bool resultReused = false;                                                                      /**< The flag indicating if the result has been reused (instead of being the outcome of an actual verification) */
     boost::variant<CCertProofVerifierInput, std::vector<CCswProofVerifierInput>> proofInput;        /**< The proof input data, it can be a (single) certificate input or a list of CSW inputs. */
 };
 

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -127,7 +127,7 @@ protected:
     ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierInput input) const;
     ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierInput> cswInputs) const;
 
-    std::map</* Cert or Tx hash */ uint256, CProofVerifierItem> proofQueue;   /**< The queue of proofs to be verified. */
+    std::map</* Cert or Tx hash */ uint256, CProofVerifierItem> proofsQueue;   /**< The queue of proofs to be verified. */
 
 private:
 


### PR DESCRIPTION
Addresses issue related to:
1. call to **clearmempool** not clearing async proof verifier queue
2. improper handling of async proof verifier queue for triggering async proof verifier run
3. performance, related to reusage of already available proof results