### PR TITLE
fix logfile output of "Leaving block file" statement

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4965,7 +4965,7 @@ bool FindBlockPos(CValidationState &state, CDiskBlockPos &pos, unsigned int nAdd
 
     if (nFile != nLastBlockFile) {
         if (!fKnown) {
-            LogPrintf("Leaving block file %i: %s\n", nFile, vinfoBlockFile.at(nFile).ToString());
+            LogPrintf("Leaving block file %i: %s\n", nLastBlockFile, vinfoBlockFile.at(nLastBlockFile).ToString());
         }
         FlushBlockFile(!fKnown);
         nLastBlockFile = nFile;


### PR DESCRIPTION
Fixes empty "Leaving block file" statement in "debug.log".

before:
        2023-03-22 19:30:47 Leaving block file 478: CBlockFileInfo(blocks=0, size=0, heights=0...0, time=1970-01-01...1970-01-01)

fix:
	    2023-03-23 06:09:42 Leaving block file 484: CBlockFileInfo(blocks=2151, size=134114647, heights=1317507...1319655, time=2023-03-19...2023-03-23)