### PR TITLE
Fix for LevelDB file usage

### DIFF
--- a/src/gtest/test_getblocktemplate.cpp
+++ b/src/gtest/test_getblocktemplate.cpp
@@ -64,7 +64,7 @@ class TestCCoinsViewDB : public CCoinsViewDB
 {
 public:
     TestCCoinsViewDB(size_t nCacheSize, bool fWipe = false)
-        : CCoinsViewDB(nCacheSize, false, fWipe)
+        : CCoinsViewDB(nCacheSize, DEFAULT_DB_MAX_OPEN_FILES, false, fWipe)
     {
     }
 
@@ -265,7 +265,7 @@ protected:
 
     void InitBlockTreeDB()
     {
-        pblocktree = new CBlockTreeDB(1 << 20, true);
+        pblocktree = new CBlockTreeDB(1 << 20, DEFAULT_DB_MAX_OPEN_FILES, true);
     }
 
     void InitSetupCoinsViewCache(CCoinsViewDB* dbCoins)

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -122,7 +122,7 @@ TEST_F(MempoolTest, TxInputLimit) {
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
     const unsigned int chainStateDbSize = 2 * 1024 * 1024;
-    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, /*fWipe*/true);
+    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
     // Create an obviously-invalid transaction
@@ -231,7 +231,7 @@ TEST_F(MempoolTest, SproutV3TxFailsAsExpected) {
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
     const unsigned int chainStateDbSize = 2 * 1024 * 1024;
-    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, /*fWipe*/true);
+    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
     CTxMemPool pool(::minRelayTxFee);
@@ -266,7 +266,7 @@ TEST_F(MempoolTest, SproutV3TxWhenGrothNotActive) {
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
     const unsigned int chainStateDbSize = 2 * 1024 * 1024;
-    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, /*fWipe*/true);
+    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
 
@@ -302,7 +302,7 @@ TEST_F(MempoolTest, SproutNegativeVersionTx) {
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
     const unsigned int chainStateDbSize = 2 * 1024 * 1024;
-    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, /*fWipe*/true);
+    CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
     chainSettingUtils::ExtendChainActiveToHeight(100);

--- a/src/gtest/test_reindex.cpp
+++ b/src/gtest/test_reindex.cpp
@@ -20,7 +20,7 @@ class CFakeCoinDB : public CCoinsViewDB
 {
 public:
     CFakeCoinDB(size_t nCacheSize, bool fWipe = false)
-        : CCoinsViewDB(nCacheSize, false, fWipe) {}
+        : CCoinsViewDB(nCacheSize, DEFAULT_DB_MAX_OPEN_FILES, false, fWipe) {}
 
     bool BatchWrite(CCoinsMap &mapCoins) { return true; }
 };

--- a/src/gtest/test_sidechain.cpp
+++ b/src/gtest/test_sidechain.cpp
@@ -1566,7 +1566,7 @@ TEST_F(SidechainsTestSuite, GetScIdsOnChainstateDbSelectOnlySidechains) {
     boost::filesystem::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
-    CCoinsViewDB chainStateDb(chainStateDbSize,/*fWipe*/true);
+    CCoinsViewDB chainStateDb(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     sidechainsView->SetBackend(chainStateDb);
 
     //Insert in db two sidechains

--- a/src/gtest/test_sidechain_to_mempool.cpp
+++ b/src/gtest/test_sidechain_to_mempool.cpp
@@ -27,7 +27,7 @@ class CCoinsOnlyViewDB : public CCoinsViewDB
 {
 public:
     CCoinsOnlyViewDB(size_t nCacheSize, bool fWipe = false)
-        : CCoinsViewDB(nCacheSize, false, fWipe) {}
+        : CCoinsViewDB(nCacheSize, DEFAULT_DB_MAX_OPEN_FILES, false, fWipe) {}
 
     bool BatchWrite(CCoinsMap &mapCoins)
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -95,7 +95,7 @@ static AMQPNotificationInterface* pAMQPNotificationInterface = NULL;
 // anyway.
 #define MIN_CORE_FILEDESCRIPTORS 0
 #else
-#define MIN_CORE_FILEDESCRIPTORS 150
+#define MIN_CORE_FILEDESCRIPTORS 825
 #endif
 
 /** Used to pass flags to the Bind() function */
@@ -381,6 +381,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-addressindex", strprintf(_("Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)"), DEFAULT_ADDRESSINDEX));
     strUsage += HelpMessageOpt("-timestampindex", strprintf(_("Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)"), DEFAULT_TIMESTAMPINDEX));
     strUsage += HelpMessageOpt("-spentindex", strprintf(_("Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)"), DEFAULT_SPENTINDEX));
+
+    strUsage += HelpMessageOpt("-blocktreedbmaxopenfiles", strprintf(_("Maximum number of open files for the Block Tree LevelDB (default: %u)"), DEFAULT_DB_MAX_OPEN_FILES));
+    strUsage += HelpMessageOpt("-coinsviewdbmaxopenfiles", strprintf(_("Maximum number of open files for the Coins View LevelDB (default: %u)"), DEFAULT_DB_MAX_OPEN_FILES));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open"));
@@ -1533,13 +1536,19 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
+    // block tree db settings
+    int blocktreedbMaxOpenFiles = GetArg("-blocktreedbmaxopenfiles", DEFAULT_DB_MAX_OPEN_FILES);
+    int coinsviewdbMaxOpenFiles = GetArg("-coinsviewdbmaxopenfiles", DEFAULT_DB_MAX_OPEN_FILES);
+
+    LogPrintf("LevelDB database configuration:\n");
+    LogPrintf("* Using %d max open files (blocktreedb)\n", blocktreedbMaxOpenFiles);
+    LogPrintf("* Using %d max open files (coinsviewdb)\n", coinsviewdbMaxOpenFiles);
 
     // cache size calculations
     int64_t nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
     int64_t nBlockTreeDBCache = nTotalCache / 8;
-
 
     if (GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX) || GetBoolArg("-spentindex", DEFAULT_SPENTINDEX)) {
         // enable 3/4 of the cache if addressindex and/or spentindex is enabled
@@ -1549,7 +1558,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
         }
     }
-
 
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
@@ -1577,8 +1585,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinscatcher;
                 delete pblocktree;
 
-                pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex || fReindexFast);
-                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex || fReindexFast);
+                pblocktree = new CBlockTreeDB(nBlockTreeDBCache, blocktreedbMaxOpenFiles, false, fReindex || fReindexFast);
+                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, coinsviewdbMaxOpenFiles, false, fReindex || fReindexFast);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
 

