### PR TITLE
Ap/zend 304

### DIFF
--- a/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_bionic/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_bionic/Dockerfile
@@ -16,7 +16,8 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils build-essential ca-certificates \
        cmake curl dirmngr fakeroot git g++-multilib gnupg2 help2man libc6-dev libgomp1 libtool lintian m4 ncurses-dev \
        pigz pkg-config pv python3-dev python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install pycryptodome b2sdk==1.14.1 b2==3.2.1 pyblake2 websocket-client pyzmq \
+    && pip3 install --upgrade pip \
+    && pip3 install packaging pycryptodome b2sdk==1.14.1 b2==3.2.1 pyblake2 websocket-client pyzmq \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -139,6 +139,8 @@ testScripts=(
   'sc_getscgenesisinfo.py'
   'fundaddresses.py'
   'sc_getcertmaturityinfo.py'
+  'sc_big_commitment_tree.py'
+  'sc_big_commitment_tree_getblockmerkleroot.py'
 );
 testScriptsExt=(
   'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/sc_big_commitment_tree.py
+++ b/qa/rpc-tests/sc_big_commitment_tree.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from decimal import Decimal
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, initialize_chain_clean, \
+     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs
+from test_framework.test_framework import ForkHeights, JSONRPCException
+from test_framework.blockchainhelper import BlockchainHelper
+
+NUMB_OF_NODES = 2
+DEBUG_MODE = 1
+EPOCH_LENGTH = 10
+CERT_FEE = Decimal('0.0001')
+
+'''
+This test excercises the txs commitment builder.
+CCTPlib stores the txs commitment tree as follows:
+- information for alive sidechains and ceased sidechains are stored on different subtrees
+- the txs commitment tree can contain up to 4096 subtrees (alive + ceased), each one for a different sidechain
+- each alive sidechain subtree has 3 subtrees, each one containing Forward Transfers, Backward Transfer Requests
+  and Certificates hashes in their leaves
+- each ceased sidechain subtree has 1 subtree containing Ceased Sidechain Withdrawal hashed in its leaves
+- FT / BWTR / CERT / CSW can contain up to 4095 leaves
+- Sidechain Creation transaction is NOT stored in a leaf, but in a separate field in the Rust structure that models
+  the txs commitment tree
+
+CCTPlib txs commitment builder fails when:
+- adding FTs / BWTRs / CERTs / CSWs belonging to more than 4096 different sidechains
+- adding more than 4095 FTs for a SC
+- adding more than 4095 BWTRs for a SC
+- adding more than 4095 CERTs for a SC
+- adding more than 4095 CSWs for a SC
+- adding a FT / BWTR / CERT for a SC after a CSW for the same SC has been added
+- adding a CSW for a SC after a FT / BWTR / CERT for the same SC has been added
+- internal hashing issues
+
+Currently, CommitmentBuilderGuard manages all these failure reasons but the last one.
+
+In this test, we call getblocktemplate() so that a txs commitment tree is built from the txs that are stored in the mempool of a node
+[CreateNewBlock(..) and related function in zend]
+1. we create a set of 4 transactions having in total 4094 FTs for a single SC; getblocktemplate() will not fail and returns a valid block
+     mempool <- {tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT]}
+     getblocktemplate() returns a block with [tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT]]
+2. adding another tx having 2 FTs for the same sc to the mempool will make getblocktemplate() ignore the newly added tx, as its addiction
+   makes the commitmentTreeBuilder fail. getblocktemplate returns the same block
+     mempool <- {tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT], tx5[2FT]}
+     getblocktemplate() returns a block with [tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT]]
+3. adding a single tx having a single FT for the same sc to the mempool does not make the commitmentTreeBuilder fail and the block
+   returned by getblocktemplate() will include the 4 txs of 1. and this newly added txs. tx of 2. is still rejected
+     mempool <- {tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT], tx5[2FT], tx6[1FT]}
+     getblocktemplate() returns a block with [tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT], tx6[1FT]]
+4. adding a single tx having a single FT for the same sc to the mempool will now make the commitmentTreeBuilder fail.
+     mempool <- {tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT], tx5[2FT], tx6[1FT], tx7[1FT]}
+     getblocktemplate() returns a block with [tx1[1024FT], tx2[1024FT], tx3[1024FT], tx4[1022FT], tx6[1FT]]
+5. We mine a block WITHOUT calling the getblocktemplate and confirm that only tx5 and tx7 are still in mempool
+     mempool <- {tx5[2FT], tx7[1FT]}
+'''
+
+class BigCommitmentTree(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
+                                 extra_args=[['-logtimemicros=1', '-debug=sc', '-debug=py', '-debug=mempool', '-debug=cert']] * NUMB_OF_NODES)
+
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = split
+        self.sync_all()
+
+    # This function waits until the getblocktemplate() command returns the given number of transactions
+    # within a specified time frame (default = 10 seconds, set to 0 seconds to wait indefinitely)
+    def wait_for_block_template(self, node_id, expected_num_transactions, timeout = 10):
+        delay = 1
+        iteration = 0
+
+        while timeout > 0 and iteration < timeout // delay:
+            current_block_template = self.nodes[node_id].getblocktemplate({}, True)
+
+            if len(current_block_template['transactions']) == expected_num_transactions:
+                return current_block_template
+
+            time.sleep(delay)
+            iteration = iteration + 1
+
+        return None
+
+    def run_test(self):
+        # Reach SC v2 fork height
+        mark_logs("Generating enough blocks to reach non-ceasing SC fork", self.nodes, DEBUG_MODE, 'e')
+        self.nodes[0].generate(ForkHeights['NON_CEASING_SC'])
+        self.sync_all()
+
+        test_helper = BlockchainHelper(self)
+
+        mark_logs("Node 0 creates a v2 sidechain (ceasing)", self.nodes, DEBUG_MODE, 'e')
+        test_helper.create_sidechain("test_sidechain", 2)
+        sc_id = test_helper.get_sidechain_id("test_sidechain")
+        mark_logs(f"Sidechain {sc_id} has been created", self.nodes, DEBUG_MODE, 'e')
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Send some coins to Node1
+        # By using a new address for Node1, we are sure that any transaction created by Node1
+        # will use the change of the previous one, forcing the getblocktemplate() function
+        # to sort transaction based on submission order (because any transaction will depend
+        # on the previous one)
+        node1_address = self.nodes[1].getnewaddress()
+        self.nodes[0].sendtoaddress(node1_address, 100)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        current_sc_txs_commitment_tree_root = ""
+
+        forwardTransferOuts = [{'toaddress': "aabb", 'amount': Decimal(0.001), "scid": sc_id, "mcReturnAddress": node1_address}]
+
+        # Add to mempool 4 transactions, each containing 1024, 1024, 1024 and 1022 forward transfers (total 4094,
+        # which is almost the limit size of ScTxsCommTree)
+        mark_logs(f"Adding 4094 FT for sc {sc_id} to the mempool (4 transactions)", self.nodes, DEBUG_MODE, 'g')
+        multipll = [1024, 1024, 1024, 1022]
+        for i in range(4):
+            self.nodes[1].sc_send(forwardTransferOuts * multipll[i], {"fee": Decimal(0.0001 * (i + 1)), "minconf": 0})
+            mark_logs(f"Sent transaction #{i + 1}", self.nodes, DEBUG_MODE, 'c')
+            self.sync_all()
+
+            block_template = self.wait_for_block_template(0, i + 1)
+            assert(block_template is not None)
+            mark_logs(f"getblocktemplate() ->", self.nodes, DEBUG_MODE, 'e')
+            for k, transaction in enumerate(block_template['transactions']):
+                mark_logs(f"  {k} - {transaction['hash']}", self.nodes, DEBUG_MODE, 'e')
+            mark_logs(f"    ScTxsCommitmentTree root: {block_template['scTxsCommitment']}", self.nodes, DEBUG_MODE, 'e')
+
+            assert_false(current_sc_txs_commitment_tree_root == block_template['scTxsCommitment'])
+            current_sc_txs_commitment_tree_root = block_template['scTxsCommitment']
+
+
+        # Let's try to add two more forward transfers to the mempool to exceed ScTxsCommTree capacity
+        mark_logs(f"Adding 2 FT for sc {sc_id} to the mempool", self.nodes, DEBUG_MODE, 'y')
+        try:
+            exceeding_tx = self.nodes[1].sc_send(forwardTransferOuts * 2, {"fee": Decimal(0.0001 * 5), "minconf": 0})
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        mark_logs(f"Sent transaction FT #4095 and #4096", self.nodes, DEBUG_MODE, 'c')
+        mark_logs(f"  4 - {exceeding_tx}", self.nodes, DEBUG_MODE, 'e')
+        self.sync_all()
+
+        # Ask for a new block template
+        block_template = self.wait_for_block_template(0, i + 1)
+        assert(block_template is not None)
+        mark_logs(f"getblocktemplate() ->", self.nodes, DEBUG_MODE, 'e')
+        for k, transaction in enumerate(block_template['transactions']):
+            mark_logs(f"  {k} - {transaction['hash']}", self.nodes, DEBUG_MODE, 'e')
+        mark_logs(f"    ScTxsCommitmentTree root: {block_template['scTxsCommitment']}", self.nodes, DEBUG_MODE, 'e')
+
+        # The commitment tree should be the same as in the previous step because we rejected the last TX.
+        assert_equal(current_sc_txs_commitment_tree_root, block_template['scTxsCommitment'])
+        # Also, exceeding_tx should not have been included in the block
+        assert_false(exceeding_tx in [tx['hash'] for tx in block_template['transactions']], "The last TX should not be included in the block candidate!!!")
+
+
+        # Try again, but this time we only send the 4095th FT, so that it will be included in the block candidate
+        # We use createrawtransaction to avoid dependencies to the previous tx
+        mark_logs(f"Adding 1 FT for sc {sc_id} to the mempool", self.nodes, DEBUG_MODE, 'g')
+        try:
+            tx_data = {"address": "aabb", "amount": 0.003, "scid": sc_id, "mcReturnAddress": node1_address}
+            rawtx = self.nodes[0].createrawtransaction([],{},[], [], [tx_data])
+            fundedtx = self.nodes[0].fundrawtransaction(rawtx)
+            sigRawtx = self.nodes[0].signrawtransaction(fundedtx['hex'])
+            last_tx = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        mark_logs(f"Sent transaction FT #4095", self.nodes, DEBUG_MODE, 'c')
+        mark_logs(f"  5 - {last_tx}", self.nodes, DEBUG_MODE, 'e')
+        self.sync_all()
+
+        # Ask for a new block template
+        block_template = self.wait_for_block_template(0, i + 2)
+        assert(block_template is not None)
+        current_sc_txs_commitment_tree_root = block_template['scTxsCommitment']
+        # Check it has been included in the block candidate
+        assert_true(last_tx in [tx['hash'] for tx in block_template['transactions']], "The last TX should be included in the block candidate!!!")
+        mark_logs(f"getblocktemplate() ->", self.nodes, DEBUG_MODE, 'e')
+        for k, transaction in enumerate(block_template['transactions']):
+            mark_logs(f"  {k} - {transaction['hash']}", self.nodes, DEBUG_MODE, 'e')
+        mark_logs(f"    ScTxsCommitmentTree root: {block_template['scTxsCommitment']}", self.nodes, DEBUG_MODE, 'e')
+
+
+        # Try again adding an exceeding tx to the block candidate
+        mark_logs(f"Adding 1 FT for sc {sc_id} to the mempool", self.nodes, DEBUG_MODE, 'y')
+        try:
+            exceeding_tx2 = self.nodes[1].sc_send(forwardTransferOuts, {"fee": Decimal(0.0001 * 7), "minconf": 0})
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        mark_logs(f"Sent transaction FT #4096", self.nodes, DEBUG_MODE, 'c')
+        mark_logs(f"  6 - {exceeding_tx2}", self.nodes, DEBUG_MODE, 'e')
+        self.sync_all()
+
+        # Ask for a new block template
+        block_template = self.wait_for_block_template(0, i + 2)
+        assert(block_template is not None)
+        mark_logs(f"getblocktemplate() ->", self.nodes, DEBUG_MODE, 'e')
+        for k, transaction in enumerate(block_template['transactions']):
+            mark_logs(f"  {k} - {transaction['hash']}", self.nodes, DEBUG_MODE, 'e')
+        mark_logs(f"    ScTxsCommitmentTree root: {block_template['scTxsCommitment']}", self.nodes, DEBUG_MODE, 'e')
+
+        # The commitment tree should be the same as in the previous step because we rejected the last TX.
+        assert_equal(current_sc_txs_commitment_tree_root, block_template['scTxsCommitment'])
+        # Also, exceeding_tx2 should not have been included in the block
+        assert_false(exceeding_tx2 in [tx['hash'] for tx in block_template['transactions']], "The last TX should not be included in the block candidate!!!")
+
+
+        # Now we mine the block that includes the 5 valid txs, then we make sure that exceeding_tx and exciding_tx2 is still in mempool
+        mark_logs(f"Mine a block", self.nodes, DEBUG_MODE, 'c')
+        self.nodes[0].generate(1)
+        self.sync_all()
+        mark_logs(f"Confirm that only the exceeding txs are still in mempool", self.nodes, DEBUG_MODE, 'g')
+        a = self.nodes[1].getrawmempool(True)
+        assert_equal(len(a), 2)
+        assert_true(exceeding_tx  in a, "tx {exceeding_tx} should still be in node 1 mempool")
+        assert_true(exceeding_tx2 in a, "tx {exceeding_tx2} should still be in node 1 mempool")
+
+        # Mine a block to clean the mempool (and make sure that exceeding_tx and exceeding_tx2 have been included in the block)
+        mark_logs(f"Mine a block", self.nodes, DEBUG_MODE, 'c')
+        self.nodes[0].generate(1)
+        self.sync_all()
+        mark_logs(f"Confirm that the exceeding txs have been included in a block", self.nodes, DEBUG_MODE, 'g')
+        a = self.nodes[1].getrawmempool(True)
+        assert_equal(len(a), 0)
+
+        # final test: a tx breaking the rules should never be accepted
+        #(it implicitly violates the max size)
+        mark_logs(f"Sending a big txs that violates the rules", self.nodes, DEBUG_MODE, 'y')
+        try:
+            self.nodes[1].sc_send(forwardTransferOuts * 4096, {"fee": Decimal(0.004), "minconf": 0})
+            assert(False)
+        except JSONRPCException as e:
+            print(e.error['message'])
+
+if __name__ == '__main__':
+    BigCommitmentTree().main()

--- a/qa/rpc-tests/sc_big_commitment_tree_getblockmerkleroot.py
+++ b/qa/rpc-tests/sc_big_commitment_tree_getblockmerkleroot.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import initialize_chain_clean, \
+     start_nodes, assert_false, mark_logs
+from test_framework.test_framework import ForkHeights, JSONRPCException
+
+NUMB_OF_NODES = 1
+DEBUG_MODE = 1
+FT_LIMIT = 4095     # Keep this aligned with CCTPlib
+
+class BigCommitmentTree_getblockmerkleroot(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
+                                 extra_args=[['-logtimemicros=1', '-debug=sc', '-debug=py', '-debug=cert']] * NUMB_OF_NODES)
+        self.is_network_split = split
+
+    def run_test(self):
+        '''
+        1. Mine blocks until reaching the sidechain fork; initialize tx_data with valid transaction data
+        2. Create a raw tx
+        3. Generate merkleTree and scTxsCommitmentTree for (FT_LIMIT - 1), FT_LIMIT and (FT_LIMIT + 1) txs (current FT_LIMIT is 4095)
+        4. Check if the ScTxsCommitmentTree stops updating due to limited height
+        '''
+
+        # Reach SC v2 fork height
+        mark_logs("Generating enough blocks to reach SC fork", self.nodes, DEBUG_MODE, 'e')
+        self.nodes[0].generate(ForkHeights['MINIMAL_SC'])
+
+        # Valid addresses...
+        return_node_address = 'ztiQcTDe5sKctYZimWcZbkJY6nFQtQmMzcC'
+        scid = '041d1207045d3a03e957a4dec777fa74d66c1f3c8b9ee02a2092ef7cf74a5f51'
+        amount = 0.001
+        address = "aabb"
+        tx_data = {"address": address, "amount": amount, "scid": scid, "mcReturnAddress": return_node_address}
+
+        # No need to create a sidechain, getblockmerkleroots works anyway
+        rawtx = self.nodes[0].createrawtransaction([],{},[], [], [tx_data])
+
+        # Evaluate scCommitment tree before and across the limit
+        mark_logs(f"Evaluating merkle root and txs commitment for a tx with {(FT_LIMIT - 1)} FT", self.nodes, DEBUG_MODE, 'g')
+        merk_limit_1 = self.nodes[0].getblockmerkleroots([rawtx]*(FT_LIMIT - 1),[])
+        mark_logs(f"Evaluating merkle root and txs commitment for a tx with {FT_LIMIT} FT", self.nodes, DEBUG_MODE, 'g')
+        merk_limit = self.nodes[0].getblockmerkleroots([rawtx]*FT_LIMIT,[])
+        assert_false(merk_limit_1['scTxsCommitment'] == merk_limit['scTxsCommitment'])    # Under normal assumptions, these must be different
+
+        # Now this will fail
+        try:
+            mark_logs(f"Evaluating merkle root and txs commitment for a tx with {(FT_LIMIT + 1)} FT (must fail)", self.nodes, DEBUG_MODE, 'y')
+            merk_over = self.nodes[0].getblockmerkleroots([rawtx]*(FT_LIMIT + 1),[])
+            mark_logs("getblockmerkleroots() did not fail (that's bad)", self.nodes, DEBUG_MODE, 'r')
+            assert(False)
+        except JSONRPCException as e:
+            print(e.error['message'])
+            
+
+if __name__ == '__main__':
+    BigCommitmentTree_getblockmerkleroot().main()

--- a/qa/rpc-tests/sc_big_commitment_tree_getblockmerkleroot.py
+++ b/qa/rpc-tests/sc_big_commitment_tree_getblockmerkleroot.py
@@ -31,7 +31,7 @@ class BigCommitmentTree_getblockmerkleroot(BitcoinTestFramework):
         4. Check if the ScTxsCommitmentTree stops updating due to limited height
         '''
 
-        # Reach SC v2 fork height
+        # Reach SC fork height
         mark_logs("Generating enough blocks to reach SC fork", self.nodes, DEBUG_MODE, 'e')
         self.nodes[0].generate(ForkHeights['MINIMAL_SC'])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -283,6 +283,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/server.cpp \
   sc/asyncproofverifier.cpp \
   sc/sidechainTxsCommitmentBuilder.cpp \
+  sc/sidechainTxsCommitmentGuard.cpp \
   sc/sidechaintypes.cpp \
   sc/proofverifier.cpp \
   sc/sidechain.cpp \
@@ -524,6 +525,7 @@ zen_tx_SOURCES = \
     primitives/transaction.cpp \
     primitives/certificate.cpp \
     sc/sidechainTxsCommitmentBuilder.cpp \
+    sc/sidechainTxsCommitmentGuard.cpp \
     sc/sidechaintypes.cpp \
     sc/proofverifier.cpp \
     sc/sidechain.cpp \

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -46,7 +46,7 @@ CMutableTransaction GetValidTransaction(int txVersion) {
 
         CTxCeasedSidechainWithdrawalInput csw_ccin;
         csw_ccin.nValue = 2.0 * COIN;
-        csw_ccin.scId = GetRandHash();
+        csw_ccin.scId = uint256S("efefef");
         std::vector<unsigned char> nullifierStr(CFieldElement::ByteSize(), 0x0);
         GetRandBytes((unsigned char*)&nullifierStr[0], CFieldElement::ByteSize()-2);
         csw_ccin.nullifier.SetByteArray(nullifierStr);
@@ -61,11 +61,13 @@ CMutableTransaction GetValidTransaction(int txVersion) {
         cr_ccout.version = 0;
         cr_ccout.nValue = 1.0 * COIN;
         cr_ccout.withdrawalEpochLength = 111;
+        cr_ccout.wCertVk   = CScVKey{SAMPLE_CERT_DARLIN_VK};
+        cr_ccout.wCeasedVk = CScVKey{SAMPLE_CSW_DARLIN_VK};
         mtx.vsc_ccout.push_back(cr_ccout);
 
         CTxForwardTransferOut ft_ccout;
         ft_ccout.nValue = 10.0 * COIN;
-        ft_ccout.scId = GetRandHash();
+        ft_ccout.scId = uint256S("effeef");
         mtx.vft_ccout.push_back(ft_ccout);
     }
     else

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -4,6 +4,7 @@
 #include <primitives/transaction.h>
 #include <primitives/certificate.h>
 #include <sc/sidechainTxsCommitmentBuilder.h>
+#include <sc/sidechainTxsCommitmentGuard.h>
 #include "tx_creation_utils.h"
 
 #include <gtest/libzendoo_test_files.h>
@@ -24,6 +25,13 @@
 extern unsigned char ReverseBitsInByte(unsigned char input);
 
 using namespace blockchain_test_utils;
+
+// Keep them aligned with those defined in CCTPlib!
+constexpr int CCTP_COMMITMENT_BUILDER_SC_LIMIT   = 4096;
+constexpr int CCTP_COMMITMENT_BUILDER_FT_LIMIT   = 4095;
+constexpr int CCTP_COMMITMENT_BUILDER_BWTR_LIMIT = 4095;
+constexpr int CCTP_COMMITMENT_BUILDER_CERT_LIMIT = 4095;
+constexpr int CCTP_COMMITMENT_BUILDER_CSW_LIMIT  = 4095;
 
 /**
  * @brief Custom field randomly generated from seed 1641809674 using the rand() function.
@@ -574,7 +582,7 @@ TEST(SidechainsField, NakedZendooFeatures_TreeCommitmentCalculation)
     //fPrintToConsole = true;
 
     //Add txes containing scCreation and fwd transfer + a certificate
-    CTransaction scCreationTx = txCreationUtils::createNewSidechainTxWith(CAmount(10), /*height*/10);
+    CTransaction scCreationTx = txCreationUtils::createNewSidechainTxWith(CAmount(10), 10);
 
     CMutableTransaction mutTx = scCreationTx;
 
@@ -687,7 +695,9 @@ TEST(SidechainsField, CommitmentComputationFromSerializedBlock)
     }
 
     // Check the commitment tree
-    uint256 scTxCommitmentHash = block.BuildScTxsCommitment(testManager.CoinsViewCache().get());
+    uint256 scTxCommitmentHash;
+    scTxCommitmentHash.SetNull();
+    block.BuildScTxsCommitment(testManager.CoinsViewCache().get(), scTxCommitmentHash);
 
     EXPECT_TRUE(scTxCommitmentHash == uint256S("2a94ae04f2dcb25b274510a4611e1443b088ed2eac9211535105b35cfbd1c543"))
         << scTxCommitmentHash.ToString();
@@ -2490,4 +2500,579 @@ TEST(CctpLibrary, TestCustomFieldsValidationFix)
     certField = FieldElementCertificateField(rawBytes);
     fe = certField.GetFieldElement(config, 1);
     ASSERT_TRUE(fe.IsValid());
+}
+
+TEST(CctpLibrary, CommitmentBuilder_toomanySC) {
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    CMutableTransaction mtx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    // forward transfers with different sc_ids
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_SC_LIMIT; i++)
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(uint256S("abc" + std::to_string(i + 100)), CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx(mtx);
+    // We should be able to push the transaction to the builder and the guard
+    ASSERT_TRUE(cmtObj.add(tx));
+    ASSERT_TRUE(guardObj.add(tx));
+
+    CMutableTransaction mtx2;
+    mtx2.nVersion = SC_TX_VERSION;
+    mtx2.vsc_ccout.resize(0);
+    mtx2.vft_ccout.resize(0);
+    mtx2.vmbtr_out.resize(0);
+    mtx2.vcsw_ccin.resize(0);
+
+    mtx2.vft_ccout.push_back(CTxForwardTransferOut(uint256S("cccc"), CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx2(mtx2);
+    // Both must fail
+    ASSERT_FALSE(cmtObj.add(tx2));
+    ASSERT_FALSE(guardObj.add(tx2));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), CCTP_COMMITMENT_BUILDER_SC_LIMIT);
+
+    // Adding a FT to an already existing sidechain must not fail
+    CMutableTransaction mtx3;
+    mtx3.nVersion = SC_TX_VERSION;
+    mtx3.vsc_ccout.resize(0);
+    mtx3.vft_ccout.resize(0);
+    mtx3.vmbtr_out.resize(0);
+    mtx3.vcsw_ccin.resize(0);
+
+    mtx3.vft_ccout.push_back(CTxForwardTransferOut(uint256S("abc" + std::to_string(110)), CAmount(12), uint256S("abba101"), uint160S("abba101")));
+    CTransaction tx3(mtx3);
+    ASSERT_TRUE(cmtObj.add(tx3));
+    ASSERT_TRUE(guardObj.add(tx3));
+
+}
+
+TEST(CctpLibrary, CommitmentBuilder_toomanyFT)
+{
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    uint256 sidechainId = uint256S("abc");
+    CMutableTransaction mtx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    // forward transfers
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_FT_LIMIT; i++)
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx(mtx);
+    // We should be able to push the transaction to the builder and the guard
+    ASSERT_TRUE(cmtObj.add(tx));
+    ASSERT_TRUE(guardObj.add(tx));
+
+    CMutableTransaction mtx2;
+    mtx2.nVersion = SC_TX_VERSION;
+    mtx2.vsc_ccout.resize(0);
+    mtx2.vft_ccout.resize(0);
+    mtx2.vmbtr_out.resize(0);
+    mtx2.vcsw_ccin.resize(0);
+
+    mtx2.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx2(mtx2);
+    // Only the guard will fail
+    ASSERT_TRUE(cmtObj.add(tx2));
+    ASSERT_FALSE(guardObj.add(tx2));
+
+    // Builder will fail now
+    ASSERT_FALSE(cmtObj.add(tx2));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), 1);
+    ASSERT_EQ(cbsRef.cbscMap.size(), 0);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft,   CCTP_COMMITMENT_BUILDER_FT_LIMIT);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].bwtr, 0);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].cert, 0);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_toomanyBWTR)
+{
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    uint256 sidechainId = uint256S("abc");
+    CMutableTransaction mtx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    Sidechain::ScBwtRequestParameters scbwtr_params;
+    scbwtr_params.vScRequestData.push_back(CFieldElement{SAMPLE_FIELD});
+    scbwtr_params.scFee = 3;
+
+    // backward transfer requests
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_BWTR_LIMIT; i++)
+        mtx.vmbtr_out.push_back(CBwtRequestOut(sidechainId, uint160S("abba101"), scbwtr_params));
+
+    CTransaction tx(mtx);
+    // We should be able to push the transaction to the builder and the guard
+    ASSERT_TRUE(cmtObj.add(tx));
+    ASSERT_TRUE(guardObj.add(tx));
+
+    CMutableTransaction mtx3;
+    mtx3.nVersion = SC_TX_VERSION;
+    mtx3.vsc_ccout.resize(0);
+    mtx3.vft_ccout.resize(0);
+    mtx3.vmbtr_out.resize(0);
+    mtx3.vcsw_ccin.resize(0);
+
+    mtx3.vmbtr_out.push_back(CBwtRequestOut(sidechainId, uint160S("abba101"), scbwtr_params));
+
+    CTransaction tx3(mtx3);
+    // Only the guard will fail
+    ASSERT_TRUE(cmtObj.add(tx3));
+    ASSERT_FALSE(guardObj.add(tx3));
+
+    // Builder will fail now
+    ASSERT_FALSE(cmtObj.add(tx3));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), 1);
+    ASSERT_EQ(cbsRef.cbscMap.size(), 0);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft,   0);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].bwtr, CCTP_COMMITMENT_BUILDER_BWTR_LIMIT);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].cert, 0);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_toomanyCERT) {
+    SelectParams(CBaseChainParams::REGTEST);
+    const BlockchainTestManager& testManager = BlockchainTestManager::GetInstance();
+
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    CTransaction scCreationTx = txCreationUtils::createNewSidechainTxWith(CAmount(10), 10);
+    CMutableTransaction mtx = scCreationTx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    // sc creation transaction
+    auto ccout = CTxScCreationOut(CAmount(10), uint256S("aaa"), CAmount(0), CAmount(0), Sidechain::ScFixedParameters());
+    ccout.version = 0;
+    ccout.withdrawalEpochLength = 100;
+    ccout.wCertVk   = CScVKey{SAMPLE_CERT_DARLIN_VK};
+    ccout.wCeasedVk = CScVKey{SAMPLE_CSW_DARLIN_VK};
+    ccout.vFieldElementCertificateFieldConfig.push_back(44);
+    ccout.customData.push_back(0x77);
+    mtx.vsc_ccout.push_back(ccout);
+
+    uint256 scId = scCreationTx.GetScIdFromScCcOut(0);
+
+    CScCertificate cert = txCreationUtils::createCertificate(scId,
+        /*epochNum*/12, CFieldElement{SAMPLE_FIELD}, /*changeTotalAmount*/0,
+        /*numChangeOut */0, /*bwtTotalAmount*/1, /*numBwt*/1, /*ftScFee*/0, /*mbtrScFee*/0);
+
+    // We should be able to add the certificates to the builder and the guard
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_CERT_LIMIT; i++) {
+        ASSERT_TRUE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+        ASSERT_TRUE(guardObj.add(cert));
+    }
+
+    // Only the guard will fail
+    ASSERT_TRUE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+    ASSERT_FALSE(guardObj.add(cert));
+
+    // Builder will fail now
+    ASSERT_FALSE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), 1);
+    ASSERT_EQ(cbsRef.cbscMap.size(), 0);
+    ASSERT_EQ(cbsRef.cbsaMap[scId].ft,   0);
+    ASSERT_EQ(cbsRef.cbsaMap[scId].bwtr, 0);
+    ASSERT_EQ(cbsRef.cbsaMap[scId].cert, CCTP_COMMITMENT_BUILDER_CERT_LIMIT);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_toomanyCSW)
+{
+    const ProvingSystem testProvingSystem = ProvingSystem::Darlin;
+
+    SelectParams(CBaseChainParams::REGTEST);
+    BlockchainTestManager::GetInstance().GenerateSidechainTestParameters(testProvingSystem, TestCircuitType::Certificate, false);
+    BlockchainTestManager::GetInstance().GenerateSidechainTestParameters(testProvingSystem, TestCircuitType::CSW, false);
+
+    uint256 sidechainId = uint256S("aabba");
+
+    CSidechain sidechain;
+    sidechain.creationBlockHeight = 100;
+    sidechain.fixedParams.withdrawalEpochLength = 20;
+    sidechain.fixedParams.constant = CFieldElement{SAMPLE_FIELD};
+    sidechain.fixedParams.version = 0;
+    sidechain.lastTopQualityCertHash = uint256S("cccc");
+    sidechain.lastTopQualityCertQuality = 100;
+    sidechain.lastTopQualityCertReferencedEpoch = -1;
+    sidechain.lastTopQualityCertBwtAmount = 50;
+    sidechain.balance = CAmount(100);
+    sidechain.fixedParams.wCertVk = BlockchainTestManager::GetInstance().GetTestVerificationKey(testProvingSystem, TestCircuitType::Certificate);
+    sidechain.fixedParams.wCeasedVk = BlockchainTestManager::GetInstance().GetTestVerificationKey(testProvingSystem, TestCircuitType::CSW);
+    
+    BlockchainTestManager& testManager = BlockchainTestManager::GetInstance();
+    testManager.Reset();
+
+    // Store the test sidechain and extend the blockchain to complete at least one epoch. 
+    testManager.StoreSidechainWithCurrentHeight(sidechainId, sidechain, sidechain.creationBlockHeight + sidechain.fixedParams.withdrawalEpochLength);
+
+    CTxCeasedSidechainWithdrawalInput input1 = testManager.CreateCswInput(sidechainId, 1, testProvingSystem);
+
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    CMutableTransaction mtx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    // ceased sidechain withdrawals
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_CSW_LIMIT; i++)
+        mtx.vcsw_ccin.push_back(input1);
+
+    CTransaction tx(mtx);
+    // We should be able to push the transaction to the builder and the guard
+    ASSERT_TRUE(cmtObj.add(tx));
+    ASSERT_TRUE(guardObj.add(tx));
+
+    CMutableTransaction mtx3;
+    mtx3.nVersion = SC_TX_VERSION;
+    mtx3.vsc_ccout.resize(0);
+    mtx3.vft_ccout.resize(0);
+    mtx3.vmbtr_out.resize(0);
+    mtx3.vcsw_ccin.resize(0);
+
+    mtx3.vcsw_ccin.push_back(input1);
+
+    CTransaction tx3(mtx3);
+    // Only the guard will fail
+    ASSERT_TRUE(cmtObj.add(tx3));
+    ASSERT_FALSE(guardObj.add(tx3));
+
+    // Builder will fail now
+    ASSERT_FALSE(cmtObj.add(tx3));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), 0);
+    ASSERT_EQ(cbsRef.cbscMap.size(), 1);
+    ASSERT_EQ(cbsRef.cbscMap[sidechainId].csw, CCTP_COMMITMENT_BUILDER_CSW_LIMIT);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_sameSC_nevermixCSWandFT)
+{
+    const ProvingSystem testProvingSystem = ProvingSystem::Darlin;
+
+    SelectParams(CBaseChainParams::REGTEST);
+    BlockchainTestManager::GetInstance().GenerateSidechainTestParameters(testProvingSystem, TestCircuitType::Certificate, false);
+    BlockchainTestManager::GetInstance().GenerateSidechainTestParameters(testProvingSystem, TestCircuitType::CSW, false);
+
+    uint256 sidechainId = uint256S("aabba");
+
+    CSidechain sidechain;
+    sidechain.creationBlockHeight = 100;
+    sidechain.fixedParams.withdrawalEpochLength = 20;
+    sidechain.fixedParams.constant = CFieldElement{SAMPLE_FIELD};
+    sidechain.fixedParams.version = 0;
+    sidechain.lastTopQualityCertHash = uint256S("cccc");
+    sidechain.lastTopQualityCertQuality = 100;
+    sidechain.lastTopQualityCertReferencedEpoch = -1;
+    sidechain.lastTopQualityCertBwtAmount = 50;
+    sidechain.balance = CAmount(100);
+    sidechain.fixedParams.wCertVk = BlockchainTestManager::GetInstance().GetTestVerificationKey(testProvingSystem, TestCircuitType::Certificate);
+    sidechain.fixedParams.wCeasedVk = BlockchainTestManager::GetInstance().GetTestVerificationKey(testProvingSystem, TestCircuitType::CSW);
+    
+    BlockchainTestManager& testManager = BlockchainTestManager::GetInstance();
+    testManager.Reset();
+
+    // Store the test sidechain and extend the blockchain to complete at least one epoch. 
+    testManager.StoreSidechainWithCurrentHeight(sidechainId, sidechain, sidechain.creationBlockHeight + sidechain.fixedParams.withdrawalEpochLength);
+
+    CTxCeasedSidechainWithdrawalInput csw = testManager.CreateCswInput(sidechainId, 1, testProvingSystem);
+
+    // FT and CSW in the same tx
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    CMutableTransaction mtx, mtx2, mtx3;;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+    mtx2.nVersion = SC_TX_VERSION;
+    mtx2.vsc_ccout.resize(0);
+    mtx2.vft_ccout.resize(0);
+    mtx2.vmbtr_out.resize(0);
+    mtx2.vcsw_ccin.resize(0);
+    mtx3.nVersion = SC_TX_VERSION;
+    mtx3.vsc_ccout.resize(0);
+    mtx3.vft_ccout.resize(0);
+    mtx3.vmbtr_out.resize(0);
+    mtx3.vcsw_ccin.resize(0);
+
+    // forward transfer
+    mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+    // ceased sidechain withdrawals
+    mtx.vcsw_ccin.push_back(csw);
+
+    CTransaction tx(mtx);
+    // Both must fail
+    ASSERT_FALSE(cmtObj.add(tx));
+    ASSERT_FALSE(guardObj.add(tx));
+
+
+    // forward transfer
+    mtx2.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+    CTransaction tx2(mtx2);
+
+    // ceased sidechain withdrawals
+    mtx3.vcsw_ccin.push_back(csw);
+    CTransaction tx3(mtx3);
+
+    SidechainTxsCommitmentBuilder cmtObj2;
+    SidechainTxsCommitmentGuard guardObj2;
+    // tx with CSW after tx with FT (builder)
+    ASSERT_TRUE(cmtObj2.add(tx2));
+    ASSERT_FALSE(cmtObj2.add(tx3));
+    // tx with CSW after tx with FT (guard)
+    ASSERT_TRUE(guardObj2.add(tx2));
+    ASSERT_FALSE(guardObj2.add(tx3));
+
+    SidechainTxsCommitmentBuilder cmtObj3;
+    SidechainTxsCommitmentGuard guardObj3;
+    // tx with FT after tx with CSW (builder)
+    ASSERT_TRUE(cmtObj3.add(tx3));
+    ASSERT_FALSE(cmtObj3.add(tx2));
+    // tx with FT after tx with CSW (guard)
+    ASSERT_TRUE(guardObj3.add(tx3));
+    ASSERT_FALSE(guardObj3.add(tx2));
+
+    // Make sure that counters in CommitmentBuilderGuard are not incremented
+    auto cbsRef  = guardObj.getCBS();
+    auto cbsRef2 = guardObj2.getCBS();
+    auto cbsRef3 = guardObj3.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft,  1);
+    ASSERT_EQ(cbsRef.cbscMap[sidechainId].csw, 0);
+    ASSERT_EQ(cbsRef2.cbsaMap[sidechainId].ft,  1);
+    ASSERT_EQ(cbsRef2.cbscMap[sidechainId].csw, 0);
+    ASSERT_EQ(cbsRef3.cbsaMap[sidechainId].ft,  0);
+    ASSERT_EQ(cbsRef3.cbscMap[sidechainId].csw, 1);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_fillFTsendBWTRandCERT)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    const BlockchainTestManager& testManager = BlockchainTestManager::GetInstance();
+
+    SidechainTxsCommitmentBuilder cmtObj;
+    SidechainTxsCommitmentGuard guardObj;
+
+    CTransaction scCreationTx = txCreationUtils::createNewSidechainTxWith(CAmount(10), 10);
+    CMutableTransaction mtx = scCreationTx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    // sc creation transaction
+    auto ccout = CTxScCreationOut(CAmount(10), uint256S("aaa"), CAmount(0), CAmount(0), Sidechain::ScFixedParameters());
+    ccout.version = 0;
+    ccout.withdrawalEpochLength = 100;
+    ccout.wCertVk   = CScVKey{SAMPLE_CERT_DARLIN_VK};
+    ccout.wCeasedVk = CScVKey{SAMPLE_CSW_DARLIN_VK};
+    ccout.vFieldElementCertificateFieldConfig.push_back(44);
+    ccout.customData.push_back(0x77);
+    mtx.vsc_ccout.push_back(ccout);
+
+    uint256 sidechainId = scCreationTx.GetScIdFromScCcOut(0);
+
+
+    // forward transfers
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_FT_LIMIT; i++)
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx(mtx);
+    ASSERT_TRUE(cmtObj.add(tx));
+    ASSERT_TRUE(guardObj.add(tx));
+
+
+    CMutableTransaction mtxbwtr;
+    mtxbwtr.nVersion = SC_TX_VERSION;
+    mtxbwtr.vsc_ccout.resize(0);
+    mtxbwtr.vft_ccout.resize(0);
+    mtxbwtr.vmbtr_out.resize(0);
+    mtxbwtr.vcsw_ccin.resize(0);
+
+    Sidechain::ScBwtRequestParameters scbwtr_params;
+    scbwtr_params.vScRequestData.push_back(CFieldElement{SAMPLE_FIELD});
+    scbwtr_params.scFee = 3;
+
+    // backward transfer requests
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_BWTR_LIMIT; i++)
+        mtxbwtr.vmbtr_out.push_back(CBwtRequestOut(sidechainId, uint160S("abba101"), scbwtr_params));
+    CTransaction txbwtr(mtxbwtr);
+    ASSERT_TRUE(cmtObj.add(txbwtr));
+    ASSERT_TRUE(guardObj.add(txbwtr));
+
+
+    CScCertificate cert = txCreationUtils::createCertificate(sidechainId,
+        /*epochNum*/12, CFieldElement{SAMPLE_FIELD}, /*changeTotalAmount*/0,
+        /*numChangeOut */0, /*bwtTotalAmount*/1, /*numBwt*/1, /*ftScFee*/0, /*mbtrScFee*/0);
+
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_CERT_LIMIT; i++) {
+        ASSERT_TRUE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+        ASSERT_TRUE(guardObj.add(cert));
+    }
+
+    CMutableTransaction mtx3, mtx4;
+    mtx3.nVersion = SC_TX_VERSION;
+    mtx3.vsc_ccout.resize(0);
+    mtx3.vft_ccout.resize(0);
+    mtx3.vmbtr_out.resize(0);
+    mtx3.vcsw_ccin.resize(0);
+    mtx4.nVersion = SC_TX_VERSION;
+    mtx4.vsc_ccout.resize(0);
+    mtx4.vft_ccout.resize(0);
+    mtx4.vmbtr_out.resize(0);
+    mtx4.vcsw_ccin.resize(0);
+
+    mtx3.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+    CTransaction tx3(mtx3);
+    ASSERT_TRUE(cmtObj.add(tx3));
+    ASSERT_FALSE(guardObj.add(tx3));
+
+    mtx4.vmbtr_out.push_back(CBwtRequestOut(sidechainId, uint160S("abba101"), scbwtr_params));
+    CTransaction tx4(mtx4);
+    ASSERT_TRUE(cmtObj.add(tx4));
+    ASSERT_FALSE(guardObj.add(tx4));
+
+    ASSERT_TRUE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+    ASSERT_FALSE(guardObj.add(cert));
+
+    // Builder will fail now
+    ASSERT_FALSE(cmtObj.add(tx3));
+    ASSERT_FALSE(cmtObj.add(tx4));
+    ASSERT_FALSE(cmtObj.add(cert, testManager.CoinsViewCache().get()));
+
+    // check counters
+    auto cbsRef  = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap.size(), 1);
+    ASSERT_EQ(cbsRef.cbscMap.size(), 0);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft,   CCTP_COMMITMENT_BUILDER_FT_LIMIT);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].bwtr, CCTP_COMMITMENT_BUILDER_BWTR_LIMIT);
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].cert, CCTP_COMMITMENT_BUILDER_CERT_LIMIT);
+}
+
+TEST(CctpLibrary, CommitmentBuilder_rewind)
+{
+    SidechainTxsCommitmentGuard guardObj;
+
+    uint256 sidechainId = uint256S("abc");
+    uint256 sidechainId2 = uint256S("abcba");
+    CMutableTransaction mtx;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+
+    const int intialFT = CCTP_COMMITMENT_BUILDER_FT_LIMIT - 3;
+
+    // forward transfers: reaching almost the limit
+    for (int i = 0; i < intialFT; i++)  // 4092
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+    // Also add a FT for another sidechain
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId2, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx(mtx);
+    ASSERT_TRUE(guardObj.add(tx));
+
+    // Each transaction will go beyond the limit, so we will try to restore the guard state as before the failure
+    for (int i = 4; i < 15; i++) {
+        CMutableTransaction mtx2;
+        mtx2.nVersion = SC_TX_VERSION;
+        mtx2.vsc_ccout.resize(0);
+        mtx2.vft_ccout.resize(0);
+        mtx2.vmbtr_out.resize(0);
+        mtx2.vcsw_ccin.resize(0);
+
+        for (int j = 0; j < i; j++)
+            mtx2.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+        CTransaction tx2(mtx2);
+
+        // Automatically restore guardObj to a valid state
+        ASSERT_FALSE(guardObj.add(tx2, true));
+
+        auto cbsRef  = guardObj.getCBS();
+        ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft, intialFT);
+        // And the other sc should have been left intact
+        ASSERT_EQ(cbsRef.cbsaMap[sidechainId2].ft, 1);
+    }
+}
+
+TEST(CctpLibrary, CommitmentBuilder_cleanCBSafterrewind)
+{
+    SidechainTxsCommitmentGuard guardObj;
+
+    uint256 sidechainId = uint256S("abc");
+    uint256 sidechainId2 = uint256S("abcba");
+    CMutableTransaction mtx, mtx2;
+    mtx.nVersion = SC_TX_VERSION;
+    mtx.vsc_ccout.resize(0);
+    mtx.vft_ccout.resize(0);
+    mtx.vmbtr_out.resize(0);
+    mtx.vcsw_ccin.resize(0);
+    mtx2.nVersion = SC_TX_VERSION;
+    mtx2.vsc_ccout.resize(0);
+    mtx2.vft_ccout.resize(0);
+    mtx2.vmbtr_out.resize(0);
+    mtx2.vcsw_ccin.resize(0);
+
+    for (int i = 0; i < 10; i++)
+        mtx.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    // forward transfers for different sidechains, sidechainId2 alone should fail
+    mtx2.vft_ccout.push_back(CTxForwardTransferOut(sidechainId, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+    for (int i = 0; i < CCTP_COMMITMENT_BUILDER_FT_LIMIT + 1; i++)  // 4096
+        mtx2.vft_ccout.push_back(CTxForwardTransferOut(sidechainId2, CAmount(43), uint256S("abba101"), uint160S("abba101")));
+
+    CTransaction tx(mtx);
+    CTransaction tx2(mtx2);
+    ASSERT_TRUE(guardObj.add(tx, true));
+    // Transaction must be rejected and cbs state should be restored
+    ASSERT_FALSE(guardObj.add(tx2, true));
+
+    // Guard object must not contain anything about sidechainId2
+    ASSERT_EQ(guardObj.getCBS().cbsaMap.size(), 1);
+    ASSERT_EQ(guardObj.getCBS().cbsaMap.count(sidechainId),  1);
+    ASSERT_EQ(guardObj.getCBS().cbsaMap.count(sidechainId2), 0);
+    ASSERT_EQ(guardObj.getCBS().cbscMap.size(), 0);
+    ASSERT_EQ(guardObj.getCBS().cbscMap.count(sidechainId),  0);
+    ASSERT_EQ(guardObj.getCBS().cbscMap.count(sidechainId2), 0);
 }

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -695,12 +695,10 @@ TEST(SidechainsField, CommitmentComputationFromSerializedBlock)
     }
 
     // Check the commitment tree
-    uint256 scTxCommitmentHash;
-    scTxCommitmentHash.SetNull();
-    block.BuildScTxsCommitment(testManager.CoinsViewCache().get(), scTxCommitmentHash);
+    block.UpdateScTxsCommitment(testManager.CoinsViewCache().get());
 
-    EXPECT_TRUE(scTxCommitmentHash == uint256S("2a94ae04f2dcb25b274510a4611e1443b088ed2eac9211535105b35cfbd1c543"))
-        << scTxCommitmentHash.ToString();
+    EXPECT_TRUE(block.hashScTxsCommitment == uint256S("2a94ae04f2dcb25b274510a4611e1443b088ed2eac9211535105b35cfbd1c543"))
+        << block.hashScTxsCommitment.ToString();
 }
 
 TEST(CctpLibrary, BitVectorUncompressed)
@@ -3075,4 +3073,8 @@ TEST(CctpLibrary, CommitmentBuilder_cleanCBSafterrewind)
     ASSERT_EQ(guardObj.getCBS().cbscMap.size(), 0);
     ASSERT_EQ(guardObj.getCBS().cbscMap.count(sidechainId),  0);
     ASSERT_EQ(guardObj.getCBS().cbscMap.count(sidechainId2), 0);
+
+    // Checking that tx2 has been rewind
+    auto cbsRef = guardObj.getCBS();
+    ASSERT_EQ(cbsRef.cbsaMap[sidechainId].ft, 10);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3429,10 +3429,31 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         assert(tree.root() == old_tree_root);
     }
 
+    // Check sidechain txs commitment tree limits now. This is less expensive than populating a txsCommitmentBuilder
+    if (ForkManager::getInstance().isNonCeasingSidechainActive(pindex->nHeight)) {
+        SidechainTxsCommitmentGuard scCommGuard;
+        for (unsigned int txIdx = 0; txIdx < block.vtx.size(); ++txIdx) {
+            const CTransaction &tx = block.vtx[txIdx];
+            if (!scCommGuard.add(tx))
+                return state.DoS(100, error("%s():%d: cannot add tx to scTxsCommitment guard", __func__, __LINE__),
+                    CValidationState::Code::INVALID, "bad-blk-tx-commitguard");
+        }
+        for (unsigned int certIdx = 0; certIdx < block.vcert.size(); certIdx++) {
+            const CScCertificate &cert = block.vcert[certIdx];
+            if (!scCommGuard.add(cert))
+                return state.DoS(100, error("%s():%d: cannot add cert to scTxsCommitmentBuilder", __func__, __LINE__),
+                    CValidationState::Code::INVALID, "bad-blk-cert-commitguard");
+        }
+    }
+
     const auto scVerifierMode = fExpensiveChecks ?
                 CScProofVerifier::Verification::Strict : CScProofVerifier::Verification::Loose;
     // Set high priority to verify the proofs as soon as possible (pausing mempool verification operations if any.)
     CScProofVerifier scVerifier{scVerifierMode, CScProofVerifier::Priority::High};
+    // We check scCommitmentBuilder's status after adding each tx or cert to avoid accepting blocks
+    // having a total number of sc or ft / bwt / csw / cert per sidechain greater than currently
+    // supported by CCTPlib.
+    // We also check that the on-the-fly calculated scTxsCommitment is equal to that included in the block.
     SidechainTxsCommitmentBuilder scCommitmentBuilder;
      
     for (unsigned int txIdx = 0; txIdx < block.vtx.size(); ++txIdx) // Processing transactions loop
@@ -3583,8 +3604,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         vTxIndexValues.push_back(std::make_pair(tx.GetHash(), CTxIndexValue(pos, txIdx, 0)));
         pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
 
-        if (fScRelatedChecks == flagScRelatedChecks::ON)
-            scCommitmentBuilder.add(tx);
+        if (fScRelatedChecks == flagScRelatedChecks::ON) {
+            bool retBuilder = scCommitmentBuilder.add(tx);
+            if (!retBuilder && ForkManager::getInstance().isNonCeasingSidechainActive(pindex->nHeight))
+                return state.DoS(100, error("%s():%d: cannot add tx to scTxsCommitmentBuilder", __func__, __LINE__),
+                    CValidationState::Code::INVALID, "bad-blk-tx-commitbuild");
+        }
     }  //end of Processing transactions loop
 
 
@@ -3792,7 +3817,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         if (fScRelatedChecks == flagScRelatedChecks::ON)
         {
-            scCommitmentBuilder.add(cert, view);
+            bool retBuilder = scCommitmentBuilder.add(cert, view);
+            if (!retBuilder && ForkManager::getInstance().isNonCeasingSidechainActive(pindex->nHeight))
+                return state.DoS(100, error("%s():%d: cannot add cert to scTxsCommitmentBuilder", __func__, __LINE__),
+                    CValidationState::Code::INVALID, "bad-blk-cert-commitbuild");
         }
 
 #ifdef ENABLE_ADDRESS_INDEXING

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1256,7 +1256,7 @@ MempoolReturnValue AcceptCertificateToMemoryPool(CTxMemPool& pool, CValidationSt
             int nDoS = 0;
 
             // checking txs commitment tree validity
-            if (ForkManager::getInstance().isNonCeasingSidechainActive(pcoinsTip->GetHeight())) {
+            if (ForkManager::getInstance().isNonCeasingSidechainActive(nextBlockHeight)) {
                 SidechainTxsCommitmentGuard scCommitmentGuard;
                 bool retval = scCommitmentGuard.add(cert);
                 if (!retval) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -23,6 +23,8 @@
 #include "pow.h"
 #include "primitives/transaction.h"
 #include "random.h"
+#include "sc/sidechainTxsCommitmentBuilder.h"
+#include "sc/sidechainTxsCommitmentGuard.h"
 #include "timedata.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -528,6 +530,24 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
         return NULL;
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
 
+    // We create a temporary sidechain tx commitment builder and populate it
+    // with the txs and certs that are progressively added to the candidate block.
+    // However, before adding a candidate tx / cert to the builder, we try adding that to a
+    // txsCommitmentGuard structure that keeps track of how many SC / FT / BWTR / CSW / CERT
+    // are currently in the candidate block. We do this, because adding a tx to the commitment tree
+    // is not an atomic operation and it is not possible to remove leaves in case we detect a failure.
+    // These failures may be caused by:
+    // - reaching the SC subtree limit
+    // - reaching the FT / BWT / CERT / CSW limit in each subtree
+    // - reaching the number of BWT limit per sidechain
+    // - trying to add a FT / BWT / CERT to a ceased sidechain
+    // - trying to add a CSW to an alive sidechain
+    // All the limits are defined in CommitmentBuilderGuard, and aligned with those defined in CCTPlib.
+    // Doing the add on the txsCommitmentGuard is reversible and prevents throwing away and rebuild
+    // the commitment tree in case of failure.
+    std::unique_ptr<SidechainTxsCommitmentBuilder> scCommBuilder(new SidechainTxsCommitmentBuilder);
+    SidechainTxsCommitmentGuard scCommGuard;
+
     // Add dummy coinbase tx as first transaction
     pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
@@ -707,6 +727,48 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
                 continue;
             }
 
+            // Skip transaction if we cannot add it to the sc commitment tree
+            if (pblock->nVersion == BLOCK_VERSION_SC_SUPPORT) {
+                // Check tx commitment tree limits
+                bool scCommitGuardRes;
+                if (tx.IsCertificate()) {
+                    scCommitGuardRes = scCommGuard.add(dynamic_cast<const CScCertificate&>(tx));
+                } else {
+                    // Immediately restore scCommitmentGuard to a valid state in case of failure
+                    scCommitGuardRes = scCommGuard.add(dynamic_cast<const CTransaction&>(tx), true);
+                }
+
+                if (!scCommitGuardRes) {
+                    LogPrint("sc", "%s():%d - Skipping [%s] because txs commitment tree guard failed\n",
+                            __func__, __LINE__, tx.GetHash().ToString());
+                    continue;
+                }
+
+                // Try adding to the real commitment tree if previous step was successful
+                bool scCommitmentBuilderResult;
+                if (tx.IsCertificate()) {
+                    scCommitmentBuilderResult = scCommBuilder->add(dynamic_cast<const CScCertificate&>(tx), view);
+                }
+                else {
+                    scCommitmentBuilderResult = scCommBuilder->add(dynamic_cast<const CTransaction&>(tx));
+                }
+                if (!scCommitmentBuilderResult)
+                {
+                    LogPrint("sc", "%s():%d - Skipping [%s] because we cannot add that to the sc commitment tree\n",
+                        __func__, __LINE__, tx.GetHash().ToString());
+                    // We cannot undo adding all the FT / BWTR / CERT / CSW contained in the tx that just failed,
+                    // so we have to destroy the scCommBuilder and add all the txs which are currently in the
+                    // block proposal
+                    scCommBuilder.reset(new SidechainTxsCommitmentBuilder);
+                    for (const auto& txInPBlock : pblock->vtx)
+                        scCommBuilder->add(txInPBlock);
+                    for (const auto& certInPBlock : pblock->vcert)
+                        scCommBuilder->add(certInPBlock, view);
+
+                    continue;
+                }
+            }
+
             try {
                 // Note that flags: we don't want to set mempool/IsStandard()
                 // policy here, but we still have to ensure that the block we
@@ -809,9 +871,16 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
 
-        if (pblock->nVersion == BLOCK_VERSION_SC_SUPPORT )
+        if (pblock->nVersion == BLOCK_VERSION_SC_SUPPORT)
         {
-            pblock->hashScTxsCommitment = pblock->BuildScTxsCommitment(view);
+            pblock->hashScTxsCommitment.SetNull();
+            bool retValtxsComm = pblock->BuildScTxsCommitment(view, pblock->hashScTxsCommitment);
+            assert(retValtxsComm);
+            // Additional check: this sc commitment must be equal to the one we built on the fly
+            const uint256& scTxsCommitment = scCommBuilder->getCommitment();
+            if (pblock->hashScTxsCommitment != scTxsCommitment) {
+                throw std::runtime_error("CreateNewBlock(): SCTxsCommitment verification failed");
+            }
         }
 
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -151,7 +151,7 @@ uint256 CBlock::BuildMerkleTree(std::vector<uint256>& vMerkleTreeIn, size_t vtxS
     return (vMerkleTreeIn.empty() ? uint256() : vMerkleTreeIn.back());
 }
 
-bool CBlock::BuildScTxsCommitment(const CCoinsViewCache& view, uint256& scCommitment)
+bool CBlock::UpdateScTxsCommitment(const CCoinsViewCache& view)
 {
     SidechainTxsCommitmentBuilder scCommitmentBuilder;
     bool result;
@@ -160,6 +160,7 @@ bool CBlock::BuildScTxsCommitment(const CCoinsViewCache& view, uint256& scCommit
     {
         result = scCommitmentBuilder.add(tx);
         if (!result){
+            hashScTxsCommitment.SetNull();
             return false;
         }
     }
@@ -168,11 +169,12 @@ bool CBlock::BuildScTxsCommitment(const CCoinsViewCache& view, uint256& scCommit
     {
         result = scCommitmentBuilder.add(cert, view);
         if (!result){
+            hashScTxsCommitment.SetNull();
             return false;
         }
     }
 
-    scCommitment = scCommitmentBuilder.getCommitment();
+    hashScTxsCommitment = scCommitmentBuilder.getCommitment();
     return true;
 }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -181,9 +181,13 @@ public:
     // merkle root).
     uint256 BuildMerkleTree(bool* mutated = NULL) const;
 
-    // Build the sc txs commitment tree as described in zendoo paper. It is based on contribution from
-    // sidechains-related txes and certificates contained in this block. Returns the txs commitment.
-    bool BuildScTxsCommitment(const CCoinsViewCache& view, uint256& scCommitment);
+    // Build / updates the sc txs commitment tree as described in zendoo paper. It is based on contribution from
+    // sidechains-related txes and certificates contained in this block. Returns the status of the opeartion.
+    // In case of failure hashScTxsCommitment is set to null.
+    bool UpdateScTxsCommitment(const CCoinsViewCache& view);
+    // Builds a commitment tree guard that keeps track of how many SC/FT/BWTR/CSW/CERT can be added to a real
+    // txs commitment tree. This is used to intercept operations that may invalidate the tree, preventing expensive
+    // allocations of a real commitment tree.
     bool BuildScTxsCommitmentGuard();
     
     std::vector<uint256> GetMerkleBranch(int nIndex) const;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -181,9 +181,10 @@ public:
     // merkle root).
     uint256 BuildMerkleTree(bool* mutated = NULL) const;
 
-    // return the sc txs commitment calculated as described in zendoo paper. It is based on contribution from
-    // sidechains-related txes and certificates contained in this block
-    uint256 BuildScTxsCommitment(const CCoinsViewCache& view);
+    // Build the sc txs commitment tree as described in zendoo paper. It is based on contribution from
+    // sidechains-related txes and certificates contained in this block. Returns the txs commitment.
+    bool BuildScTxsCommitment(const CCoinsViewCache& view, uint256& scCommitment);
+    bool BuildScTxsCommitmentGuard();
     
     std::vector<uint256> GetMerkleBranch(int nIndex) const;
     std::string ToString() const;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -731,9 +731,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         if (certSupported) {
             CCoinsViewCache view(pcoinsTip);
-            pblock->hashScTxsCommitment.SetNull();
             // At this point, txs commitment tree should be valid
-            bool retValtxsComm = pblock->BuildScTxsCommitment(view, pblock->hashScTxsCommitment);
+            bool retValtxsComm = pblock->UpdateScTxsCommitment(view);
             assert(retValtxsComm);
         }
 
@@ -1054,8 +1053,6 @@ UniValue getblockmerkleroots(const UniValue& params, bool fHelp) {
     CCoinsViewCache view(pcoinsTip);
 
     uint256 merkleTree = pblock->BuildMerkleTree();
-    uint256 scTxsCommitment;
-    scTxsCommitment.SetNull();
     if (certSupported) {
         if (!pblock->BuildScTxsCommitmentGuard()) {
             LogPrint("sc", "%s():%d - scTxsCommitment guard failed. Check the number of sc or txs / cert for each sc.\n",
@@ -1063,7 +1060,7 @@ UniValue getblockmerkleroots(const UniValue& params, bool fHelp) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "scTxsCommitment guard failed");
         }
 
-        if (!pblock->BuildScTxsCommitment(view, scTxsCommitment))
+        if (!pblock->UpdateScTxsCommitment(view))
         {
             LogPrint("sc", "%s():%d - scTxsCommitment evaluation failed.\n",
                 __func__, __LINE__);
@@ -1073,7 +1070,7 @@ UniValue getblockmerkleroots(const UniValue& params, bool fHelp) {
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("merkleTree", merkleTree.ToString());
-    result.pushKV("scTxsCommitment", scTxsCommitment.ToString());
+    result.pushKV("scTxsCommitment", pblock->hashScTxsCommitment.ToString());
 
     return result;
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1057,7 +1057,18 @@ UniValue getblockmerkleroots(const UniValue& params, bool fHelp) {
     uint256 scTxsCommitment;
     scTxsCommitment.SetNull();
     if (certSupported) {
-        scTxsCommitment = pblock->BuildScTxsCommitment(view);
+        if (!pblock->BuildScTxsCommitmentGuard()) {
+            LogPrint("sc", "%s():%d - scTxsCommitment guard failed. Check the number of sc or txs / cert for each sc.\n",
+                __func__, __LINE__);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "scTxsCommitment guard failed");
+        }
+
+        if (!pblock->BuildScTxsCommitment(view, scTxsCommitment))
+        {
+            LogPrint("sc", "%s():%d - scTxsCommitment evaluation failed.\n",
+                __func__, __LINE__);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "scTxsCommitment evaluation failed");
+        }
     }
 
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -731,7 +731,10 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         if (certSupported) {
             CCoinsViewCache view(pcoinsTip);
-            pblock->hashScTxsCommitment = pblock->BuildScTxsCommitment(view);
+            pblock->hashScTxsCommitment.SetNull();
+            // At this point, txs commitment tree should be valid
+            bool retValtxsComm = pblock->BuildScTxsCommitment(view, pblock->hashScTxsCommitment);
+            assert(retValtxsComm);
         }
 
         result.pushKV("merkleTree", pblock->hashMerkleRoot.ToString());

--- a/src/sc/sidechainTxsCommitmentBuilder.cpp
+++ b/src/sc/sidechainTxsCommitmentBuilder.cpp
@@ -161,6 +161,14 @@ bool SidechainTxsCommitmentBuilder::add_fwt(const CTxForwardTransferOut& ccout, 
          &ret_code
     );
 
+    if (ret) {
+    LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added FT for sidechain scId[%s].\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding FT for sidechain scId[%s] (CCTPlib error).\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+    }
+
     return ret;
 }
 
@@ -189,7 +197,7 @@ bool SidechainTxsCommitmentBuilder::add_bwtr(const CBwtRequestOut& ccout, const 
     const uint160& bwtr_pk_hash = ccout.mcDestinationAddress;
     BufferWithSize bws_bwtr_pk_hash(bwtr_pk_hash.begin(), bwtr_pk_hash.size());
 
-    return zendoo_commitment_tree_add_bwtr(const_cast<commitment_tree_t*>(_cmt),
+    bool ret = zendoo_commitment_tree_add_bwtr(const_cast<commitment_tree_t*>(_cmt),
          scid_fe,
          ccout.scFee,
          sc_req_data.get(),
@@ -199,6 +207,16 @@ bool SidechainTxsCommitmentBuilder::add_bwtr(const CBwtRequestOut& ccout, const 
          out_idx,
          &ret_code
     );
+
+    if (ret) {
+        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added BWTR for sidechain scId[%s].\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding BWTR for sidechain scId[%s] (CCTPlib error).\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+    }
+
+    return ret;
 }
 
 bool SidechainTxsCommitmentBuilder::add_csw(const CTxCeasedSidechainWithdrawalInput& ccin, CctpErrorCode& ret_code)
@@ -213,13 +231,23 @@ bool SidechainTxsCommitmentBuilder::add_csw(const CTxCeasedSidechainWithdrawalIn
 
     wrappedFieldPtr sptrNullifier = ccin.nullifier.GetFieldElement();
 
-    return zendoo_commitment_tree_add_csw(const_cast<commitment_tree_t*>(_cmt),
+    bool ret = zendoo_commitment_tree_add_csw(const_cast<commitment_tree_t*>(_cmt),
          scid_fe,
          ccin.nValue,
          sptrNullifier.get(),
          &bws_csw_pk_hash,
          &ret_code
     );
+
+    if (ret) {
+        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added CSW for sidechain scId[%s].\n",
+            __func__, __LINE__, ccin.scId.ToString());
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding CSW for sidechain scId[%s] (CCTPlib error).\n",
+            __func__, __LINE__, ccin.scId.ToString());
+    }
+
+    return ret;
 }
 
 bool SidechainTxsCommitmentBuilder::add_cert(const CScCertificate& cert, const Sidechain::ScFixedParameters scFixedParams, CctpErrorCode& ret_code)
@@ -276,7 +304,7 @@ bool SidechainTxsCommitmentBuilder::add_cert(const CScCertificate& cert, const S
 
     wrappedFieldPtr sptrCum = cert.endEpochCumScTxCommTreeRoot.GetFieldElement();
 
-    return zendoo_commitment_tree_add_cert(const_cast<commitment_tree_t*>(_cmt),
+    bool ret = zendoo_commitment_tree_add_cert(const_cast<commitment_tree_t*>(_cmt),
          scid_fe,
          cert.epochNumber,
          cert.quality,
@@ -289,6 +317,16 @@ bool SidechainTxsCommitmentBuilder::add_cert(const CScCertificate& cert, const S
          cert.mainchainBackwardTransferRequestScFee,
          &ret_code
     );
+
+    if (ret) {
+        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added CERT for sidechain scId[%s].\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding CERT for sidechain scId[%s] (CCTPlib error).\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+    }
+
+    return ret;
 }
 
 bool SidechainTxsCommitmentBuilder::add(const CTransaction& tx)

--- a/src/sc/sidechainTxsCommitmentBuilder.cpp
+++ b/src/sc/sidechainTxsCommitmentBuilder.cpp
@@ -161,10 +161,7 @@ bool SidechainTxsCommitmentBuilder::add_fwt(const CTxForwardTransferOut& ccout, 
          &ret_code
     );
 
-    if (ret) {
-    LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added FT for sidechain scId[%s].\n",
-            __func__, __LINE__, ccout.GetScId().ToString());
-    } else {
+    if (!ret) {
         LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding FT for sidechain scId[%s] (CCTPlib error).\n",
             __func__, __LINE__, ccout.GetScId().ToString());
     }
@@ -208,10 +205,7 @@ bool SidechainTxsCommitmentBuilder::add_bwtr(const CBwtRequestOut& ccout, const 
          &ret_code
     );
 
-    if (ret) {
-        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added BWTR for sidechain scId[%s].\n",
-            __func__, __LINE__, ccout.GetScId().ToString());
-    } else {
+    if (!ret) {
         LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding BWTR for sidechain scId[%s] (CCTPlib error).\n",
             __func__, __LINE__, ccout.GetScId().ToString());
     }
@@ -239,10 +233,7 @@ bool SidechainTxsCommitmentBuilder::add_csw(const CTxCeasedSidechainWithdrawalIn
          &ret_code
     );
 
-    if (ret) {
-        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added CSW for sidechain scId[%s].\n",
-            __func__, __LINE__, ccin.scId.ToString());
-    } else {
+    if (!ret) {
         LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding CSW for sidechain scId[%s] (CCTPlib error).\n",
             __func__, __LINE__, ccin.scId.ToString());
     }
@@ -318,10 +309,7 @@ bool SidechainTxsCommitmentBuilder::add_cert(const CScCertificate& cert, const S
          &ret_code
     );
 
-    if (ret) {
-        LogPrint("sc", "%s():%d - scTxsCommitment builder: successfully added CERT for sidechain scId[%s].\n",
-            __func__, __LINE__, cert.GetScId().ToString());
-    } else {
+    if (!ret) {
         LogPrint("sc", "%s():%d - scTxsCommitment building failed when adding CERT for sidechain scId[%s] (CCTPlib error).\n",
             __func__, __LINE__, cert.GetScId().ToString());
     }

--- a/src/sc/sidechainTxsCommitmentBuilder.h
+++ b/src/sc/sidechainTxsCommitmentBuilder.h
@@ -41,7 +41,6 @@ private:
 
     bool add_csw(const CTxCeasedSidechainWithdrawalInput& ccin, CctpErrorCode& ret_code);
     bool add_cert(const CScCertificate& cert, Sidechain::ScFixedParameters scFixedParams, CctpErrorCode& ret_code);
-
 };
 
 #endif

--- a/src/sc/sidechainTxsCommitmentGuard.cpp
+++ b/src/sc/sidechainTxsCommitmentGuard.cpp
@@ -119,7 +119,7 @@ bool SidechainTxsCommitmentGuard::add_cert(const CScCertificate& cert)
     }
 
     // We have an hard limit for the total number of backward transfers inside all the certificates per sidechain
-    if (cbs.cbsaMap[cert.GetScId()].bwt + bt_list_len > cbs.BWT_LIMIT) {
+    if (bt_list_len > cbs.BWT_LIMIT) {
         LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many total BWT when adding cert for scId[%s]\n",
             __func__, __LINE__, cert.GetScId().ToString());
         return false;
@@ -131,7 +131,6 @@ bool SidechainTxsCommitmentGuard::add_cert(const CScCertificate& cert)
     // Only try to add if under the limit; increase the counter only if add was successful.
     if (counterRef.cert < cbs.CERT_LIMIT) {
         ++counterRef.cert;
-        counterRef.bwt += bt_list_len;
         return true;
     } else {
         LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many CERT for sidechain scId[%s].\n",
@@ -227,7 +226,7 @@ bool SidechainTxsCommitmentGuard::add(const CScCertificate& cert)
 void SidechainTxsCommitmentGuard::keepMapsClean() {
     auto itA = cbs.cbsaMap.begin();
     while (itA != cbs.cbsaMap.end()) {
-        if ((itA->second.bwt == 0) && (itA->second.bwtr == 0) && (itA->second.cert == 0) && (itA->second.ft == 0))
+        if ((itA->second.bwtr == 0) && (itA->second.cert == 0) && (itA->second.ft == 0))
             cbs.cbsaMap.erase(itA++);
         else
             ++itA;
@@ -281,7 +280,6 @@ void SidechainTxsCommitmentGuard::rewind(const CScCertificate& cert) {
     size_t bt_list_len = cert.GetVout().size() - cert.nFirstBwtPos;
     CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[cert.GetScId()];
     --counterRef.cert;
-    counterRef.bwt -= bt_list_len;
     keepMapsClean();
 }
 

--- a/src/sc/sidechainTxsCommitmentGuard.cpp
+++ b/src/sc/sidechainTxsCommitmentGuard.cpp
@@ -1,0 +1,280 @@
+#include <sc/sidechainTxsCommitmentGuard.h>
+#include <primitives/transaction.h>
+#include <primitives/certificate.h>
+#include <uint256.h>
+#include <algorithm>
+#include <iostream>
+
+#ifdef BITCOIN_TX
+bool SidechainTxsCommitmentGuard::add(const CTransaction& tx, bool autoRewind) { return true; }
+bool SidechainTxsCommitmentGuard::add(const CScCertificate& cert) { return true; }
+#else
+
+bool SidechainTxsCommitmentGuard::add_fwt(const CTxForwardTransferOut& ccout)
+{
+    LogPrint("sc", "%s():%d entering \n", __func__, __LINE__);
+
+    // Check against the number of sidechains currently in the commitment tree
+    // If we are adding a new sc and we already hit the limit, do not add anything
+    if (!cbs.checkAvailableSpaceAliveSC(ccout.GetScId()))
+        return false;
+
+    // The sidechain id should not be already in the ceased tree
+    if (cbs.checkExistenceInCeasedSCTree(ccout.GetScId())) {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: adding fwt for scId[%s] on alive subtree, but already added on ceased subtree.\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+        return false;
+    }
+
+    CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[ccout.GetScId()];
+
+    // Check against the number of FT already present in the sc subtree.
+    // Only try to add if under the limit; increase the counter only if add was successful,
+    // as adding may fail for reasons different than having a full subtree.
+    if (counterRef.ft < cbs.FT_LIMIT) {
+        ++counterRef.ft;
+        LogPrint("sc", "%s():%d - scTxsCommitment guard: successfully added FT for sidechain scId[%s] - current size: %d.\n",
+            __func__, __LINE__, ccout.GetScId().ToString(), counterRef.ft);
+        return true;
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many FT for sidechain scId[%s].\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+        return false;
+    }
+}
+
+bool SidechainTxsCommitmentGuard::add_bwtr(const CBwtRequestOut& ccout)
+{
+    LogPrint("sc", "%s():%d entering \n", __func__, __LINE__);
+
+    // Check against the number of sidechains currently in the commitment tree
+    // If we are adding a new sc and we already hit the limit, do not add anything
+    if (!cbs.checkAvailableSpaceAliveSC(ccout.GetScId()))
+        return false;
+
+    // The sidechain id should not be already in the ceased tree
+    if (cbs.checkExistenceInCeasedSCTree(ccout.GetScId())) {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: adding bwtr for scId[%s] on alive subtree, but already added on ceased subtree.\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+        return false;
+    }
+
+    CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[ccout.GetScId()];
+
+    // Check against the number of BWT already present in the sc subtree.
+    // Only try to add if under the limit; increase the counter only if add was successful,
+    // as adding may fail for reasons different than having a full subtree.
+    if (counterRef.bwtr < cbs.BWTR_LIMIT) {
+        ++counterRef.bwtr;
+        LogPrint("sc", "%s():%d - scTxsCommitment guard: successfully added BWTR for sidechain scId[%s].\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+        return true;
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many BWTR for sidechain scId[%s].\n",
+            __func__, __LINE__, ccout.GetScId().ToString());
+        return false;
+    }
+}
+
+bool SidechainTxsCommitmentGuard::add_csw(const CTxCeasedSidechainWithdrawalInput& ccin)
+{
+    LogPrint("sc", "%s():%d entering \n", __func__, __LINE__);
+
+    // Check against the number of sidechains currently in the commitment tree
+    // If we are adding a new sc and we already hit the limit, do not add anything
+    if (!cbs.checkAvailableSpaceCeasedSC(ccin.scId))
+        return false;
+
+    // The sidechain id should not be already in the alive tree
+    if (cbs.checkExistenceInAliveSCTree(ccin.scId)) {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: adding csw for scId[%s] on ceased subtree, but already added on alive subtree.\n",
+            __func__, __LINE__, ccin.scId.ToString());
+        return false;
+    }
+
+    CommitmentBuilderStatsCeasedCounter& counterRef = cbs.cbscMap[ccin.scId];
+
+    // Check against the number of CSW already present in the sc subtree.
+    // Only try to add if under the limit; increase the counter only if add was successful,
+    // as adding may fail for reasons different than having a full subtree.
+    if (counterRef.csw < cbs.CSW_LIMIT) {
+        ++counterRef.csw;
+        LogPrint("sc", "%s():%d - scTxsCommitment guard: successfully added CSW for sidechain scId[%s].\n",
+            __func__, __LINE__, ccin.scId.ToString());
+        return true;
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many CSW for sidechain scId[%s].\n",
+            __func__, __LINE__, ccin.scId.ToString());
+        return false;
+    }
+}
+
+bool SidechainTxsCommitmentGuard::add_cert(const CScCertificate& cert)
+{
+    LogPrint("sc", "%s():%d entering \n", __func__, __LINE__);
+
+    size_t bt_list_len = cert.GetVout().size() - cert.nFirstBwtPos;
+
+    // Check against the number of sidechains currently in the commitment tree
+    // If we are adding a new sc and we already hit the limit, do not add anything
+    if (!cbs.checkAvailableSpaceAliveSC(cert.GetScId()))
+        return false;
+
+    // The sidechain id should not be already in the ceased tree
+    if (cbs.checkExistenceInCeasedSCTree(cert.GetScId())) {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: adding cert for scId[%s] on alive subtree, but already added on ceased subtree.\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+        return false;
+    }
+
+    // We have an hard limit for the total number of backward transfers inside all the certificates per sidechain
+    if (cbs.cbsaMap[cert.GetScId()].bwt + bt_list_len > cbs.BWT_LIMIT) {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many total BWT when adding cert for scId[%s]\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+        return false;
+    }
+
+    CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[cert.GetScId()];
+
+    // Check against the number of CERT already present in the sc subtree.
+    // Only try to add if under the limit; increase the counter only if add was successful,
+    // as adding may fail for reasons different than having a full subtree.
+    if (counterRef.cert < cbs.CERT_LIMIT) {
+        ++counterRef.cert;
+        counterRef.bwt += bt_list_len;
+        LogPrint("sc", "%s():%d - scTxsCommitment guard: successfully added CERT for sidechain scId[%s].\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+        return true;
+    } else {
+        LogPrint("sc", "%s():%d - scTxsCommitment guard failed: too many CERT for sidechain scId[%s].\n",
+            __func__, __LINE__, cert.GetScId().ToString());
+        return false;
+    }
+}
+
+bool SidechainTxsCommitmentGuard::add(const CTransaction& tx, bool autoRewind)
+{
+    if (!tx.IsScVersion())
+        return true;
+
+    LogPrint("sc", "%s():%d adding tx[%s] to ScTxsCommitmentGuard\n", __func__, __LINE__, tx.GetHash().ToString());
+
+    const uint256& tx_hash = tx.GetHash();
+
+    bool addOK = true;
+    int addedFt = 0, addedBwtr = 0, addedCsw = 0;
+
+    for (unsigned int fwtIdx = 0; fwtIdx < tx.GetVftCcOut().size(); ++fwtIdx)
+    {
+        const CTxForwardTransferOut& ccout = tx.GetVftCcOut().at(fwtIdx);
+
+        if (!add_fwt(ccout))
+        {
+            LogPrintf("%s():%d Error adding fwt: tx[%s], pos[%d]\n", __func__, __LINE__,
+                tx_hash.ToString(), fwtIdx);
+            addOK = false;
+            break;
+        } else {
+            addedFt++;
+        }
+    }
+
+    if (addOK) {
+        for (unsigned int bwtrIdx = 0; bwtrIdx < tx.GetVBwtRequestOut().size(); ++bwtrIdx)
+        {
+            const CBwtRequestOut& ccout = tx.GetVBwtRequestOut().at(bwtrIdx);
+
+            if (!add_bwtr(ccout))
+            {
+                LogPrintf("%s():%d Error adding bwtr: tx[%s], pos[%d]\n", __func__, __LINE__,
+                    tx_hash.ToString(), bwtrIdx);
+                addOK = false;
+                break;
+            } else {
+                addedBwtr++;
+            }
+        }
+    }
+
+    if (addOK) {
+        for (unsigned int cswIdx = 0; cswIdx < tx.GetVcswCcIn().size(); ++cswIdx)
+        {
+            const CTxCeasedSidechainWithdrawalInput& ccin = tx.GetVcswCcIn().at(cswIdx);
+
+            if (!add_csw(ccin))
+            {
+                LogPrintf("%s():%d Error adding csw: tx[%s], pos[%d]\n", __func__, __LINE__,
+                    tx_hash.ToString(), cswIdx);
+                addOK = false;
+                break;
+            } else {
+                addedCsw++;
+            }
+        }
+    }
+
+    // Restore CBS to a valid state if we were not able to add any of the FT / BWTR / CSW
+    if (!addOK && autoRewind) {
+        rewind(tx, addedFt, addedBwtr, addedCsw);
+        
+        // Remove from the maps all the sidechains without entities
+        std::vector<uint256> aliveToBeRemoved;
+        for (auto [scid, cbsa]: cbs.cbsaMap) {
+            if ((cbsa.bwt == 0) && (cbsa.bwtr == 0) && (cbsa.cert == 0) && (cbsa.ft == 0))
+                aliveToBeRemoved.push_back(scid);
+        }
+        for (auto scid: aliveToBeRemoved)
+            cbs.cbsaMap.erase(scid);
+
+        std::vector<uint256> ceasedToBeRemoved;
+        for (auto [scid, cbsc]: cbs.cbscMap) {
+            if (cbsc.csw == 0)
+                ceasedToBeRemoved.push_back(scid);
+        }
+        for (auto scid: ceasedToBeRemoved)
+            cbs.cbscMap.erase(scid);
+    }
+
+    return addOK;
+}
+
+bool SidechainTxsCommitmentGuard::add(const CScCertificate& cert)
+{
+    LogPrint("sc", "%s():%d adding cert[%s] to ScTxsCommitmentGuard\n", __func__, __LINE__, cert.GetHash().ToString());
+
+    if (!add_cert(cert))
+    {
+        LogPrintf("%s():%d Error adding cert[%s]\n", __func__, __LINE__,
+            cert.GetHash().ToString());
+        return false;
+    }
+    return true;
+}
+
+void SidechainTxsCommitmentGuard::rewind(const CTransaction& tx, const int addedFt, const int addedBwtr, const int addedCsw) {
+    LogPrint("sc", "%s():%d Rewind scCommitmentGuard after failure %d FT, %d BWTR, %d CSW \n",
+            __func__, __LINE__, addedFt, addedBwtr, addedCsw);
+
+    for (unsigned int cswIdx = 0; cswIdx < addedCsw; ++cswIdx)
+    {
+        const CTxCeasedSidechainWithdrawalInput& ccin = tx.GetVcswCcIn().at(cswIdx);
+        CommitmentBuilderStatsCeasedCounter& counterRef = cbs.cbscMap[ccin.scId];
+        counterRef.csw--;
+    }
+
+    for (unsigned int bwtrIdx = 0; bwtrIdx < addedBwtr; ++bwtrIdx)
+    {
+        const CBwtRequestOut& ccout = tx.GetVBwtRequestOut().at(bwtrIdx);
+        CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[ccout.GetScId()];
+        counterRef.bwtr--;
+    }
+
+    for (unsigned int fwtIdx = 0; fwtIdx < addedFt; ++fwtIdx)
+    {
+        const CTxForwardTransferOut& ccout = tx.GetVftCcOut().at(fwtIdx);
+        CommitmentBuilderStatsAliveCounter& counterRef = cbs.cbsaMap[ccout.GetScId()];
+        counterRef.ft--;
+    }
+}
+
+#endif

--- a/src/sc/sidechainTxsCommitmentGuard.h
+++ b/src/sc/sidechainTxsCommitmentGuard.h
@@ -41,7 +41,6 @@ private:
         uint32_t   ft = 0;
         uint32_t bwtr = 0;
         uint32_t cert = 0;
-        uint32_t  bwt = 0;
     };
     struct CommitmentBuilderStatsCeasedCounter {
         uint32_t  csw = 0;
@@ -55,7 +54,7 @@ private:
         static const int BWTR_LIMIT = 4095;
         static const int CERT_LIMIT = 4095;
         static const int  CSW_LIMIT = 4095;
-        static const int  BWT_LIMIT = 4096;
+        static const int  BWT_LIMIT = 4095;
 
         bool checkAvailableSpaceAliveSC(const uint256& scid) {
             if ((cbsaMap.count(scid) == 0) && ((cbsaMap.size() + cbscMap.size()) >= SC_LIMIT)) {

--- a/src/sc/sidechainTxsCommitmentGuard.h
+++ b/src/sc/sidechainTxsCommitmentGuard.h
@@ -24,6 +24,9 @@ public:
     bool add(const CTransaction& tx, bool autoRewind = false);
     bool add(const CScCertificate& cert);
 
+    void rewind(const CTransaction& tx);
+    void rewind(const CScCertificate& cert);
+
 private:
     bool add_fwt(const CTxForwardTransferOut& ccout);
     bool add_bwtr(const CBwtRequestOut& ccout);
@@ -31,6 +34,7 @@ private:
     bool add_cert(const CScCertificate& cert);
 
     void rewind(const CTransaction& tx, const int failingFt, const int failingBwtr, const int failingCsw);
+    void keepMapsClean();
 
     // Keeping information separated to closely mimic CCTPlib structures
     struct CommitmentBuilderStatsAliveCounter {

--- a/src/sc/sidechainTxsCommitmentGuard.h
+++ b/src/sc/sidechainTxsCommitmentGuard.h
@@ -1,0 +1,90 @@
+#ifndef SIDECHAIN_TX_COMMITMENT_GUARD
+#define SIDECHAIN_TX_COMMITMENT_GUARD
+
+#include "coins.h"
+#include <sc/sidechaintypes.h>
+
+class uint256;
+class CTransaction;
+
+class CScCertificate;
+class CTxForwardTransferOut;
+class CBwtRequestOut;
+class CTxCeasedSidechainWithdrawalInput;
+
+class SidechainTxsCommitmentGuard
+{
+public:
+    SidechainTxsCommitmentGuard() {};
+    ~SidechainTxsCommitmentGuard() {};
+
+    SidechainTxsCommitmentGuard(const SidechainTxsCommitmentGuard&) = delete;
+    SidechainTxsCommitmentGuard& operator=(const SidechainTxsCommitmentGuard&) = delete;
+
+    bool add(const CTransaction& tx, bool autoRewind = false);
+    bool add(const CScCertificate& cert);
+
+private:
+    bool add_fwt(const CTxForwardTransferOut& ccout);
+    bool add_bwtr(const CBwtRequestOut& ccout);
+    bool add_csw(const CTxCeasedSidechainWithdrawalInput& ccin);
+    bool add_cert(const CScCertificate& cert);
+
+    void rewind(const CTransaction& tx, const int failingFt, const int failingBwtr, const int failingCsw);
+
+    // Keeping information separated to closely mimic CCTPlib structures
+    struct CommitmentBuilderStatsAliveCounter {
+        uint32_t   ft = 0;
+        uint32_t bwtr = 0;
+        uint32_t cert = 0;
+        uint32_t  bwt = 0;
+    };
+    struct CommitmentBuilderStatsCeasedCounter {
+        uint32_t  csw = 0;
+    };
+    struct CommitmentBuilderStats {
+        std::map<uint256, CommitmentBuilderStatsAliveCounter>  cbsaMap;
+        std::map<uint256, CommitmentBuilderStatsCeasedCounter> cbscMap;
+        // The following values MUST be aligned with those specified in CCTPlib!
+        static const int   SC_LIMIT = 4096;
+        static const int   FT_LIMIT = 4095;
+        static const int BWTR_LIMIT = 4095;
+        static const int CERT_LIMIT = 4095;
+        static const int  CSW_LIMIT = 4095;
+        static const int  BWT_LIMIT = 4096;
+
+        bool checkAvailableSpaceAliveSC(const uint256& scid) {
+            if ((cbsaMap.count(scid) == 0) && ((cbsaMap.size() + cbscMap.size()) >= SC_LIMIT)) {
+                LogPrint("sc", "%s():%d - scTxsCommitment building failed: too many sidechains, when adding scId[%s].\n",
+                    __func__, __LINE__, scid.ToString());
+                return false;
+            }
+            return true;
+        }
+        bool checkAvailableSpaceCeasedSC(const uint256& scid) {
+            if ((cbscMap.count(scid) == 0) && ((cbsaMap.size() + cbscMap.size()) >= SC_LIMIT)) {
+                LogPrint("sc", "%s():%d - scTxsCommitment building failed: too many sidechains, when adding scId[%s].\n",
+                    __func__, __LINE__, scid.ToString());
+                return false;
+            }
+            return true;
+        }
+        bool checkExistenceInAliveSCTree(const uint256& scid) {
+            if (cbsaMap.count(scid) > 0) {
+                return true;
+            }
+            return false;
+        }
+        bool checkExistenceInCeasedSCTree(const uint256& scid) {
+            if (cbscMap.count(scid) > 0) {
+                return true;
+            }
+            return false;
+        }
+    } cbs;
+
+public:
+    const CommitmentBuilderStats& getCBS() { return cbs; };
+};
+
+#endif


### PR DESCRIPTION
This pull request adds several checks when building a sidechain tx commitment tree, managing the errors returned by CCTPcrypto lib.
In particular, the validity check is performed:

- before accepting a tx/cert in the mempool
- creating a block via getblocktemplate()
- validating an incoming block
