### PR TITLE
Adapt repository for incremental release notes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,6 +1,0 @@
-(note: this is a temporary file, to be added-to by anybody, and moved to
-release-notes at release time)
-
-Notable changes
-===============
-

--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -1,0 +1,26 @@
+zend v4.0.99
+=========
+
+## Important notes
+- PR [#526](https://github.com/HorizenOfficial/zen/pull/526) implements [ZenIP-42204](https://github.com/HorizenOfficial/ZenIPs/blob/master/zenip-42204.md), which introduces a hard fork disabling the possibility to move transparent funds to shield addresses. After the hard fork, only shielded-to-shielded and shielded-to-transparent transactions will be allowed. For this reason, the following RPC commands have been (partially or fully) deprecated: `z_sendmany`, `z_shieldcoinbase` and `z_mergetoaddress` (check inline documentation for additional details).
+- PR [#539](https://github.com/HorizenOfficial/zen/pull/541) modifies the data structure returned by RPC method `getrawmempool` [#539](https://github.com/HorizenOfficial/zen/pull/539)
+- PR [#541](https://github.com/HorizenOfficial/zen/pull/541) fixes an issue that made explorers, relying on `zend` RPC commands, not to show old transactions including P2PK scripts. The fix has an effect only on transactions processed after the update, so in case of explorers it is recommended to run a (fast) reindex to properly handle also previously received transactions. However, reindexing is not mandatory.
+
+## New Features and Improvements
+- Implementation of [ZenIP-42204](https://github.com/HorizenOfficial/ZenIPs/blob/master/zenip-42204.md): a hard-fork is introduced which results in shielding txs being deprecated [#526](https://github.com/HorizenOfficial/zen/pull/526)
+- Removal of the p2p alert system [#540](https://github.com/HorizenOfficial/zen/pull/540)
+- Added support for Pay-To-Public-Key (P2PK) scripts [#541](https://github.com/HorizenOfficial/zen/pull/541)
+
+## Bugfixes and Minor Changes
+- Fix compilation warnings for GCC (v12) and clang (v15), update boost to v1.81 [#513](https://github.com/HorizenOfficial/zen/pull/513)
+- Refactoring of error code handling for proof verifier, UI improvements for reindex (fast) [#504](https://github.com/HorizenOfficial/zen/pull/504)
+- Fix compilation errors for recent macOS versions [#536](https://github.com/HorizenOfficial/zen/pull/536)
+- Fix for preventing already received and spent txs to be asked for again [#537](https://github.com/HorizenOfficial/zen/pull/537)
+- Fix for limitedmap [#538](https://github.com/HorizenOfficial/zen/pull/538)
+- Fix for return value of function mempoolToJSON [#539](https://github.com/HorizenOfficial/zen/pull/539)
+
+## Contributors
+* [@a-petrini](https://github.com/a-petrini)
+* [@drgora](https://github.com/drgora)
+* [@JackPiri](https://github.com/JackPiri)
+* [@ptagl](https://github.com/ptagl)


### PR DESCRIPTION
This PR adapt repository for incremental release notes:

- release note template file "./doc/release-notes.md" has been removed
- current release note file has been created and populated "./doc/release-notes/release-notes-current.md"

In this particular case, the current release note file has been populated starting from main branch commit f3e17aa67d0c62287604d31c15f1c55df350e671 and excluding:

- e33877ec5579f10b848f1735cd49da7a7ba1868d [#532] (because this PR targets only an internal tool used for release preparation)
- 54f5020ae7c2b211a58792f12e635f7e2399eca2 [#542] (because this PR is already included in 4.0.0-rc3)