### PR TITLE
Set fork 10 activation height (testnet only)

### DIFF
--- a/src/gtest/test_forkmanager.cpp
+++ b/src/gtest/test_forkmanager.cpp
@@ -462,7 +462,7 @@ TEST(ForkManager, NonCeasingSCVersionForkMainnet) {
 TEST(ForkManager, NonCeasingSCVersionForkTestnet) {
     SelectParams(CBaseChainParams::TESTNET);
 
-    int nonCeasingSCVersionForkHeight = 2000000;    // PLACEHOLDER!
+    int nonCeasingSCVersionForkHeight = 1228700;
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight - 1), 1);
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight), 2);
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight + 1), 2);
@@ -471,7 +471,7 @@ TEST(ForkManager, NonCeasingSCVersionForkTestnet) {
 TEST(ForkManager, NonCeasingSCVersionForkRegtest) {
     SelectParams(CBaseChainParams::REGTEST);
 
-    int nonCeasingSCVersionForkHeight = 480;    // PLACEHOLDER!
+    int nonCeasingSCVersionForkHeight = 480;
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight - 1), 1);
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight), 2);
     EXPECT_EQ(ForkManager::getInstance().getMaxSidechainVersion(nonCeasingSCVersionForkHeight + 1), 2);

--- a/src/zen/forks/fork10_nonceasingsidechainfork.cpp
+++ b/src/zen/forks/fork10_nonceasingsidechainfork.cpp
@@ -5,7 +5,7 @@ namespace zen {
 NonCeasingSidechainFork::NonCeasingSidechainFork()
 {
     setHeightMap({{CBaseChainParams::Network::MAIN,2500000},            // PLACEHOLDER!
-                  {CBaseChainParams::Network::REGTEST,480},             // PLACEHOLDER!
-                  {CBaseChainParams::Network::TESTNET,2000000}});       // PLACEHOLDER!
+                  {CBaseChainParams::Network::REGTEST,480},
+                  {CBaseChainParams::Network::TESTNET,1228700}});
 }
 }


### PR DESCRIPTION
Fork 10 enables sidechains v2

Testnet fork activation block 1228700 2023-03-13 ~15:00UTC

This is a backport from the release branch 4.0.0-rc1.