--- a/src/main.h
+++ b/src/main.h
@@ -237,11 +237,11 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
- * 
+ *
  * @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface (see validationinterface.h) - this will have its BlockChecked method called whenever *any* block completes validation.
  * @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock  The block we want to process.
@@ -271,7 +271,7 @@ void ProcessMempoolMsg(const CTxMemPool& pool, CNode* pfrom);
 
 /**
  * @brief The enumeration of states of the sidechain batch proof verification.
- * 
+ *
  * It is useful to correctly handle the behavior of the ProcessTxBaseMsg() function,
  * in particular it should request an asynchronous batch verification of the proof
  * when called for the first time (with parameter NOT_VERIFIED_YET) and then should
@@ -386,10 +386,10 @@ enum class MempoolProofVerificationFlag
 
 /**
  * @brief Rejects a certificate or transaction submitted to memory pool.
- * 
+ *
  * It sends an error message to the node that has sent the invalid entry
  * and eventually bans it.
- * 
+ *
  * @param state The state of the validation process (containing the error information)
  * @param txBase The transaction or certificate that failed the verification
  * @param pfrom The node that sent the offending transaction or certificate
@@ -423,7 +423,7 @@ CAmount GetMinRelayFee(const CTransactionBase& tx, unsigned int nBytes, bool fAl
 /**
  * Check transaction inputs, and make sure any
  * pay-to-script-hash transactions are evaluating IsStandard scripts
- * 
+ *
  * Why bother? To avoid denial-of-service attacks; an attacker
  * can submit a standard HASH... OP_EQUAL transaction,
  * which will get accepted into blocks. The redemption
@@ -432,7 +432,7 @@ CAmount GetMinRelayFee(const CTransactionBase& tx, unsigned int nBytes, bool fAl
  *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
  */
 
