### PR TITLE
Fix `mempool_double_spend.py` test

### DIFF
--- a/qa/rpc-tests/mempool_double_spend.py
+++ b/qa/rpc-tests/mempool_double_spend.py
@@ -35,9 +35,6 @@ class TxnMallTest(BitcoinTestFramework):
             self.join_network()
         else:
             self.split_network()
-
-        sync_blocks(self.nodes[1 : NUMB_OF_NODES])
-        sync_mempools(self.nodes[1 : NUMB_OF_NODES])
         
         self.sync_all()
 
@@ -134,7 +131,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Sync mempools except for the last (disconnected) node
         mark_logs("Waiting for honest nodes to sync mempool", self.nodes, DEBUG_MODE)
-        sync_mempools(self.nodes[1 : NUMB_OF_NODES - 1])
+        sync_mempools(self.nodes[0 : NUMB_OF_NODES - 1])
 
         mark_logs("Check that all the nodes have {} transactions in the mempool except the last one".format(iterations), self.nodes, DEBUG_MODE)
         for i in range(NUMB_OF_NODES):

--- a/qa/rpc-tests/run_until_fails.py
+++ b/qa/rpc-tests/run_until_fails.py
@@ -26,9 +26,12 @@ if not path.isfile(test_file):
 
 error_occurred = False
 
+counter = 0
+
 while not error_occurred:
-    print(f"Running test: {test_file} - {datetime.now().strftime('%H:%M:%S')}")
-    command_call = subprocess.Popen(["python", test_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    counter = counter + 1
+    print(f"[{counter}] Running test: {test_file} - {datetime.now().strftime('%H:%M:%S')}")
+    command_call = subprocess.Popen(["python", test_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
     output, errors = command_call.communicate()
     error_occurred = command_call.returncode != 0
 


### PR DESCRIPTION
The test `mempool_double_spend.py` was sporadically failing on the CI due to a wrong synchronization of mempools.

This PR fixed the issue and also adds some small improvements to the helper script `run_until_fails.py` to:
- add the number of iteration
- set the output mode to text