### PR TITLE
Remove old todos

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1055,13 +1055,11 @@ UniValue sc_create(const UniValue& params, bool fHelp)
         {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected positive integer in the range [1,..,255]");
         }
-        // TODO as soon as CSW are supported, check against wCeasedVk presence: in that case must be size() > 0
     }
 
     // ---------------------------------------------------------
     if (setKeyArgs.count("vBitVectorCertificateFieldConfig"))
     {
-        // TODO as soon as CSW are supported, check against wCeasedVk presence: in that case must be size() > 0
         UniValue PairsArray = find_value(inputObject, "vBitVectorCertificateFieldConfig").get_array();
         if (!PairsArray.isNull())
         {


### PR DESCRIPTION
The `sc_create` RPC command included two TODOs that are not applicable anymore.

They were added in an early stage of the Zendoo development when we thought it could be useful to have strict checks on Field Elements and Bit Vectors in relation to the support of Ceased Sidechain Withdrawal, but in the end, they are not useful anymore.