-/** 
+/**
  * Check for standard transaction types
  * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
  * @return True if all inputs (scriptSigs) use only standard transaction forms
@@ -448,7 +448,7 @@ unsigned int GetLegacySigOpCount(const CTransactionBase& tx);
 
 /**
  * Count ECDSA signature operations in pay-to-script-hash inputs.
- * 
+ *
  * @param[in] mapInputs Map of previous transactions that have outputs we're spending
  * @return maximum number of sigops required to validate this transaction's inputs
  * @see CTransaction::FetchInputs
@@ -514,9 +514,9 @@ bool IsFinalTx(const CTransactionBase &tx, int nBlockHeight, int64_t nBlockTime)
  */
 bool CheckFinalTx(const CTransactionBase &tx, int flags = -1);
 
-/** 
+/**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {
@@ -724,7 +724,7 @@ struct CTransactionNetworkObj
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
         SerializationOp(s, CSerActionUnserialize(), nType, nVersion);
-    } 
+    }
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -83,8 +83,8 @@ TestingSetup::TestingSetup()
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
-        pblocktree = new CBlockTreeDB(1 << 20, true);
-        pcoinsdbview = new CCoinsViewDB(1 << 23, true);
+        pblocktree = new CBlockTreeDB(1 << 20, DEFAULT_DB_MAX_OPEN_FILES, true);
+        pcoinsdbview = new CCoinsViewDB(1 << 23, DEFAULT_DB_MAX_OPEN_FILES, true);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
         InitBlockIndex();
 #ifdef ENABLE_WALLET

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -127,12 +127,10 @@ void static BatchWriteCswNullifier(CLevelDBBatch &batch, const uint256 &scId, co
     }
 }
 
-CCoinsViewDB::CCoinsViewDB(std::string dbName, size_t nCacheSize, bool fMemory, bool fWipe) :
-                           db(GetDataDir() / dbName, nCacheSize, fMemory, fWipe) {
+CCoinsViewDB::CCoinsViewDB(std::string dbName, size_t nCacheSize, int maxOpenFiles, bool fMemory, bool fWipe) : db(GetDataDir() / dbName, nCacheSize, maxOpenFiles, fMemory, fWipe) {
 }
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) :
-                           db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe) {
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, int maxOpenFiles, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, maxOpenFiles, fMemory, fWipe) {
 }
 
 
@@ -289,8 +287,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
     return db.WriteBatch(batch);
 }
 
-CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) :
-                           CLevelDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe) {
+CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, int maxOpenFiles, bool fMemory, bool fWipe) : CLevelDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, maxOpenFiles, fMemory, fWipe) {
 }
 
 bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -123,9 +123,9 @@ class CCoinsViewDB : public CCoinsView
 {
 protected:
     CLevelDBWrapper db;
-    CCoinsViewDB(std::string dbName, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CCoinsViewDB(std::string dbName, size_t nCacheSize, int maxOpenFiles, bool fMemory = false, bool fWipe = false);
 public:
-    CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CCoinsViewDB(size_t nCacheSize, int maxOpenFiles, bool fMemory = false, bool fWipe = false);
 
     bool GetAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree)   const override;
     bool GetNullifier(const uint256 &nf)                                 const override;
@@ -157,7 +157,7 @@ public:
 class CBlockTreeDB : public CLevelDBWrapper
 {
 public:
-    CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CBlockTreeDB(size_t nCacheSize, int maxOpenFiles, bool fMemory = false, bool fWipe = false);
 private:
     CBlockTreeDB(const CBlockTreeDB&);
     void operator=(const CBlockTreeDB&);

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -361,7 +361,7 @@ class FakeCoinsViewDB : public CCoinsViewDB {
     ZCIncrementalMerkleTree t;
 
 public:
-    FakeCoinsViewDB(std::string dbName, uint256& hash) : CCoinsViewDB(dbName, 100, false, false), hash(hash) {}
+    FakeCoinsViewDB(std::string dbName, uint256& hash) : CCoinsViewDB(dbName, 100, DEFAULT_DB_MAX_OPEN_FILES, false, false), hash(hash) {}
 
     bool GetAnchorAt(const uint256 &rt, ZCIncrementalMerkleTree &tree) const override {
         if (rt == t.root()) {


### PR DESCRIPTION
- Set maxopenfiles default to 400
- A command line parameter is provided for setting maxopenfiles explicitly for each database (blocktree and coinsview)