### PR TITLE
Ap/sync mempools improvement

### DIFF
--- a/qa/rpc-tests/checkblockatheight.py
+++ b/qa/rpc-tests/checkblockatheight.py
@@ -34,11 +34,11 @@ MAIN_NODE = HONEST_NODES[0]                 # Hardcoded alias, do not change
 
 class checkblockatheight(BitcoinTestFramework):
 
-    def setup_chain(self, split=False):
+    def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False, minAge=FINALITY_MIN_AGE):
+    def setup_network(self, minAge=FINALITY_MIN_AGE):
         assert_equal(MAIN_NODE, HONEST_NODES[0])
 
         self.nodes = []
@@ -52,7 +52,7 @@ class checkblockatheight(BitcoinTestFramework):
 
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx + 1)
-        self.is_network_split = split
+        self.is_network_split = False
         self.sync_all()
 
     def split_network(self):
@@ -269,7 +269,7 @@ class checkblockatheight(BitcoinTestFramework):
 
         stop_nodes(self.nodes)
         wait_bitcoinds()
-        self.setup_network(False, 0)
+        self.setup_network(minAge=0)
 
         chunks = 305
         self.mark_logs(f"  Node {MAIN_NODE} generates {chunks} blocks")
@@ -446,7 +446,7 @@ class checkblockatheight(BitcoinTestFramework):
         # restart Nodes and check their balance, at this point the 1000 coins should be in the wallet of node2
         stop_nodes(self.nodes)
         wait_bitcoinds()
-        self.setup_network(False, 0)
+        self.setup_network(minAge=0)
 
         final_bal1 = Decimal(self.nodes[HONEST_NODES[1]].getbalance() )
         final_bal2 = Decimal(self.nodes[HONEST_NODES[2]].getbalance() )

--- a/qa/rpc-tests/checkblockatheight.py
+++ b/qa/rpc-tests/checkblockatheight.py
@@ -5,24 +5,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.script import OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_EQUAL, hash160, OP_CHECKSIG, OP_CHECKBLOCKATHEIGHT
+from test_framework.script import OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_CHECKSIG, OP_CHECKBLOCKATHEIGHT
 from test_framework.util import assert_equal, assert_greater_than, bytes_to_hex_str, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, disconnect_nodes
+    start_nodes, stop_nodes, sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, disconnect_nodes
 from test_framework.script import CScript
 from test_framework.mininode import CTransaction, ToHex
 from test_framework.util import hex_str_to_bytes, swap_bytes
-import traceback
 from binascii import unhexlify
 from io import BytesIO
-import os,sys
-import shutil
+import os
 from decimal import Decimal
-import binascii
-import codecs
-import pprint
 
-import time
 
 NUMB_OF_NODES = 4
 
@@ -34,6 +27,11 @@ FINALITY_MIN_AGE = 75
 
 # mainchain uses this value for targeting a blockhash when building cbh script starting from chain tip backwards
 CBH_DELTA_HEIGHT = 300
+
+DISHONEST_NODE_INDEX = NUMB_OF_NODES - 1    # Dishonest node
+HONEST_NODES = list(range(NUMB_OF_NODES))
+HONEST_NODES.remove(DISHONEST_NODE_INDEX)
+MAIN_NODE = HONEST_NODES[0]
 
 class checkblockatheight(BitcoinTestFramework):
 
@@ -52,33 +50,41 @@ class checkblockatheight(BitcoinTestFramework):
                 ["-debug=py", "-debug=cbh", "-cbhsafedepth="+str(FINALITY_SAFE_DEPTH), "-cbhminage="+str(minAge)]
             ])
 
-        if not split:
-            # 2 and 3 are joint only if split==false
-            connect_nodes_bi(self.nodes, 2, 3)
-            connect_nodes_bi(self.nodes, 3, 2)
-            sync_blocks(self.nodes[2:NUMB_OF_NODES])
-            sync_mempools(self.nodes[2:NUMB_OF_NODES])
-
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 0)
-        connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 1)
+        for idx in range(NUMB_OF_NODES - 1):
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = split
         self.sync_all()
 
     def split_network(self):
-        # Split the network of 4 nodes into nodes 0-1-2 and 3.
-        assert not self.is_network_split
-        disconnect_nodes(self.nodes[2], 3)
-        disconnect_nodes(self.nodes[3], 2)
+        # Disconnect the dishonest node from the network
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+        elif idx == 0:
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+        else:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+            connect_nodes_bi(self.nodes, idx - 1, idx + 1)
         self.is_network_split = True
 
 
     def join_network(self):
-        #Join the (previously split) network pieces together: 0-1-2-3
-        assert self.is_network_split
-        connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 2)
+        #Join the (previously split) network pieces together
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+        elif idx == 0:
+            connect_nodes_bi(self.nodes, idx, idx + 1)
+        else:
+            disconnect_nodes(self.nodes[idx - 1], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         sync_blocks(self.nodes, 1, False, 5)
         self.is_network_split = False
 
@@ -107,27 +113,27 @@ class checkblockatheight(BitcoinTestFramework):
         blocks = []
         self.bl_count = 0
 
-        blocks.append(self.nodes[0].getblockhash(0))
+        blocks.append(self.nodes[MAIN_NODE].getblockhash(0))
 
         small_target_h = 3
 
-        self.mark_logs("Node0 generates %d blocks" % (CBH_DELTA_HEIGHT + small_target_h - 1))
-        blocks.extend(self.nodes[0].generate(CBH_DELTA_HEIGHT + small_target_h -1))
+        self.mark_logs(f"Node {MAIN_NODE} generates {CBH_DELTA_HEIGHT + small_target_h - 1} blocks")
+        blocks.extend(self.nodes[MAIN_NODE].generate(CBH_DELTA_HEIGHT + small_target_h -1))
         self.sync_all()
 
         amount_node1 = Decimal("1002.0")
-        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), amount_node1)
+        self.nodes[MAIN_NODE].sendtoaddress(self.nodes[HONEST_NODES[1]].getnewaddress(), amount_node1)
         self.sync_all()
 
-        self.mark_logs("Node0 generates 1 blocks")
-        blocks.extend(self.nodes[0].generate(1))
+        self.mark_logs(f"Node {MAIN_NODE} generates 1 blocks")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1))
         self.sync_all()
 
         self.mark_logs("Trying to send a tx with a scriptPubKey referencing a block too recent...")
 
         # Create a tx having in its scriptPubKey a custom referenced block in the CHECKBLOCKATHEIGHT part 
         # select necessary utxos for doing the PAYMENT
-        usp = self.nodes[0].listunspent()
+        usp = self.nodes[MAIN_NODE].listunspent()
 
         payment = Decimal('1.0')
         fee     = Decimal('0.00005')
@@ -140,15 +146,15 @@ class checkblockatheight(BitcoinTestFramework):
             if amount >= payment+fee:
                 break
 
-        outputs = {self.nodes[0].getnewaddress(): (Decimal(amount) - payment - fee), self.nodes[2].getnewaddress(): payment}
-        rawTx   = self.nodes[0].createrawtransaction(inputs, outputs)
+        outputs = {self.nodes[MAIN_NODE].getnewaddress(): (Decimal(amount) - payment - fee), self.nodes[HONEST_NODES[2]].getnewaddress(): payment}
+        rawTx   = self.nodes[MAIN_NODE].createrawtransaction(inputs, outputs)
 
         # build an object from the raw tx in order to be able to modify it
         tx_01 = CTransaction()
         f = BytesIO(unhexlify(rawTx))
         tx_01.deserialize(f)
 
-        decodedScriptOrig = self.nodes[0].decodescript(bytes_to_hex_str(tx_01.vout[1].scriptPubKey))
+        decodedScriptOrig = self.nodes[MAIN_NODE].decodescript(bytes_to_hex_str(tx_01.vout[1].scriptPubKey))
 
         scriptOrigAsm = decodedScriptOrig['asm']
 
@@ -168,26 +174,26 @@ class checkblockatheight(BitcoinTestFramework):
         tx_01.vout[1].scriptPubKey = modScriptPubKey
         tx_01.rehash()
 
-        decodedScriptMod = self.nodes[0].decodescript(bytes_to_hex_str(tx_01.vout[1].scriptPubKey))
-        print("  Modified scriptPubKey in tx 1: ", decodedScriptMod['asm'])
+        decodedScriptMod = self.nodes[MAIN_NODE].decodescript(bytes_to_hex_str(tx_01.vout[1].scriptPubKey))
+        print(f"  Modified scriptPubKey in tx 1: {decodedScriptMod['asm']}")
 
-        signedRawTx = self.nodes[0].signrawtransaction(ToHex(tx_01))
+        signedRawTx = self.nodes[MAIN_NODE].signrawtransaction(ToHex(tx_01))
 
-        h = self.nodes[0].getblockcount()
+        h = self.nodes[MAIN_NODE].getblockcount()
         assert_greater_than(FINALITY_MIN_AGE, h - modTargetHeigth)
 
-        print("  Node0 sends %f coins to Node2" % payment)
+        print(f"  Node {MAIN_NODE} sends {payment} coins to Node {HONEST_NODES[2]}")
 
         try:
-            txid = self.nodes[0].sendrawtransaction(signedRawTx['hex'])
-            print("  Tx sent: ", txid)
+            txid = self.nodes[MAIN_NODE].sendrawtransaction(signedRawTx['hex'])
+            print(f"  Tx sent: {txid}")
             # should fail, therefore force test failure
             assert_equal(True, False)
 
         except JSONRPCException as e:
             print("  ==> tx has been rejected as expected:")
-            print("      referenced block height=%d, chainActive.height=%d, minimumAge=%d" % (modTargetHeigth, h, FINALITY_MIN_AGE))
-            print
+            print(f"      referenced block height={modTargetHeigth}, chainActive.height={h}, minimumAge={FINALITY_MIN_AGE}\n")
+
 
         #-------------------------------------------------------------------------------------------------------
         print("Check that small digit height for referenced blocks works in scriptPubKey")
@@ -195,66 +201,65 @@ class checkblockatheight(BitcoinTestFramework):
         # check that small height works for 'check block at height' in script
         #--------------------------------------------------------------------
         node1_pay = Decimal('0.5')
-        self.mark_logs("  Node0 sends %f coins to Node3" % node1_pay)
+        self.mark_logs(f"  Node {MAIN_NODE} sends {node1_pay} coins to Node {DISHONEST_NODE_INDEX}")
 
-        tx1 = self.nodes[0].sendtoaddress(self.nodes[3].getnewaddress(), node1_pay)
-        print("  ==> tx sent: ", tx1)
+        tx1 = self.nodes[MAIN_NODE].sendtoaddress(self.nodes[DISHONEST_NODE_INDEX].getnewaddress(), node1_pay)
+        print(f"  ==> tx sent: {tx1}")
 
         sync_mempools(self.nodes[0:4])
 
-        assert_equal(self.is_in_mempool(tx1), True)
+        assert_equal(self.is_in_mempool(tx1, node_idx=MAIN_NODE), True)
 
-        script = self.nodes[0].getrawtransaction(tx1, 1)['vout'][0]['scriptPubKey']['asm']
+        script = self.nodes[MAIN_NODE].getrawtransaction(tx1, 1)['vout'][0]['scriptPubKey']['asm']
         tokens = script.split()
         small_h = int(tokens[6])
         small_h_hash = swap_bytes(tokens[5])
 
-        print("  ScriptPubKey: ", script)
+        print(f"  ScriptPubKey: {script}")
 
         assert_equal(small_h, small_target_h)
         assert_equal(small_h_hash, blocks[int(small_h)])
 
-        print("  Node0 generating 1 honest block")
-        blocks.extend(self.nodes[0].generate(1))
+        print(f"  Node {MAIN_NODE} generating 1 honest block")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1))
         self.sync_all()
 
-        print("  | Node2 balance: ", self.nodes[2].getbalance())
-        print("  | Node3 balance: ", self.nodes[3].getbalance())
+        print(f"  | Node {HONEST_NODES[2]} balance: ", self.nodes[HONEST_NODES[2]].getbalance())
+        print(f"  | Node {DISHONEST_NODE_INDEX} balance: ", self.nodes[DISHONEST_NODE_INDEX].getbalance())
 
         # check tx is no more in mempool
-        assert_equal(self.is_in_mempool(tx1), False)
+        assert_equal(self.is_in_mempool(tx1, node_idx=MAIN_NODE), False)
 
         # check tx is in the block just mined
-        assert_equal(self.is_in_block(tx1, blocks[-1], 3), True)
+        assert_equal(self.is_in_block(tx1, blocks[-1], node_idx=DISHONEST_NODE_INDEX), True)
 
         # check the balance is the one expected
-        assert_equal(self.nodes[3].getbalance(), node1_pay)
+        assert_equal(self.nodes[DISHONEST_NODE_INDEX].getbalance(), node1_pay)
 
         amount_node2 = Decimal("0.25")
-        self.mark_logs("  Node3 sends {} coins to Node2".format(amount_node2) )
+        self.mark_logs(f"  Node {DISHONEST_NODE_INDEX} sends {amount_node2} coins to Node {HONEST_NODES[2]}")
 
-        tx2 = self.nodes[3].sendtoaddress(self.nodes[2].getnewaddress(), amount_node2)
-        print("  ==> tx sent: ", tx2)
+        tx2 = self.nodes[DISHONEST_NODE_INDEX].sendtoaddress(self.nodes[HONEST_NODES[2]].getnewaddress(), amount_node2)
+        print(f"  ==> tx sent: {tx2}")
 
         sync_mempools(self.nodes[0:4])
 
-        assert_equal(self.is_in_mempool(tx2), True)
+        assert_equal(self.is_in_mempool(tx2, node_idx=MAIN_NODE), True)
 
-        print("  Node0 generating 1 honest block")
-        blocks.extend(self.nodes[0].generate(1))
+        print(f"  Node {MAIN_NODE} generating 1 honest block")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1))
         self.sync_all()
 
         # check tx is no more in mempool
-        assert_equal(self.is_in_mempool(tx2), False)
+        assert_equal(self.is_in_mempool(tx2, node_idx=MAIN_NODE), False)
 
         # check tx is in the block just mined
-        assert_equal(self.is_in_block(tx2, blocks[-1], 1), True)
+        assert_equal(self.is_in_block(tx2, blocks[-1], node_idx=HONEST_NODES[1]), True)
 
         # check Node2 got his money
-        assert_equal(amount_node2, self.nodes[2].getbalance())
+        assert_equal(amount_node2, self.nodes[HONEST_NODES[2]].getbalance())
 
-        print("  ==> OK, small digit height works in scripts:")
-        print
+        print("  ==> OK, small digit height works in scripts:\n")
         #--------------------------------------------------------------------
         
         print("Verify that a legal tx, when the referenced block is reverted, becomes invalid until the necessary depth of the referenced block height has been reached...")
@@ -267,18 +272,18 @@ class checkblockatheight(BitcoinTestFramework):
         self.setup_network(False, 0)
 
         chunks = 305
-        self.mark_logs("  Node0 generates %d blocks" % chunks)
-        blocks.extend(self.nodes[0].generate(chunks)) 
+        self.mark_logs(f"  Node {MAIN_NODE} generates {chunks} blocks")
+        blocks.extend(self.nodes[MAIN_NODE].generate(chunks)) 
         self.sync_all()
 
-        self.mark_logs("  Split network: (0)---(1)---(2)   (3)")
+        self.mark_logs(f"The network is split: {HONEST_NODES[0]}-{HONEST_NODES[1]}-{HONEST_NODES[2]} .. {DISHONEST_NODE_INDEX}")
         self.split_network()
 
-        self.mark_logs("  Node0 generating 1 honest block")
-        blocks.extend(self.nodes[0].generate(1)) 
+        self.mark_logs(f"  Node {MAIN_NODE} generating 1 honest block")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1)) 
         sync_blocks(self.nodes, 1, False, 5)
 
-        h_current = self.nodes[1].getblockcount()
+        h_current = self.nodes[HONEST_NODES[1]].getblockcount()
 
         # we will perform on attack aimed at reverting from this block (latest generated) upward
         h_attacked = h_current
@@ -289,7 +294,7 @@ class checkblockatheight(BitcoinTestFramework):
         h_attacked_swapped = swap_bytes(hex_tmp)
         h_safe_estimated = h_attacked + FINALITY_SAFE_DEPTH + 1
 
-        print("  Honest network has current h[%d]" % h_attacked)
+        print(f"  Honest network has current h[{h_attacked}]")
 
         # mainchain creates cbh scripts where target block hash/height are CBH_DELTA_HEIGHT older than chain tip
         h_checked = h_current - CBH_DELTA_HEIGHT
@@ -299,7 +304,7 @@ class checkblockatheight(BitcoinTestFramework):
         hash_checked_swapped = swap_bytes(hash_checked)
 
         # select input, we have just one big utxo 
-        usp = self.nodes[1].listunspent()
+        usp = self.nodes[HONEST_NODES[1]].listunspent()
         assert_equal(len(usp), 1)
 
         amount = Decimal('1000.0')
@@ -307,10 +312,10 @@ class checkblockatheight(BitcoinTestFramework):
         change = amount_node1 - amount - fee
 
         inputs  = [{"txid":usp[0]['txid'], "vout":usp[0]['vout']}]
-        outputs = {self.nodes[1].getnewaddress(): change, self.nodes[2].getnewaddress(): amount}
+        outputs = {self.nodes[HONEST_NODES[1]].getnewaddress(): change, self.nodes[HONEST_NODES[2]].getnewaddress(): amount}
 
-        print("  Creating raw tx referencing the current block %d where Node1 sends %f coins to Node2..." % (h_attacked, amount))
-        rawTx   = self.nodes[1].createrawtransaction(inputs, outputs)
+        print(f"  Creating raw tx referencing the current block {h_attacked} where Node {HONEST_NODES[1]} sends {amount} coins to Node {HONEST_NODES[2]}...")
+        rawTx   = self.nodes[HONEST_NODES[1]].createrawtransaction(inputs, outputs)
 
         # replace hash and h referenced in tx's script with the ones of target block 
         from_buf = str(hash_checked_swapped)+'02'+str(h_checked_swapped)
@@ -319,7 +324,7 @@ class checkblockatheight(BitcoinTestFramework):
         # tamper just the output to Node2, not the change
 
         # select the right output, we can not rely on order of appearence of outputs
-        decVout = self.nodes[1].decoderawtransaction(rawTx)['vout']
+        decVout = self.nodes[HONEST_NODES[1]].decoderawtransaction(rawTx)['vout']
         idx = 0
         if decVout[1]['value'] == amount:
             idx = 1
@@ -329,111 +334,111 @@ class checkblockatheight(BitcoinTestFramework):
 
         rawTxReplaced = rawTx.replace(sp1, sp2)
 
-        signedRawTxReplaced = self.nodes[1].signrawtransaction(rawTxReplaced)
+        signedRawTxReplaced = self.nodes[HONEST_NODES[1]].signrawtransaction(rawTxReplaced)
 
-        print("  | Node1 balance: ", self.nodes[1].getbalance())
-        print("  | Node2 balance: ", self.nodes[2].getbalance())
-        assert_equal(amount_node1, self.nodes[1].getbalance())
-        assert_equal(amount_node2, self.nodes[2].getbalance())
+        print(f"  | Node {HONEST_NODES[1]} balance: {self.nodes[HONEST_NODES[1]].getbalance()}")
+        print(f"  | Node {HONEST_NODES[2]} balance: {self.nodes[HONEST_NODES[2]].getbalance()}")
+        assert_equal(amount_node1, self.nodes[HONEST_NODES[1]].getbalance())
+        assert_equal(amount_node2, self.nodes[HONEST_NODES[2]].getbalance())
 
         # the tx modified has a script that is currently valid but that will not pass the check
         # at referenced block once the chain is reverted
-        tx_1000 = self.nodes[1].sendrawtransaction(signedRawTxReplaced['hex'])
-        print("  ==> tx sent: ", tx_1000)
-        print("       amount : %f" % ( amount))
-        print("       change : %f" % ( change))
+        tx_1000 = self.nodes[HONEST_NODES[1]].sendrawtransaction(signedRawTxReplaced['hex'])
+        print(f"  ==> tx sent: {tx_1000}")
+        print(f"       amount : {amount}")
+        print(f"       change : {change}")
 
-        sync_mempools(self.nodes[0:3])
-        assert_equal(self.is_in_mempool(tx_1000, 1), True)
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=HONEST_NODES[1]), True)
         print("  OK, tx is in mempool...")
-        print("  | Node1 balance: ", self.nodes[1].getbalance())
-        print("  | Node2 balance: ", self.nodes[2].getbalance())
-        assert_equal(change,    self.nodes[1].getbalance())
-        assert_equal(amount_node2, self.nodes[2].getbalance())
+        print(f"  | Node {HONEST_NODES[1]} balance: {self.nodes[HONEST_NODES[1]].getbalance()}")
+        print(f"  | Node {HONEST_NODES[2]} balance: {self.nodes[HONEST_NODES[2]].getbalance()}")
+        assert_equal(change,    self.nodes[HONEST_NODES[1]].getbalance())
+        assert_equal(amount_node2, self.nodes[HONEST_NODES[2]].getbalance())
 
-        print("  Node0 generating 1 honest block")
-        blocks.extend(self.nodes[0].generate(1))
-        sync_blocks(self.nodes[0:2])
+        print(f"  Node {MAIN_NODE} generating 1 honest block")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1))
+        sync_blocks([self.nodes[i] for i in HONEST_NODES[0:2]])
         
         # check tx is no more in mempool
-        assert_equal(self.is_in_mempool(tx_1000, 1), False)
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=HONEST_NODES[1]), False)
 
         # check tx is in the block just mined
-        assert_equal(self.is_in_block(tx_1000, blocks[-1], 1), True)
+        assert_equal(self.is_in_block(tx_1000, blocks[-1], node_idx=HONEST_NODES[1]), True)
         print("  OK, tx is not in mempool anymore (it is contained in the block just mined)")
-        print("  Block: (%d) %s" % ( int(self.nodes[2].getblockcount()), blocks[-1]))
+        print(f"  Block: ({int(self.nodes[HONEST_NODES[2]].getblockcount())}) {blocks[-1]}")
 
-        print("  | Node1 balance: ", self.nodes[1].getbalance())
-        print("  | Node2 balance: ", self.nodes[2].getbalance())
-        assert_equal(change, self.nodes[1].getbalance())
-        assert_equal(amount_node2 + amount, self.nodes[2].getbalance())
+        print(f"  | Node {HONEST_NODES[1]} balance: {self.nodes[HONEST_NODES[1]].getbalance()}")
+        print(f"  | Node {HONEST_NODES[2]} balance: {self.nodes[HONEST_NODES[2]].getbalance()}")
+        assert_equal(change, self.nodes[HONEST_NODES[1]].getbalance())
+        assert_equal(amount_node2 + amount, self.nodes[HONEST_NODES[2]].getbalance())
 
-        print("  Node3 generating 3 malicious blocks thus reverting the honest chain once the ntw is joined!")
-        blocks.extend(self.nodes[3].generate(3))
+        print(f"  Node {DISHONEST_NODE_INDEX} generating 3 malicious blocks thus reverting the honest chain once the ntw is joined!")
+        blocks.extend(self.nodes[DISHONEST_NODE_INDEX].generate(3))
         sync_blocks(self.nodes, limit_loop=5)
         
         self.mark_logs("Joining network")
         self.join_network()
 
-        print("  Network joined: (0)---(1)---(2)---(3)")
+        self.mark_logs(f"The network is joined: {HONEST_NODES[0]}-{HONEST_NODES[1]}-{HONEST_NODES[2]}-{DISHONEST_NODE_INDEX}")
         self.mark_logs("Network joined")
 
         # check attacked transaction is back in the mempool of nodes belonging to the honest portion of the joined network
-        assert_equal(self.is_in_mempool(tx_1000, 0), True)
-        assert_equal(self.is_in_mempool(tx_1000, 1), True)
-        assert_equal(self.is_in_mempool(tx_1000, 2), True)
-        assert_equal(self.is_in_mempool(tx_1000, 3), False)
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=MAIN_NODE), True)
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=HONEST_NODES[1]), True)
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=HONEST_NODES[2]), True)
+        assert_equal(self.is_in_mempool(tx_1000, node_idx=DISHONEST_NODE_INDEX), False)
 
         print("  ==> the block has been reverted, the tx is back in the mempool of the reverted nodes!")
 
-        node1_bal = Decimal(self.nodes[1].getbalance() )
-        node2_bal = Decimal(self.nodes[2].getbalance() )
+        node1_bal = Decimal(self.nodes[HONEST_NODES[1]].getbalance() )
+        node2_bal = Decimal(self.nodes[HONEST_NODES[2]].getbalance() )
 
-        print("  | Node1 balance: ", node1_bal)
-        print("  | Node2 balance: ", node2_bal)
+        print(f"  | Node {HONEST_NODES[1]} balance: ", node1_bal)
+        print(f"  | Node {HONEST_NODES[2]} balance: ", node2_bal)
         assert_equal(change, node1_bal)
         assert_equal(amount_node2, node2_bal)
 
-        print("  Node0 generating 1 honest block")
-        blocks.extend(self.nodes[0].generate(1))
+        print(f"  Node {MAIN_NODE} generating 1 honest block")
+        blocks.extend(self.nodes[MAIN_NODE].generate(1))
         self.sync_all()
         
         # check tx_1000 is in the block just mined
-        assert_equal(self.is_in_block(tx_1000, blocks[-1], 2), True)
+        assert_equal(self.is_in_block(tx_1000, blocks[-1], node_idx=HONEST_NODES[2]), True)
 
         print("  ==> TX referencing reverted block has been mined in a new block!!")
-        print("       Block: (%d) %s" % ( int(self.nodes[3].getblockcount()), blocks[-1]))
+        print(f"       Block: ({int(self.nodes[DISHONEST_NODE_INDEX].getblockcount())}) {blocks[-1]}")
 
-        node1_bal = Decimal(self.nodes[1].getbalance() )
-        node2_bal = Decimal(self.nodes[2].getbalance() )
+        node1_bal = Decimal(self.nodes[HONEST_NODES[1]].getbalance() )
+        node2_bal = Decimal(self.nodes[HONEST_NODES[2]].getbalance() )
 
-        print("  | Node1 balance: ", node1_bal)
-        print("  | Node2 balance: ", node2_bal)
+        print(f"  | Node {HONEST_NODES[1]} balance: ", node1_bal)
+        print(f"  | Node {HONEST_NODES[2]} balance: ", node2_bal)
         assert_equal(change, node1_bal)
         assert_equal(amount_node2, node2_bal)
 
-        print("  Node3 generating %d honest blocks more" % (FINALITY_SAFE_DEPTH - 2))
+        print(f"  Node {DISHONEST_NODE_INDEX} generating {FINALITY_SAFE_DEPTH - 2} honest blocks more")
 
-        blocks.extend(self.nodes[3].generate(FINALITY_SAFE_DEPTH - 2))
+        blocks.extend(self.nodes[DISHONEST_NODE_INDEX].generate(FINALITY_SAFE_DEPTH - 2))
         self.sync_all()
 
         # from this block on, the tx will become valid because finality safe depth has been reached
         # and the cbh script is not checked anymore
-        h_safe = self.nodes[1].getblockcount()
+        h_safe = self.nodes[HONEST_NODES[1]].getblockcount()
         assert_equal(h_safe, h_safe_estimated)
 
-        node1_zbal = Decimal(self.nodes[1].z_gettotalbalance()['total'])
-        node2_zbal = Decimal(self.nodes[2].z_gettotalbalance()['total'])
-        node1_bal = Decimal(self.nodes[1].getbalance() )
-        node2_bal = Decimal(self.nodes[2].getbalance() )
+        node1_zbal = Decimal(self.nodes[HONEST_NODES[1]].z_gettotalbalance()['total'])
+        node2_zbal = Decimal(self.nodes[HONEST_NODES[2]].z_gettotalbalance()['total'])
+        node1_bal = Decimal(self.nodes[HONEST_NODES[1]].getbalance() )
+        node2_bal = Decimal(self.nodes[HONEST_NODES[2]].getbalance() )
 
-        print("  OK, at h[%d] the attacked tx have been restored (node will have it in cached balance after a restart)" % h_safe)
+        print(f"  OK, at h[{h_safe}] the attacked tx have been restored (node will have it in cached balance after a restart)")
 
         print("  Balances before node restart:")
-        print("  | Node1 balance (cached): ", node1_bal)
-        print("  | Node2 balance (cached): ", node2_bal)
-        print("  | Node1 z_balance: ", node1_zbal)
-        print("  | Node2 z_balance: ", node2_zbal)
+        print(f"  | Node {HONEST_NODES[1]} balance (cached): {node1_bal}")
+        print(f"  | Node {HONEST_NODES[2]} balance (cached): {node2_bal}")
+        print(f"  | Node {HONEST_NODES[1]} z_balance: {node1_zbal}")
+        print(f"  | Node {HONEST_NODES[2]} z_balance: {node2_zbal}")
 
         # non-cached balance must be ok while cached balance still does not have correct amounts
         assert_equal(node2_bal + amount, node2_zbal)
@@ -444,14 +449,14 @@ class checkblockatheight(BitcoinTestFramework):
         wait_bitcoinds()
         self.setup_network(False, 0)
 
-        final_bal1 = Decimal(self.nodes[1].getbalance() )
-        final_bal2 = Decimal(self.nodes[2].getbalance() )
-        node1_zbal = Decimal(self.nodes[1].z_gettotalbalance()['total'])
-        node2_zbal = Decimal(self.nodes[2].z_gettotalbalance()['total'])
+        final_bal1 = Decimal(self.nodes[HONEST_NODES[1]].getbalance() )
+        final_bal2 = Decimal(self.nodes[HONEST_NODES[2]].getbalance() )
+        node1_zbal = Decimal(self.nodes[HONEST_NODES[1]].z_gettotalbalance()['total'])
+        node2_zbal = Decimal(self.nodes[HONEST_NODES[2]].z_gettotalbalance()['total'])
 
         print("  Balances after node restart:")
-        print("  | Node1 balance: ", final_bal1)
-        print("  | Node2 balance: ", final_bal2)
+        print(f"  | Node {HONEST_NODES[1]} balance: {final_bal1}")
+        print(f"  | Node {HONEST_NODES[2]} balance: {final_bal2}")
 
         # ensure the amounts have been restored in cached balances
         assert_equal(node1_bal, final_bal1)

--- a/qa/rpc-tests/mempool_double_spend.py
+++ b/qa/rpc-tests/mempool_double_spend.py
@@ -17,10 +17,10 @@ DEBUG_MODE = 1
 NUMB_OF_NODES = 3
 SC_COINS_MAT = 1
 
-DOUBLE_SPEND_NODE_INDEX = NUMB_OF_NODES - 1    # The node that tries to perform the double spend
+DOUBLE_SPEND_NODE_INDEX = NUMB_OF_NODES - 1     # The node that tries to perform the double spend
 HONEST_NODES = list(range(NUMB_OF_NODES))
 HONEST_NODES.remove(DOUBLE_SPEND_NODE_INDEX)
-MAIN_NODE = HONEST_NODES[0]
+MAIN_NODE = HONEST_NODES[0]                     # Hardcoded alias, do not change
 
 
 class TxnMallTest(BitcoinTestFramework):
@@ -30,6 +30,8 @@ class TxnMallTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
     def setup_network(self, split=False):
+        assert_equal(MAIN_NODE, HONEST_NODES[0])
+
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args= [['-blockprioritysize=0',
             '-debug=py', '-debug=sc', '-debug=mempool', '-debug=net', '-debug=cert', '-debug=zendoo_mc_cryptolib',
             '-scproofqueuesize=0', '-logtimemicros=1', '-sccoinsmaturity=%d' % SC_COINS_MAT]] * NUMB_OF_NODES )

--- a/qa/rpc-tests/mempool_double_spend.py
+++ b/qa/rpc-tests/mempool_double_spend.py
@@ -25,11 +25,11 @@ MAIN_NODE = HONEST_NODES[0]                     # Hardcoded alias, do not change
 
 class TxnMallTest(BitcoinTestFramework):
 
-    def setup_chain(self, split=False):
+    def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         assert_equal(MAIN_NODE, HONEST_NODES[0])
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args= [['-blockprioritysize=0',
@@ -38,7 +38,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx + 1)
-        self.is_network_split = split
+        self.is_network_split = False
         self.sync_all()
 
     def join_network(self):

--- a/qa/rpc-tests/sc_cert_ceasing_split.py
+++ b/qa/rpc-tests/sc_cert_ceasing_split.py
@@ -10,22 +10,26 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
-    wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
+    start_nodes, connect_nodes_bi, assert_true, mark_logs, \
+    get_epoch_data, sync_mempools, \
     disconnect_nodes, advance_epoch, swap_bytes
 
-from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
+from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import *
 
 from decimal import Decimal
 import pprint
-import time
 
 NUMB_OF_NODES = 4
 DEBUG_MODE = 1
 EPOCH_LENGTH = 10
 FT_SC_FEE = Decimal('0')
 MBTR_SC_FEE = Decimal('0')
+
+DISHONEST_NODE_INDEX = NUMB_OF_NODES - 1    # Dishonest node
+HONEST_NODES = list(range(NUMB_OF_NODES))
+HONEST_NODES.remove(DISHONEST_NODE_INDEX)
+MAIN_NODE = HONEST_NODES[0]
 
 # Create one-input, one-output, no-fee transaction:
 class CeasingSplitTest(BitcoinTestFramework):
@@ -39,30 +43,40 @@ class CeasingSplitTest(BitcoinTestFramework):
                                  extra_args=[['-scproofqueuesize=0', '-logtimemicros=1', '-debug=sc', '-debug=py',
                                               '-debug=mempool', '-debug=net', '-debug=bench']] * NUMB_OF_NODES)
 
-        if not split:
-            # 2 and 3 are joint only if split==false
-            connect_nodes_bi(self.nodes, 2, 3)
-            sync_blocks(self.nodes[2:4])
-            sync_mempools(self.nodes[2:4])
-
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 2)
+        for idx in range(NUMB_OF_NODES - 1):
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = split
         self.sync_all()
 
     def split_network(self):
-        # Split the network of three nodes into nodes 0-1-2 and 3.
-        assert not self.is_network_split
-        disconnect_nodes(self.nodes[2], 3)
-        disconnect_nodes(self.nodes[3], 2)
+        # Disconnect the dishonest node from the network
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+        elif idx == 0:
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+        else:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+            connect_nodes_bi(self.nodes, idx - 1, idx + 1)
         self.is_network_split = True
 
     def join_network(self):
-        # Join the (previously split) network pieces together: 0-1-2-3
-        assert self.is_network_split
-        connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 2)
-        time.sleep(2)
+        #Join the (previously split) network pieces together
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+        elif idx == 0:
+            connect_nodes_bi(self.nodes, idx, idx + 1)
+        else:
+            disconnect_nodes(self.nodes[idx - 1], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = False
 
     def run_test(self):
@@ -75,28 +89,23 @@ class CeasingSplitTest(BitcoinTestFramework):
         '''
 
         # prepare some coins 
-        self.nodes[2].generate(1)
+        self.nodes[HONEST_NODES[2]].generate(1)
         self.sync_all()
-        self.nodes[1].generate(1)
+        self.nodes[HONEST_NODES[1]].generate(1)
         self.sync_all()
-        self.nodes[0].generate(ForkHeights['MINIMAL_SC']-2)
+        self.nodes[MAIN_NODE].generate(ForkHeights['MINIMAL_SC']-2)
         self.sync_all()
-        block_2 = self.nodes[0].getbestblockhash()
-        self.nodes[0].generate(1)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
-        prev_epoch_hash = self.nodes[0].getbestblockhash()
-        block_1 = prev_epoch_hash
 
         sc_address = "0000000000000000000000000000000000000000000000000000000000000abc"
         sc_epoch_len = EPOCH_LENGTH
         sc_cr_amount = Decimal('12.00000000')
 
         certMcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
-        cswMcTest = CSWTestUtils(self.options.tmpdir, self.options.srcdir)
 
         # generate wCertVk and constant
         vk = certMcTest.generate_params("sc1")
-        cswVk = cswMcTest.generate_params("csw1")
         constant = generate_random_field_element_hex()
 
         cmdInput = {
@@ -109,85 +118,84 @@ class CeasingSplitTest(BitcoinTestFramework):
             'mainchainBackwardTransferRequestDataLength': 1
         }
 
-        res = self.nodes[0].sc_create(cmdInput)
+        res = self.nodes[MAIN_NODE].sc_create(cmdInput)
         tx =   res['txid']
         scid = res['scid']
         self.sync_all()
-        mark_logs("tx {} created SC {}".format(tx, scid), self.nodes, DEBUG_MODE)
+        mark_logs(f"tx {tx} created SC {scid}", self.nodes, DEBUG_MODE)
 
-        mc_dest_addr = self.nodes[1].getnewaddress()
+        mc_dest_addr = self.nodes[HONEST_NODES[1]].getnewaddress()
         fe1 = [generate_random_field_element_hex()]
 
         # advance two epochs
-        mark_logs("\nLet 2 epochs pass by...".  format(sc_epoch_len), self.nodes, DEBUG_MODE)
+        mark_logs("\nLet 2 epochs pass by...", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
             scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
             scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
-        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
-        numbBlocks = ceas_height - self.nodes[0].getblockcount() + sc_epoch_len - 1
+        ceas_height = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
+        numbBlocks = ceas_height - self.nodes[MAIN_NODE].getblockcount() + sc_epoch_len - 1
 
-        mark_logs("\nNode0 generates {} block reaching the sg for the next epoch".format(numbBlocks), self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(numbBlocks)
+        mark_logs(f"\nNode {MAIN_NODE} generates {numbBlocks} block reaching the sg for the next epoch", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(numbBlocks)
         self.sync_all()
 
-        cur_h = self.nodes[0].getblockcount()
-        ret=self.nodes[0].getscinfo(scid, True, False)['items'][0]
+        cur_h = self.nodes[MAIN_NODE].getblockcount()
+        ret=self.nodes[MAIN_NODE].getscinfo(scid, True, False)['items'][0]
         cr_height=ret['createdAtBlockHeight']
         ceas_h = ret['ceasingHeight']
-        mark_logs("epoch number={}, current height={}, creation height={}, ceasingHeight={}, epoch_len={}"
-            .format(epoch_number, cur_h, cr_height, ceas_h, sc_epoch_len), self.nodes, DEBUG_MODE)
-        print
+        mark_logs(f"epoch number={epoch_number}, current height={cur_h}, creation height={cr_height}, ceasingHeight={ceas_h}, epoch_len={sc_epoch_len}\n",
+                  self.nodes, DEBUG_MODE)
 
-        bal_initial = self.nodes[0].getscinfo(scid, False, False)['items'][0]['balance']
+        bal_initial = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]['balance']
 
         #============================================================================================
         mark_logs("\nSplit network", self.nodes, DEBUG_MODE)
         self.split_network()
-        mark_logs("The network is split: 0-1-2 .. 3", self.nodes, DEBUG_MODE)
+        mark_logs(f"The network is split: {HONEST_NODES[0]}-{HONEST_NODES[1]}-{HONEST_NODES[2]} .. {DISHONEST_NODE_INDEX}", self.nodes, DEBUG_MODE)
 
         # Network part 0-1-2
         print("------------------")
         # use different nodes for sending txes and cert in order to be sure there are no dependancies from each other
         fwt_amount = Decimal("2.0")
-        mc_return_address = self.nodes[0].getnewaddress()
-        mark_logs("\nNTW part 1) Node0 sends {} coins to SC".format(fwt_amount), self.nodes, DEBUG_MODE)
+        mc_return_address = self.nodes[MAIN_NODE].getnewaddress()
+        mark_logs(f"\nNTW part 1) Node {MAIN_NODE} sends {fwt_amount} coins to SC", self.nodes, DEBUG_MODE)
         cmdInput = [{'toaddress': "abcd", 'amount': fwt_amount, "scid": scid, 'mcReturnAddress': mc_return_address}]
-        tx_fwd = self.nodes[0].sc_send(cmdInput)
-        sync_mempools(self.nodes[0:3])
+        tx_fwd = self.nodes[MAIN_NODE].sc_send(cmdInput)
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check fwd tx {} is in mempool".format(tx_fwd), self.nodes, DEBUG_MODE)
-        assert_true(tx_fwd in self.nodes[0].getrawmempool()) 
+        mark_logs(f"              Check fwd tx {tx_fwd} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(tx_fwd in self.nodes[MAIN_NODE].getrawmempool()) 
 
         outputs = [{'vScRequestData':fe1, 'scFee':Decimal("0.001"), 'scid':scid, 'mcDestinationAddress': mc_dest_addr}]
         cmdParms = { "minconf":0, "fee":0.0}
-        mark_logs("\nNTW part 1) Node1 creates a tx with a bwt request", self.nodes, DEBUG_MODE)
+        mark_logs(f"\nNTW part 1) Node {HONEST_NODES[1]} creates a tx with a bwt request", self.nodes, DEBUG_MODE)
         try:
-            tx_bwt = self.nodes[1].sc_request_transfer(outputs, cmdParms);
+            tx_bwt = self.nodes[HONEST_NODES[1]].sc_request_transfer(outputs, cmdParms);
         except JSONRPCException as e:
             errorString = e.error['message']
             mark_logs(errorString,self.nodes,DEBUG_MODE)
             assert_true(False)
 
-        sync_mempools(self.nodes[0:3])
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check bwd tx {} is in mempool".format(tx_bwt), self.nodes, DEBUG_MODE)
-        assert_true(tx_bwt in self.nodes[0].getrawmempool()) 
+        mark_logs(f"              Check bwd tx {tx_bwt} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(tx_bwt in self.nodes[MAIN_NODE].getrawmempool()) 
 
-        mark_logs("\nNTW part 1) Node2 sends a certificate for keeping the SC alive", self.nodes, DEBUG_MODE)
-        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[2], sc_epoch_len)
+        mark_logs(f"\nNTW part 1) Node {HONEST_NODES[2]} sends a certificate for keeping the SC alive", self.nodes, DEBUG_MODE)
+        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[HONEST_NODES[2]], sc_epoch_len)
 
         bt_amount = Decimal("5.0")
-        addr_node1 = self.nodes[1].getnewaddress()
+        addr_node1 = self.nodes[HONEST_NODES[1]].getnewaddress()
         quality = 10
         scid_swapped = str(swap_bytes(scid))
  
@@ -204,111 +212,104 @@ class CeasingSplitTest(BitcoinTestFramework):
  
         amount_cert = [{"address": addr_node1, "amount": bt_amount}]
         try:
-            cert_bad = self.nodes[2].sc_send_certificate(scid, epoch_number, 10,
+            cert_bad = self.nodes[HONEST_NODES[2]].sc_send_certificate(scid, epoch_number, 10,
                 epoch_cum_tree_hash, proof, amount_cert, 0, 0, 0.01)
         except JSONRPCException as e:
             errorString = e.error['message']
-            print("Send certificate failed with reason {}".format(errorString))
+            print(f"Send certificate failed with reason {errorString}")
             assert(False)
 
-        sync_mempools(self.nodes[0:3])
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check cert {} is in mempool".format(cert_bad), self.nodes, DEBUG_MODE)
-        assert_true(cert_bad in self.nodes[0].getrawmempool()) 
+        mark_logs(f"              Check cert {cert_bad} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(cert_bad in self.nodes[MAIN_NODE].getrawmempool()) 
 
         # Network part 2
         print("------------------")
 
-        mark_logs("\nNTW part 2) Let SC cease... ".format(scid), self.nodes, DEBUG_MODE)
+        mark_logs("\nNTW part 2) Let SC cease... ", self.nodes, DEBUG_MODE)
 
-        mark_logs("NTW part 2) Node3 generates 1 block", self.nodes, DEBUG_MODE)
-        self.nodes[3].generate(1)
-        sync_mempools(self.nodes[3:4])
+        mark_logs(f"NTW part 2) Node {DISHONEST_NODE_INDEX} generates 1 block", self.nodes, DEBUG_MODE)
+        self.nodes[DISHONEST_NODE_INDEX].generate(1)
+        sync_mempools([self.nodes[DISHONEST_NODE_INDEX]])
 
         # check it is really ceased
-        ret = self.nodes[3].getscinfo(scid, False, False)['items'][0]
+        ret = self.nodes[DISHONEST_NODE_INDEX].getscinfo(scid, False, False)['items'][0]
         assert_equal(ret['state'], "CEASED")
 
         #============================================================================================
         mark_logs("\nJoining network", self.nodes, DEBUG_MODE)
         self.join_network()
+        self.sync_all()
         mark_logs("Network joined", self.nodes, DEBUG_MODE)
 
         any_error = False
 
         # check SC is really ceased
-        mark_logs("Check that Node3 has prevailed and SC is really ceased...".format(tx_fwd), self.nodes, DEBUG_MODE)
-        ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
+        mark_logs(f"Check that Node {DISHONEST_NODE_INDEX} has prevailed and SC is really ceased...", self.nodes, DEBUG_MODE)
+        ret = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]
         assert_equal(ret['state'], "CEASED")
 
-        mark_logs("Check fwd tx {} is no more in mempool...".format(tx_fwd), self.nodes, DEBUG_MODE)
+        mark_logs(f"Check fwd tx {tx_fwd} is no more in mempool...", self.nodes, DEBUG_MODE)
 
-        #assert_false(tx_fwd in self.nodes[0].getrawmempool()) 
-        if tx_fwd in self.nodes[0].getrawmempool():
+        if tx_fwd in self.nodes[MAIN_NODE].getrawmempool():
             print("FIX FIX FIX!!! fwt is still in mempool" )
             any_error = True
 
 
-        mark_logs("And that no info are available too...".format(tx_fwd), self.nodes, DEBUG_MODE)
+        mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
-            dec = self.nodes[0].getrawtransaction(tx_fwd, 1)
-            print("FIX FIX FIX!!! tx_fwd has info in Node0" )
+            dec = self.nodes[MAIN_NODE].getrawtransaction(tx_fwd, 1)
+            print(f"FIX FIX FIX!!! tx_fwd has info in Node {self.nodes[MAIN_NODE]}" )
             any_error = True
             #assert (False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
             assert_true("No information" in errorString)
 
-        mark_logs("Check bwd tx {} is no more in mempool".format(tx_bwt), self.nodes, DEBUG_MODE)
-        #assert_false(tx_bwt in self.nodes[0].getrawmempool()) 
-        if tx_bwt in self.nodes[0].getrawmempool():
+        mark_logs(f"Check bwd tx {tx_bwt} is no more in mempool", self.nodes, DEBUG_MODE)
+        if tx_bwt in self.nodes[MAIN_NODE].getrawmempool():
             print("FIX FIX FIX!!! bwt is still in mempool" )
             any_error = True
 
-        mark_logs("And that no info are available too...".format(tx_bwt), self.nodes, DEBUG_MODE)
+        mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
-            dec = self.nodes[0].getrawtransaction(tx_bwt, 1)
-            print("FIX FIX FIX!!! tx_bwt has info in Node0" )
+            dec = self.nodes[MAIN_NODE].getrawtransaction(tx_bwt, 1)
+            print(f"FIX FIX FIX!!! tx_bwt has info in Node {self.nodes[MAIN_NODE]}" )
             any_error = True
             #assert (False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
             assert_true("No information" in errorString)
 
-        mark_logs("Check cert {} is no more in mempool".format(cert_bad), self.nodes, DEBUG_MODE)
-        #assert_false(cert in self.nodes[0].getrawmempool()) 
-        if cert_bad in self.nodes[0].getrawmempool():
+        mark_logs(f"Check cert {cert_bad} is no more in mempool", self.nodes, DEBUG_MODE)
+        if cert_bad in self.nodes[MAIN_NODE].getrawmempool():
             print("FIX FIX FIX!!! cert is still in mempool" )
 
         mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
-            dec = self.nodes[0].getrawtransaction(cert_bad, 1)
-            print("FIX FIX FIX!!! cert has info in Node0" )
+            dec = self.nodes[MAIN_NODE].getrawtransaction(cert_bad, 1)
+            print(f"FIX FIX FIX!!! cert has info in Node {self.nodes[MAIN_NODE]}" )
             any_error = True
-            #assert (False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
 
         mark_logs("Check SC balance has not changed", self.nodes, DEBUG_MODE)
         try:
-            bal_final = self.nodes[0].getscinfo(scid)['items'][0]['balance']
+            bal_final = self.nodes[MAIN_NODE].getscinfo(scid)['items'][0]['balance']
             assert_equal(bal_initial, bal_final)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
 
-        pprint.pprint(self.nodes[0].getrawmempool())
+        pprint.pprint(self.nodes[MAIN_NODE].getrawmempool())
 
         if any_error:
             print(" =========================> Test failed!!!")
             assert(False)
-
-        # if any_error this should fail
-        #self.nodes[0].generate(1)
-
 
 if __name__ == '__main__':
     CeasingSplitTest().main()

--- a/qa/rpc-tests/sc_cert_ceasing_split.py
+++ b/qa/rpc-tests/sc_cert_ceasing_split.py
@@ -38,7 +38,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         assert_equal(MAIN_NODE, HONEST_NODES[0])
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
@@ -47,7 +47,7 @@ class CeasingSplitTest(BitcoinTestFramework):
 
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx + 1)
-        self.is_network_split = split
+        self.is_network_split = False
         self.sync_all()
 
     def split_network(self):

--- a/qa/rpc-tests/sc_cert_ceasing_split.py
+++ b/qa/rpc-tests/sc_cert_ceasing_split.py
@@ -29,7 +29,7 @@ MBTR_SC_FEE = Decimal('0')
 DISHONEST_NODE_INDEX = NUMB_OF_NODES - 1    # Dishonest node
 HONEST_NODES = list(range(NUMB_OF_NODES))
 HONEST_NODES.remove(DISHONEST_NODE_INDEX)
-MAIN_NODE = HONEST_NODES[0]
+MAIN_NODE = HONEST_NODES[0]                 # Hardcoded alias, do not change
 
 # Create one-input, one-output, no-fee transaction:
 class CeasingSplitTest(BitcoinTestFramework):
@@ -39,6 +39,8 @@ class CeasingSplitTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
     def setup_network(self, split=False):
+        assert_equal(MAIN_NODE, HONEST_NODES[0])
+
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
                                  extra_args=[['-scproofqueuesize=0', '-logtimemicros=1', '-debug=sc', '-debug=py',
                                               '-debug=mempool', '-debug=net', '-debug=bench']] * NUMB_OF_NODES)
@@ -180,7 +182,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         cmdParms = { "minconf":0, "fee":0.0}
         mark_logs(f"\nNTW part 1) Node {HONEST_NODES[1]} creates a tx with a bwt request", self.nodes, DEBUG_MODE)
         try:
-            tx_bwt = self.nodes[HONEST_NODES[1]].sc_request_transfer(outputs, cmdParms);
+            tx_bwt = self.nodes[HONEST_NODES[1]].sc_request_transfer(outputs, cmdParms)
         except JSONRPCException as e:
             errorString = e.error['message']
             mark_logs(errorString,self.nodes,DEBUG_MODE)
@@ -198,7 +200,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         addr_node1 = self.nodes[HONEST_NODES[1]].getnewaddress()
         quality = 10
         scid_swapped = str(swap_bytes(scid))
- 
+
         proof = certMcTest.create_test_proof("sc1",
                                              scid_swapped,
                                              epoch_number,
@@ -209,7 +211,7 @@ class CeasingSplitTest(BitcoinTestFramework):
                                              constant = constant,
                                              pks      = [addr_node1],
                                              amounts  = [bt_amount])
- 
+
         amount_cert = [{"address": addr_node1, "amount": bt_amount}]
         try:
             cert_bad = self.nodes[HONEST_NODES[2]].sc_send_certificate(scid, epoch_number, 10,
@@ -260,7 +262,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
             dec = self.nodes[MAIN_NODE].getrawtransaction(tx_fwd, 1)
-            print(f"FIX FIX FIX!!! tx_fwd has info in Node {self.nodes[MAIN_NODE]}" )
+            print(f"FIX FIX FIX!!! tx_fwd has info in Node {MAIN_NODE}" )
             any_error = True
             #assert (False)
         except JSONRPCException as e:
@@ -276,7 +278,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
             dec = self.nodes[MAIN_NODE].getrawtransaction(tx_bwt, 1)
-            print(f"FIX FIX FIX!!! tx_bwt has info in Node {self.nodes[MAIN_NODE]}" )
+            print(f"FIX FIX FIX!!! tx_bwt has info in Node {MAIN_NODE}" )
             any_error = True
             #assert (False)
         except JSONRPCException as e:
@@ -291,7 +293,7 @@ class CeasingSplitTest(BitcoinTestFramework):
         mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
             dec = self.nodes[MAIN_NODE].getrawtransaction(cert_bad, 1)
-            print(f"FIX FIX FIX!!! cert has info in Node {self.nodes[MAIN_NODE]}" )
+            print(f"FIX FIX FIX!!! cert has info in Node {MAIN_NODE}" )
             any_error = True
         except JSONRPCException as e:
             errorString = e.error['message']

--- a/qa/rpc-tests/sc_cert_memcleanup_split.py
+++ b/qa/rpc-tests/sc_cert_memcleanup_split.py
@@ -38,7 +38,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         assert_equal(MAIN_NODE, HONEST_NODES[0])
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
@@ -47,7 +47,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx + 1)
-        self.is_network_split = split
+        self.is_network_split = False
         self.sync_all()
 
     def split_network(self):

--- a/qa/rpc-tests/sc_cert_memcleanup_split.py
+++ b/qa/rpc-tests/sc_cert_memcleanup_split.py
@@ -11,9 +11,10 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
-    wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
+    get_epoch_data, sync_mempools, \
     disconnect_nodes, advance_epoch, swap_bytes
-from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
+
+from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import *
 
 from decimal import Decimal
@@ -25,6 +26,11 @@ DEBUG_MODE = 1
 EPOCH_LENGTH = 10
 FT_SC_FEE = Decimal('0')
 MBTR_SC_FEE = Decimal('0')
+
+DISHONEST_NODE_INDEX = NUMB_OF_NODES - 1    # Dishonest node
+HONEST_NODES = list(range(NUMB_OF_NODES))
+HONEST_NODES.remove(DISHONEST_NODE_INDEX)
+MAIN_NODE = HONEST_NODES[0]
 
 # Create one-input, one-output, no-fee transaction:
 class CertMempoolCleanupSplit(BitcoinTestFramework):
@@ -38,31 +44,42 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
                                  extra_args=[['-logtimemicros=1', '-scproofqueuesize=0', '-debug=sc', '-debug=py',
                                               '-debug=mempool', '-debug=net', '-debug=bench']] * NUMB_OF_NODES)
 
-        if not split:
-            # 2 and 3 are joint only if split==false
-            connect_nodes_bi(self.nodes, 2, 3)
-            sync_blocks(self.nodes[2:4])
-            sync_mempools(self.nodes[2:4])
-
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 2)
+        for idx in range(NUMB_OF_NODES - 1):
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = split
         self.sync_all()
 
     def split_network(self):
-        # Split the network of three nodes into nodes 0-1-2 and 3.
-        assert not self.is_network_split
-        disconnect_nodes(self.nodes[2], 3)
-        disconnect_nodes(self.nodes[3], 2)
+        # Disconnect the dishonest node from the network
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+        elif idx == 0:
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+        else:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+            connect_nodes_bi(self.nodes, idx - 1, idx + 1)
         self.is_network_split = True
 
     def join_network(self):
-        # Join the (previously split) network pieces together: 0-1-2-3
-        assert self.is_network_split
-        connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 2)
-        time.sleep(2)
+        #Join the (previously split) network pieces together
+        idx = DISHONEST_NODE_INDEX
+        if idx == NUMB_OF_NODES - 1:
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+        elif idx == 0:
+            connect_nodes_bi(self.nodes, idx, idx + 1)
+        else:
+            disconnect_nodes(self.nodes[idx - 1], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = False
+        time.sleep(2)
 
     def run_test(self):
         '''
@@ -74,18 +91,18 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         '''
 
         # prepare some coins 
-        self.nodes[3].generate(1)
+        self.nodes[DISHONEST_NODE_INDEX].generate(1)
         self.sync_all()
-        self.nodes[2].generate(1)
+        self.nodes[HONEST_NODES[2]].generate(1)
         self.sync_all()
-        self.nodes[1].generate(1)
+        self.nodes[HONEST_NODES[1]].generate(1)
         self.sync_all()
-        self.nodes[0].generate(ForkHeights['MINIMAL_SC']-3)
+        self.nodes[MAIN_NODE].generate(ForkHeights['MINIMAL_SC']-3)
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
 
-        print("Node0 Chain h = ", self.nodes[0].getblockcount())
+        print(f"Node {MAIN_NODE} Chain h = {self.nodes[MAIN_NODE].getblockcount()}")
 
         sc_address = "0000000000000000000000000000000000000000000000000000000000000abc"
         sc_epoch_len = EPOCH_LENGTH
@@ -107,80 +124,80 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
             'mainchainBackwardTransferRequestDataLength': 1
         }
 
-        res = self.nodes[0].sc_create(cmdInput)
+        res = self.nodes[MAIN_NODE].sc_create(cmdInput)
         tx =   res['txid']
         scid = res['scid']
         scid_swapped = str(swap_bytes(scid))
         self.sync_all()
-        mark_logs("tx {} created SC {}".format(tx, scid), self.nodes, DEBUG_MODE)
+        mark_logs(f"tx {tx} created SC {scid}", self.nodes, DEBUG_MODE)
 
-        dest_addr = self.nodes[1].getnewaddress()
+        dest_addr = self.nodes[HONEST_NODES[1]].getnewaddress()
         fe1 = [generate_random_field_element_hex()]
 
         # advance two epochs
         mark_logs("\nLet 2 epochs pass by...", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
              scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
              scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
-        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
-        numbBlocks = ceas_height - self.nodes[0].getblockcount() + sc_epoch_len - 1
-        print("Node0 Chain h = ", self.nodes[0].getblockcount())
+        ceas_height = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
+        numbBlocks = ceas_height - self.nodes[MAIN_NODE].getblockcount() + sc_epoch_len - 1
+        print(f"Node {MAIN_NODE} Chain h = {self.nodes[MAIN_NODE].getblockcount()}")
 
-        mark_logs("\nNode0 generates {} block reaching the sg for the next epoch".format(numbBlocks), self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(numbBlocks)
+        mark_logs(f"\nNode {MAIN_NODE} generates {numbBlocks} block reaching the sg for the next epoch", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(numbBlocks)
         self.sync_all()
-        print("Node0 Chain h = ", self.nodes[0].getblockcount())
+        print(f"Node {MAIN_NODE} Chain h = {self.nodes[MAIN_NODE].getblockcount()}")
         
-        bal_initial = self.nodes[0].getscinfo(scid, False, False)['items'][0]['balance']
+        bal_initial = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]['balance']
 
         #============================================================================================
         mark_logs("\nSplit network", self.nodes, DEBUG_MODE)
         self.split_network()
-        mark_logs("The network is split: 0-1-2 .. 3", self.nodes, DEBUG_MODE)
+        mark_logs(f"The network is split: {HONEST_NODES[0]}-{HONEST_NODES[1]}-{HONEST_NODES[2]} .. {DISHONEST_NODE_INDEX}", self.nodes, DEBUG_MODE)
 
         # Network part 0-1-2
         print("------------------")
         # use different nodes for sending txes and cert in order to be sure there are no dependancies from each other
         fwt_amount = Decimal("2.0")
-        mc_return_address = self.nodes[0].getnewaddress()
-        mark_logs("\nNTW part 1) Node0 sends {} coins to SC".format(fwt_amount), self.nodes, DEBUG_MODE)
+        mc_return_address = self.nodes[MAIN_NODE].getnewaddress()
+        mark_logs(f"\nNTW part 1) Node {MAIN_NODE} sends {fwt_amount} coins to SC", self.nodes, DEBUG_MODE)
         cmdInput = [{'toaddress': "abcd", 'amount': fwt_amount, "scid": scid, 'mcReturnAddress': mc_return_address}]
-        tx_fwd = self.nodes[0].sc_send(cmdInput)
-        sync_mempools(self.nodes[0:3])
+        tx_fwd = self.nodes[MAIN_NODE].sc_send(cmdInput)
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check fwd tx {} is in mempool".format(tx_fwd), self.nodes, DEBUG_MODE)
-        assert_true(tx_fwd in self.nodes[0].getrawmempool()) 
+        mark_logs(f"              Check fwd tx {tx_fwd} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(tx_fwd in self.nodes[MAIN_NODE].getrawmempool()) 
 
         outputs = [{'vScRequestData': fe1, 'scFee': Decimal("0.001"), 'scid': scid, 'mcDestinationAddress': dest_addr}]
         cmdParms = { "minconf":0, "fee":0.0}
-        mark_logs("\nNTW part 1) Node1 creates a tx with a bwt request", self.nodes, DEBUG_MODE)
+        mark_logs(f"\nNTW part 1) Node {HONEST_NODES[1]} creates a tx with a bwt request", self.nodes, DEBUG_MODE)
         try:
-            tx_bwt = self.nodes[1].sc_request_transfer(outputs, cmdParms)
+            tx_bwt = self.nodes[HONEST_NODES[1]].sc_request_transfer(outputs, cmdParms)
         except JSONRPCException as e:
             errorString = e.error['message']
             mark_logs(errorString,self.nodes,DEBUG_MODE)
             assert_true(False)
 
-        sync_mempools(self.nodes[0:3])
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check bwd tx {} is in mempool".format(tx_bwt), self.nodes, DEBUG_MODE)
-        assert_true(tx_bwt in self.nodes[0].getrawmempool()) 
+        mark_logs(f"              Check bwd tx {tx_bwt} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(tx_bwt in self.nodes[MAIN_NODE].getrawmempool()) 
 
-        mark_logs("\nNTW part 1) Node2 sends a certificate", self.nodes, DEBUG_MODE)
-        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[2], sc_epoch_len)
+        mark_logs(f"\nNTW part 1) Node {HONEST_NODES[2]} sends a certificate", self.nodes, DEBUG_MODE)
+        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[HONEST_NODES[2]], sc_epoch_len)
 
         bt_amount = Decimal("5.0")
-        addr_node1 = self.nodes[1].getnewaddress()
+        addr_node1 = self.nodes[HONEST_NODES[1]].getnewaddress()
         quality = 10
 
         proof = certMcTest.create_test_proof("sc1",
@@ -196,25 +213,25 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         amount_cert = [{"address": addr_node1, "amount": bt_amount}]
         try:
-            cert_bad = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
+            cert_bad = self.nodes[HONEST_NODES[2]].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert, 0, 0, 0.01)
         except JSONRPCException as e:
             errorString = e.error['message']
-            print("Send certificate failed with reason {}".format(errorString))
+            print(f"Send certificate failed with reason {errorString}")
             assert(False)
-        sync_mempools(self.nodes[0:3])
+        sync_mempools([self.nodes[i] for i in HONEST_NODES])
 
-        mark_logs("              Check cert {} is in mempool".format(cert_bad), self.nodes, DEBUG_MODE)
-        assert_true(cert_bad in self.nodes[0].getrawmempool()) 
-        print("Node0 Chain h = ", self.nodes[0].getblockcount())
+        mark_logs(f"              Check cert {cert_bad} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(cert_bad in self.nodes[MAIN_NODE].getrawmempool()) 
+        print(f"Node {MAIN_NODE} Chain h = {self.nodes[MAIN_NODE].getblockcount()}")
 
         # Network part 2
         #------------------
-        mark_logs("\nNTW part 2) Node3 sends a certificate", self.nodes, DEBUG_MODE)
-        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[3], sc_epoch_len)
+        mark_logs(f"\nNTW part 2) Dishonest node {DISHONEST_NODE_INDEX} sends a certificate", self.nodes, DEBUG_MODE)
+        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[DISHONEST_NODE_INDEX], sc_epoch_len)
 
         bt_amount_2 = Decimal("10.0")
-        addr_node1 = self.nodes[1].getnewaddress()
+        addr_node1 = self.nodes[HONEST_NODES[1]].getnewaddress()
         quality = 5
 
         proof = certMcTest.create_test_proof("sc1",
@@ -230,23 +247,23 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         amount_cert = [{"address": addr_node1, "amount": bt_amount_2}]
         try:
-            cert = self.nodes[3].sc_send_certificate(scid, epoch_number, quality,
+            cert = self.nodes[DISHONEST_NODE_INDEX].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert, 0, 0, 0.01)
         except JSONRPCException as e:
             errorString = e.error['message']
-            print("Send certificate failed with reason {}".format(errorString))
+            print(f"Send certificate failed with reason {errorString}")
             assert(False)
-        sync_mempools(self.nodes[3:4])
+        sync_mempools([self.nodes[DISHONEST_NODE_INDEX]])
 
-        mark_logs("              Check cert {} is in mempool".format(cert), self.nodes, DEBUG_MODE)
-        assert_true(cert in self.nodes[3].getrawmempool())
-        print("Node3 Chain h = ", self.nodes[3].getblockcount())
+        mark_logs(f"              Check cert {cert} is in mempool", self.nodes, DEBUG_MODE)
+        assert_true(cert in self.nodes[DISHONEST_NODE_INDEX].getrawmempool())
+        print(f"Dishonest node {DISHONEST_NODE_INDEX} Chain h = {self.nodes[DISHONEST_NODE_INDEX].getblockcount()}")
 
 
-        mark_logs("Node3 generates 1 block", self.nodes, DEBUG_MODE)
-        self.nodes[3].generate(1)
-        sync_mempools(self.nodes[3:4])
-        print("Node3 Chain h = ", self.nodes[3].getblockcount())
+        mark_logs(f"Dishonest node {DISHONEST_NODE_INDEX} generates 1 block", self.nodes, DEBUG_MODE)
+        self.nodes[DISHONEST_NODE_INDEX].generate(1)
+        sync_mempools([self.nodes[DISHONEST_NODE_INDEX]])
+        print(f"Dishonest node {DISHONEST_NODE_INDEX} Chain h = {self.nodes[DISHONEST_NODE_INDEX].getblockcount()}")
 
         #============================================================================================
         mark_logs("\nJoining network", self.nodes, DEBUG_MODE)
@@ -254,39 +271,39 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         mark_logs("Network joined", self.nodes, DEBUG_MODE)
 
         # check SC is alive
-        ret = self.nodes[3].getscinfo(scid, False, False)['items'][0]
+        ret = self.nodes[DISHONEST_NODE_INDEX].getscinfo(scid, False, False)['items'][0]
         assert_equal(ret['state'], "ALIVE")
 
-        mark_logs("Check fwd tx {} is still in mempool...".format(tx_fwd), self.nodes, DEBUG_MODE)
-        assert_true(tx_fwd in self.nodes[0].getrawmempool()) 
+        mark_logs(f"Check fwd tx {tx_fwd} is still in mempool...", self.nodes, DEBUG_MODE)
+        assert_true(tx_fwd in self.nodes[MAIN_NODE].getrawmempool()) 
 
-        mark_logs("Check bwd tx {} is still in mempool, even though we crossed the epoch safeguard".format(tx_bwt), self.nodes, DEBUG_MODE)
-        assert_true(tx_bwt in self.nodes[0].getrawmempool()) 
+        mark_logs(f"Check bwd tx {tx_bwt} is still in mempool, even though we crossed the epoch safeguard", self.nodes, DEBUG_MODE)
+        assert_true(tx_bwt in self.nodes[MAIN_NODE].getrawmempool()) 
 
-        mark_logs("Check cert {} is no more in mempool, since we crossed the epoch safeguard".format(cert_bad), self.nodes, DEBUG_MODE)
-        assert_false(cert_bad in self.nodes[0].getrawmempool()) 
+        mark_logs(f"Check cert {cert_bad} is no more in mempool, since we crossed the epoch safeguard", self.nodes, DEBUG_MODE)
+        assert_false(cert_bad in self.nodes[MAIN_NODE].getrawmempool()) 
 
         mark_logs("And that no info are available too...", self.nodes, DEBUG_MODE)
         try:
-            self.nodes[0].getrawtransaction(cert_bad, 1)
+            self.nodes[MAIN_NODE].getrawtransaction(cert_bad, 1)
             assert (False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
 
         mark_logs("Check SC balance has been properly changed", self.nodes, DEBUG_MODE)
         try:
-            bal_final = self.nodes[0].getscinfo(scid)['items'][0]['balance']
+            bal_final = self.nodes[MAIN_NODE].getscinfo(scid)['items'][0]['balance']
             assert_equal(bal_initial - bt_amount_2, bal_final)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("===> {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"===> {errorString}", self.nodes, DEBUG_MODE)
 
         for i in range(NUMB_OF_NODES):
             pprint.pprint(self.nodes[i].getrawmempool())
 
         # if any_error this should fail
-        self.nodes[0].generate(1)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
 
 

--- a/qa/rpc-tests/sc_csw_memcleanup_split.py
+++ b/qa/rpc-tests/sc_csw_memcleanup_split.py
@@ -13,7 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
-    get_epoch_data, sync_mempools, \
+    get_epoch_data, sync_mempools, sync_blocks, \
     disconnect_nodes, advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights
@@ -21,7 +21,6 @@ from test_framework.mc_test.mc_test import CertTestUtils, CSWTestUtils, generate
 
 from decimal import Decimal
 import pprint
-import time
 
 NUMB_OF_NODES = 4
 DEBUG_MODE = 1
@@ -32,7 +31,7 @@ MBTR_SC_FEE = Decimal('0')
 DISHONEST_NODE_INDEX = NUMB_OF_NODES - 1    # Dishonest node
 HONEST_NODES = list(range(NUMB_OF_NODES))
 HONEST_NODES.remove(DISHONEST_NODE_INDEX)
-MAIN_NODE = HONEST_NODES[0]
+MAIN_NODE = HONEST_NODES[0]                 # Hardcoded alias, do not change
 
 # Create one-input, one-output, no-fee transaction:
 class CertMempoolCleanupSplit(BitcoinTestFramework):
@@ -42,6 +41,8 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
     def setup_network(self, split=False):
+        assert_equal(MAIN_NODE, HONEST_NODES[0])
+
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
                                  extra_args=[['-logtimemicros=1', '-scproofqueuesize=0', '-debug=sc', '-debug=py',
                                               '-debug=mempool', '-debug=net', '-debug=bench']] * NUMB_OF_NODES)
@@ -81,7 +82,6 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
             connect_nodes_bi(self.nodes, idx, idx - 1)
             connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = False
-        time.sleep(2)
 
     def run_test(self):
         '''
@@ -158,7 +158,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         self.nodes[MAIN_NODE].generate(numbBlocks)
         self.sync_all()
         print(f"Node {MAIN_NODE} Chain h = {self.nodes[MAIN_NODE].getblockcount()}")
-        
+
         #============================================================================================
         mark_logs("\nSplit network", self.nodes, DEBUG_MODE)
         self.split_network()
@@ -265,6 +265,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         #============================================================================================
         mark_logs("\nJoining network", self.nodes, DEBUG_MODE)
         self.join_network()
+        sync_blocks(self.nodes)
         mark_logs("Network joined", self.nodes, DEBUG_MODE)
 
         mark_logs("\nCheck that the sidechain is ceased", self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_csw_memcleanup_split.py
+++ b/qa/rpc-tests/sc_csw_memcleanup_split.py
@@ -40,7 +40,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         assert_equal(MAIN_NODE, HONEST_NODES[0])
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
@@ -49,7 +49,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx + 1)
-        self.is_network_split = split
+        self.is_network_split = False
         self.sync_all()
 
     def split_network(self):

--- a/qa/rpc-tests/sc_csw_nullifier.py
+++ b/qa/rpc-tests/sc_csw_nullifier.py
@@ -37,7 +37,7 @@ class CswNullifierTest(BitcoinTestFramework):
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         assert_equal(MAIN_NODE, NET_NODES[0])
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
@@ -522,7 +522,7 @@ class CswNullifierTest(BitcoinTestFramework):
         mark_logs("\nChecking persistance stopping and restarting nodes", self.nodes, DEBUG_MODE)
         stop_nodes(self.nodes)
         wait_bitcoinds()
-        self.setup_network(False)
+        self.setup_network()
 
         mark_logs("Checking nodes balance...", self.nodes, DEBUG_MODE)
         assert_equal(n0_bal, self.nodes[MAIN_NODE].z_gettotalbalance()['total'])

--- a/qa/rpc-tests/sc_csw_nullifier.py
+++ b/qa/rpc-tests/sc_csw_nullifier.py
@@ -11,19 +11,23 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
-    wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
+    wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
     disconnect_nodes, advance_epoch, swap_bytes
-from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
+from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import *
 
 from decimal import Decimal
 import pprint
-import time
 
 NUMB_OF_NODES = 3
 DEBUG_MODE = 1
 EPOCH_LENGTH = 6
 CERT_FEE = Decimal('0.0001')
+
+ISOLATED_NODE = NUMB_OF_NODES - 1       # index of node to be disconneted from the network
+NET_NODES = list(range(NUMB_OF_NODES))
+NET_NODES.remove(ISOLATED_NODE)
+MAIN_NODE = NET_NODES[0]
 
 
 # Create one-input, one-output, no-fee transaction:
@@ -38,29 +42,40 @@ class CswNullifierTest(BitcoinTestFramework):
                                  extra_args=[["-sccoinsmaturity=0", '-scproofqueuesize=0', '-logtimemicros=1', '-debug=sc', '-debug=py',
                                               '-debug=mempool', '-debug=net', '-debug=bench']] * NUMB_OF_NODES)
 
-        if not split:
-            # 1 and 2 are joint only if split==false
-            connect_nodes_bi(self.nodes, 1, 2)
-            sync_blocks(self.nodes[1:3])
-            sync_mempools(self.nodes[1:3])
-
-        connect_nodes_bi(self.nodes, 0, 1)
-        self.is_network_split = split
+        for idx in range(NUMB_OF_NODES - 1):
+            connect_nodes_bi(self.nodes, idx, idx+1)
+        self.is_network_split = False
         self.sync_all()
 
     def split_network(self):
-        # Split the network of three nodes into nodes 0-1 and 2.
-        assert not self.is_network_split
-        disconnect_nodes(self.nodes[1], 2)
-        disconnect_nodes(self.nodes[2], 1)
+        # Disconnect the "double spend" node from the network
+        idx = ISOLATED_NODE
+        if idx == NUMB_OF_NODES - 1:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+        elif idx == 0:
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+        else:
+            disconnect_nodes(self.nodes[idx], idx - 1)
+            disconnect_nodes(self.nodes[idx - 1], idx)
+            disconnect_nodes(self.nodes[idx], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx)
+            connect_nodes_bi(self.nodes, idx - 1, idx + 1)
         self.is_network_split = True
 
     def join_network(self):
-        # Join the (previously split) network pieces together: 0-1-2
-        assert self.is_network_split
-        connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 1)
-        time.sleep(2)
+        #Join the (previously split) network pieces together
+        idx = ISOLATED_NODE
+        if idx == NUMB_OF_NODES - 1:
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+        elif idx == 0:
+            connect_nodes_bi(self.nodes, idx, idx + 1)
+        else:
+            disconnect_nodes(self.nodes[idx - 1], idx + 1)
+            disconnect_nodes(self.nodes[idx + 1], idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx - 1)
+            connect_nodes_bi(self.nodes, idx, idx + 1)
         self.is_network_split = False
 
     def run_test(self):
@@ -74,9 +89,8 @@ class CswNullifierTest(BitcoinTestFramework):
         '''
 
         # prepare some coins 
-        self.nodes[0].generate(ForkHeights['MINIMAL_SC'])
+        self.nodes[MAIN_NODE].generate(ForkHeights['MINIMAL_SC'])
         self.sync_all()
-        prev_epoch_hash = self.nodes[0].getbestblockhash()
 
         sc_address = "0000000000000000000000000000000000000000000000000000000000000abc"
         sc_epoch_len = EPOCH_LENGTH
@@ -101,74 +115,73 @@ class CswNullifierTest(BitcoinTestFramework):
             "constant": constant
         })
 
-        rawtx = self.nodes[0].createrawtransaction([], {}, [], sc_cr)
-        funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-        sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'])
-        finalRawtx = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
+        rawtx = self.nodes[MAIN_NODE].createrawtransaction([], {}, [], sc_cr)
+        funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+        sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'])
+        finalRawtx = self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
         self.sync_all()
 
-        decoded_tx = self.nodes[2].getrawtransaction(finalRawtx, 1)
+        decoded_tx = self.nodes[ISOLATED_NODE].getrawtransaction(finalRawtx, 1)
         scid = decoded_tx['vsc_ccout'][0]['scid']
-        mark_logs("created SC id: {}".format(scid), self.nodes, DEBUG_MODE)
-        print
+        mark_logs(f"created SC id: {scid}", self.nodes, DEBUG_MODE)
 
         # advance two epochs
-        mark_logs("\nLet 2 epochs pass by...".  format(sc_epoch_len), self.nodes, DEBUG_MODE)
+        mark_logs("\nLet 2 epochs pass by...", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
              scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
              scid, "sc1", constant, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
 
         # mine one block for having last cert in chain
-        mark_logs("\nNode0 generates 1 block confirming last cert", self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(1)
+        mark_logs(f"\nNode {MAIN_NODE} generates 1 block confirming last cert", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
 
         # check we have cert data hash for the last active certificate
         mark_logs("\nCheck we have expected cert data hashes", self.nodes, DEBUG_MODE)
         try:
-            assert_true(self.nodes[0].getactivecertdatahash(scid)['certDataHash'])
+            assert_true(self.nodes[MAIN_NODE].getactivecertdatahash(scid)['certDataHash'])
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("{}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"{errorString}", self.nodes, DEBUG_MODE)
             assert (False)
 
-        mark_logs("Let SC cease... ".format(scid), self.nodes, DEBUG_MODE)
+        mark_logs("Let SC cease... ", self.nodes, DEBUG_MODE)
 
         nbl = int(sc_epoch_len * 1.5)
-        mark_logs("Node0 generates {} blocks".format(nbl), self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(nbl)
+        mark_logs(f"Node {MAIN_NODE} generates {nbl} blocks", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(nbl)
         self.sync_all()
 
         # check it is really ceased
-        ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
+        ret = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]
         assert_equal(ret['state'], "CEASED")
 
         # and has the expected balance
-        sc_bal = self.nodes[0].getscinfo(scid, False, False)['items'][0]['balance']
+        sc_bal = self.nodes[MAIN_NODE].getscinfo(scid, False, False)['items'][0]['balance']
         assert_equal(sc_bal, sc_cr_amount)
 
         mark_logs("\nCreate a CSW withdrawing half the sc balance... ", self.nodes, DEBUG_MODE)
 
         # CSW sender MC address
-        csw_mc_address = self.nodes[0].getnewaddress()
+        csw_mc_address = self.nodes[MAIN_NODE].getnewaddress()
 
         sc_csw_amount = sc_bal/2
         null1 = generate_random_field_element_hex()
-        actCertData = self.nodes[0].getactivecertdatahash(scid)['certDataHash']
-        print("Active Cert Data Hash: -------> ", actCertData)
+        actCertData = self.nodes[MAIN_NODE].getactivecertdatahash(scid)['certDataHash']
+        print(f"Active Cert Data Hash: -------> {actCertData}")
 
-        ceasingCumScTxCommTree = self.nodes[0].getceasingcumsccommtreehash(scid)['ceasingCumScTxCommTree']
+        ceasingCumScTxCommTree = self.nodes[MAIN_NODE].getceasingcumsccommtreehash(scid)['ceasingCumScTxCommTree']
 
         scid_swapped = str(swap_bytes(scid))
         sc_proof1 = cswMcTest.create_test_proof("sc1",
@@ -192,77 +205,75 @@ class CswNullifierTest(BitcoinTestFramework):
         }]
 
         # recipient MC address
-        taddr_2 = self.nodes[2].getnewaddress()
+        taddr_2 = self.nodes[ISOLATED_NODE].getnewaddress()
         sc_csw_tx_outs = {taddr_2: sc_csw_amount}
 
-        rawtx = self.nodes[0].createrawtransaction([], sc_csw_tx_outs, sc_csws)
-        funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-        sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'], None, None, "NONE")
-        finalRawtx = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
-        mark_logs("sent csw 1 {} retrieving {} coins on Node2 behalf".format(finalRawtx, sc_csws[0]['amount']), self.nodes, DEBUG_MODE)
+        rawtx = self.nodes[MAIN_NODE].createrawtransaction([], sc_csw_tx_outs, sc_csws)
+        funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+        sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'], None, None, "NONE")
+        finalRawtx = self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
+        mark_logs(f"sent csw 1 {finalRawtx} retrieving {sc_csws[0]['amount']} coins on Node {ISOLATED_NODE} behalf", self.nodes, DEBUG_MODE)
         self.sync_all()
 
-        decoded_tx = self.nodes[1].getrawtransaction(finalRawtx, 1)
+        decoded_tx = self.nodes[NET_NODES[1]].getrawtransaction(finalRawtx, 1)
         # vin  - size(1): utxo for paying the fee
         # vout - size(2): recipient of the funds + sender change
         # vcsw_ccin - size(1): CSW funds
         assert_equal(1, len(decoded_tx['vin']))
         assert_equal(2, len(decoded_tx['vout']))
         assert_equal(1, len(decoded_tx['vcsw_ccin']))
-        csw_in = decoded_tx['vcsw_ccin'][0]
 
         mark_logs("Check csw is in mempool...", self.nodes, DEBUG_MODE)
-        assert_true(finalRawtx in self.nodes[2].getrawmempool())
+        assert_true(finalRawtx in self.nodes[ISOLATED_NODE].getrawmempool())
 
-        mark_logs("\nNode0 generates 1 block confirming CSW", self.nodes, DEBUG_MODE)
-        bl = self.nodes[0].generate(1)[-1]
+        mark_logs(f"\nNode {MAIN_NODE} generates 1 block confirming CSW", self.nodes, DEBUG_MODE)
+        bl = self.nodes[MAIN_NODE].generate(1)[-1]
         self.sync_all()
 
-        
         mark_logs("Check csw is in block just mined...", self.nodes, DEBUG_MODE)
-        assert_true(finalRawtx in self.nodes[0].getblock(bl, True)['tx'])
+        assert_true(finalRawtx in self.nodes[MAIN_NODE].getblock(bl, True)['tx'])
 
         mark_logs("Check nullifier is in MC...", self.nodes, DEBUG_MODE)
-        res = self.nodes[0].checkcswnullifier(scid, null1)
+        res = self.nodes[MAIN_NODE].checkcswnullifier(scid, null1)
         assert_equal(res['data'], 'true')
 
-        n2_bal = self.nodes[2].getbalance()
-        mark_logs("Check Node2 has the expected balance...", self.nodes, DEBUG_MODE)
+        n2_bal = self.nodes[ISOLATED_NODE].getbalance()
+        mark_logs(f"Check Node {ISOLATED_NODE} has the expected balance...", self.nodes, DEBUG_MODE)
         assert_equal(n2_bal, sc_csw_amount)
 
         amount_2_1 = Decimal(n2_bal)/Decimal('4.0')
-        mark_logs("\nNode2 sends {} coins to Node1 using csw funds...".format(amount_2_1), self.nodes, DEBUG_MODE)
-        tx = self.nodes[2].sendtoaddress(self.nodes[1].getnewaddress(), amount_2_1);
-        mark_logs("tx = {}".format(tx), self.nodes, DEBUG_MODE)
+        mark_logs(f"\nNode {ISOLATED_NODE} sends {amount_2_1} coins to Node {NET_NODES[1]} using csw funds...", self.nodes, DEBUG_MODE)
+        tx = self.nodes[ISOLATED_NODE].sendtoaddress(self.nodes[NET_NODES[1]].getnewaddress(), amount_2_1)
+        mark_logs(f"tx = {tx}", self.nodes, DEBUG_MODE)
         self.sync_all()
 
-        mark_logs("Node0 generates 1 block", self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(1)
+        mark_logs(f"\nNode {MAIN_NODE} generates 1 block", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
 
         
-        mark_logs("\nNode2 invalidate its chain from csw block on...", self.nodes, DEBUG_MODE)
-        self.nodes[2].invalidateblock(bl)
-        sync_mempools(self.nodes[0:2])
+        mark_logs(f"\nNode {ISOLATED_NODE} invalidate its chain from csw block on...", self.nodes, DEBUG_MODE)
+        self.nodes[ISOLATED_NODE].invalidateblock(bl)
+        sync_mempools([self.nodes[i] for i in NET_NODES])
 
-        mark_logs("Check csw has been put back in Node2 mempool...", self.nodes, DEBUG_MODE)
-        assert_true(tx, finalRawtx in self.nodes[2].getrawmempool())
+        mark_logs(f"Check csw has been put back in Node {ISOLATED_NODE} mempool...", self.nodes, DEBUG_MODE)
+        assert_true(tx, finalRawtx in self.nodes[ISOLATED_NODE].getrawmempool())
 
-        mark_logs("Check Node2 has null confirmed balance...", self.nodes, DEBUG_MODE)
-        n2_bal = self.nodes[2].z_gettotalbalance()['total']
+        mark_logs(f"Check Node {ISOLATED_NODE} has null confirmed balance...", self.nodes, DEBUG_MODE)
+        n2_bal = self.nodes[ISOLATED_NODE].z_gettotalbalance()['total']
         assert_equal(Decimal(n2_bal), Decimal('0.0'))
 
-        mark_logs("Check nullifier is no more in MC from Node2 perspective...", self.nodes, DEBUG_MODE)
-        res = self.nodes[2].checkcswnullifier(scid, null1)
+        mark_logs(f"Check nullifier is no more in MC from Node {ISOLATED_NODE} perspective...", self.nodes, DEBUG_MODE)
+        res = self.nodes[ISOLATED_NODE].checkcswnullifier(scid, null1)
         assert_equal(res['data'], 'false')
 
-        mark_logs("\nNode2 reconsider last invalidated blocks", self.nodes, DEBUG_MODE)
-        self.nodes[2].reconsiderblock(bl)
+        mark_logs(f"\nNode {ISOLATED_NODE} reconsider last invalidated blocks", self.nodes, DEBUG_MODE)
+        self.nodes[ISOLATED_NODE].reconsiderblock(bl)
         self.sync_all()
 
         
-        mark_logs("Check nullifier is back in MC from Node2 perspective...", self.nodes, DEBUG_MODE)
-        res = self.nodes[2].checkcswnullifier(scid, null1)
+        mark_logs(f"Check nullifier is back in MC from Node {ISOLATED_NODE} perspective...", self.nodes, DEBUG_MODE)
+        res = self.nodes[ISOLATED_NODE].checkcswnullifier(scid, null1)
         assert_equal(res['data'], 'true')
 
         # Try to create CSW with the nullifier which already exists in the chain
@@ -270,15 +281,15 @@ class CswNullifierTest(BitcoinTestFramework):
         sc_csw_amount = sc_bal/4
         sc_csws[0]['amount'] = sc_csw_amount
         sc_csw_tx_outs = {taddr_2: sc_csw_amount}
-        rawtx = self.nodes[0].createrawtransaction([], sc_csw_tx_outs, sc_csws)
-        funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-        sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'])
+        rawtx = self.nodes[MAIN_NODE].createrawtransaction([], sc_csw_tx_outs, sc_csws)
+        funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+        sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'])
         try:
-            self.nodes[0].sendrawtransaction(sigRawtx['hex'])
+            self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
             assert(False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("Send csw failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"Send csw failed with reason {errorString}", self.nodes, DEBUG_MODE)
 
 
         mark_logs("\nCreate a CSW withdrawing un third of the original sc balance... ", self.nodes, DEBUG_MODE)
@@ -308,30 +319,30 @@ class CswNullifierTest(BitcoinTestFramework):
         }]
 
         try:
-            rawtx = self.nodes[0].createrawtransaction([], sc_csw_tx_outs, sc_csws)
-            funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-            sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'])
-            finalRawTx = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
-            mark_logs("sent csw 2 {} retrieving {} coins on Node2 behalf".format(finalRawtx, sc_csw_amount), self.nodes, DEBUG_MODE)
+            rawtx = self.nodes[MAIN_NODE].createrawtransaction([], sc_csw_tx_outs, sc_csws)
+            funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+            sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'])
+            finalRawTx = self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
+            mark_logs(f"sent csw 2 {finalRawtx} retrieving {sc_csw_amount} coins on Node {ISOLATED_NODE} behalf", self.nodes, DEBUG_MODE)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("Send csw failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"Send csw failed with reason {errorString}", self.nodes, DEBUG_MODE)
             assert(False)
 
-        mark_logs("\nNode0 generates 1 block confirming CSW", self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(1)
+        mark_logs(f"\nNode {MAIN_NODE} generates 1 block confirming CSW", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(1)
         self.sync_all()
 
-        n1_bal = self.nodes[1].z_gettotalbalance()['total']
-        n2_bal = self.nodes[2].z_gettotalbalance()['total']
-        mark_logs("Node1 has {} confirmed balance".format(n1_bal), self.nodes, DEBUG_MODE)
-        mark_logs("Node2 has {} confirmed balance".format(n2_bal), self.nodes, DEBUG_MODE)
+        n1_bal = self.nodes[NET_NODES[1]].z_gettotalbalance()['total']
+        n2_bal = self.nodes[ISOLATED_NODE].z_gettotalbalance()['total']
+        mark_logs(f"Node {NET_NODES[1]} has {n1_bal} confirmed balance", self.nodes, DEBUG_MODE)
+        mark_logs(f"Node {ISOLATED_NODE} has {n2_bal} confirmed balance", self.nodes, DEBUG_MODE)
         
 
         #============================================================================================
         mark_logs("\nSplit network", self.nodes, DEBUG_MODE)
         self.split_network()
-        mark_logs("The network is split: 0-1 .. 2", self.nodes, DEBUG_MODE)
+        mark_logs(f"The network is split: {NET_NODES[0]}-{NET_NODES[1]} .. {ISOLATED_NODE}", self.nodes, DEBUG_MODE)
 
         # Network part 0-1
         #------------------
@@ -339,7 +350,7 @@ class CswNullifierTest(BitcoinTestFramework):
         mark_logs("\nCreate a CSW withdrawing one sixth of the original sc balance... ", self.nodes, DEBUG_MODE)
         sc_csw_amount = sc_bal/6
         null_n0 = generate_random_field_element_hex()
-        taddr_1 = self.nodes[1].getnewaddress()
+        taddr_1 = self.nodes[NET_NODES[1]].getnewaddress()
         sc_csw_tx_outs_1 = {taddr_1: sc_csw_amount}
 
         sc_proof_n0 = cswMcTest.create_test_proof("sc1",
@@ -363,44 +374,44 @@ class CswNullifierTest(BitcoinTestFramework):
         }]
 
         try:
-            rawtx = self.nodes[0].createrawtransaction([], sc_csw_tx_outs_1, sc_csws)
-            funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-            sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'])
-            tx_n1 = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
+            rawtx = self.nodes[MAIN_NODE].createrawtransaction([], sc_csw_tx_outs_1, sc_csws)
+            funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+            sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'])
+            tx_n1 = self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("Send csw failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"Send csw failed with reason {errorString}", self.nodes, DEBUG_MODE)
             assert(False)
 
-        sync_mempools(self.nodes[0:2])
-        mark_logs("Node0 sent csw {} retrieving {} coins on Node1 behalf".format(tx_n1, sc_csws[0]['amount']), self.nodes, DEBUG_MODE)
+        sync_mempools([self.nodes[i] for i in NET_NODES])
+        mark_logs(f"Node {MAIN_NODE} sent csw {tx_n1} retrieving {sc_csws[0]['amount']} coins on Node {NET_NODES[1]} behalf", self.nodes, DEBUG_MODE)
 
-        self.nodes[0].generate(1)
-        sync_blocks(self.nodes[0:2])
-        sync_mempools(self.nodes[0:2])
+        self.nodes[MAIN_NODE].generate(1)
+        sync_blocks([self.nodes[i] for i in NET_NODES])
+        sync_mempools([self.nodes[i] for i in NET_NODES])
 
-        n1_bal = self.nodes[1].z_gettotalbalance()['total']
-        mark_logs("Node1 has {} confirmed balance".format(n1_bal), self.nodes, DEBUG_MODE)
+        n1_bal = self.nodes[NET_NODES[1]].z_gettotalbalance()['total']
+        mark_logs(f"Node {NET_NODES[1]} has {n1_bal} confirmed balance", self.nodes, DEBUG_MODE)
         assert_equal(Decimal(n1_bal), Decimal(amount_2_1 + sc_bal/6)) 
 
         # Node1 sends all of its balance to Node0
         amount = Decimal(n1_bal) - Decimal("0.0001")
-        tx_1_0 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), amount);
-        mark_logs("tx = {}".format(tx_1_0), self.nodes, DEBUG_MODE)
-        mark_logs("Node1 sent {} coins to Node0 using csw funds...".format(amount), self.nodes, DEBUG_MODE)
-        sync_mempools(self.nodes[0:2])
+        tx_1_0 = self.nodes[NET_NODES[1]].sendtoaddress(self.nodes[MAIN_NODE].getnewaddress(), amount)
+        mark_logs(f"tx = {tx_1_0}", self.nodes, DEBUG_MODE)
+        mark_logs(f"Node {NET_NODES[1]} sent {amount} coins to Node {MAIN_NODE} using csw funds...", self.nodes, DEBUG_MODE)
+        sync_mempools([self.nodes[i] for i in NET_NODES])
 
         mark_logs("Check tx is in mempool", self.nodes, DEBUG_MODE)
-        assert_true(tx_1_0 in self.nodes[0].getrawmempool()) 
-        assert_true(tx_1_0 in self.nodes[1].getrawmempool()) 
+        assert_true(tx_1_0 in self.nodes[MAIN_NODE].getrawmempool()) 
+        assert_true(tx_1_0 in self.nodes[NET_NODES[1]].getrawmempool()) 
 
-        mark_logs("Check tx is in Node0 wallet", self.nodes, DEBUG_MODE)
-        utxos = self.nodes[0].listunspent(0, 0)
+        mark_logs(f"Check tx is in Node {MAIN_NODE} wallet", self.nodes, DEBUG_MODE)
+        utxos = self.nodes[MAIN_NODE].listunspent(0, 0)
         assert_equal(tx_1_0, utxos[0]['txid']) 
 
         # check we have emptied the SC balance
-        sc_bal_n0 = self.nodes[0].getscinfo(scid)['items'][0]['balance']
-        mark_logs("sc balance from Node0 view is: {}".format(sc_bal_n0), self.nodes, DEBUG_MODE)
+        sc_bal_n0 = self.nodes[MAIN_NODE].getscinfo(scid)['items'][0]['balance']
+        mark_logs(f"sc balance from Node {MAIN_NODE} view is: {sc_bal_n0}", self.nodes, DEBUG_MODE)
         assert_equal(Decimal(sc_bal_n0), Decimal('0.0'))
 
         print
@@ -410,7 +421,7 @@ class CswNullifierTest(BitcoinTestFramework):
         sc_csw_amount = sc_bal/12
         sc_csw_tx_outs = {taddr_2: sc_csw_amount}
         null_n2 = generate_random_field_element_hex()
-        csw_mc_address = self.nodes[2].getnewaddress()
+        csw_mc_address = self.nodes[ISOLATED_NODE].getnewaddress()
 
         sc_proof_n2 = cswMcTest.create_test_proof("sc1",
                                                   sc_csw_amount,
@@ -433,28 +444,29 @@ class CswNullifierTest(BitcoinTestFramework):
         }]
 
         try:
-            rawtx = self.nodes[2].createrawtransaction([], sc_csw_tx_outs, sc_csws)
-            funded_tx = self.nodes[2].fundrawtransaction(rawtx)
-            sigRawtx = self.nodes[2].signrawtransaction(funded_tx['hex'])
-            tx_n2 = self.nodes[2].sendrawtransaction(sigRawtx['hex'])
+            rawtx = self.nodes[ISOLATED_NODE].createrawtransaction([], sc_csw_tx_outs, sc_csws)
+            funded_tx = self.nodes[ISOLATED_NODE].fundrawtransaction(rawtx)
+            sigRawtx = self.nodes[ISOLATED_NODE].signrawtransaction(funded_tx['hex'])
+            tx_n2 = self.nodes[ISOLATED_NODE].sendrawtransaction(sigRawtx['hex'])
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("Send csw failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"Send csw failed with reason {errorString}", self.nodes, DEBUG_MODE)
             assert(False)
 
-        self.sync_all()
+        sync_mempools([self.nodes[ISOLATED_NODE]])
 
-        mark_logs("Node2 sent csw {} retrieving {} coins for himself".format(tx_n2, sc_csws[0]['amount']), self.nodes, DEBUG_MODE)
+        mark_logs(f"Node {ISOLATED_NODE} sent csw {tx_n2} retrieving {sc_csws[0]['amount']} coins for himself", self.nodes, DEBUG_MODE)
 
-        self.nodes[2].generate(1)
-        self.sync_all()
-        
-        n2_bal = self.nodes[2].z_gettotalbalance()['total']
-        mark_logs("Node2 has {} confirmed balance".format(n2_bal), self.nodes, DEBUG_MODE)
+        self.nodes[ISOLATED_NODE].generate(1)
+        sync_mempools([self.nodes[ISOLATED_NODE]])
+        sync_blocks([self.nodes[ISOLATED_NODE]])
+
+        n2_bal = self.nodes[ISOLATED_NODE].z_gettotalbalance()['total']
+        mark_logs(f"Node {ISOLATED_NODE} has {n2_bal} confirmed balance", self.nodes, DEBUG_MODE)
 
         # check we have still 1.0 coin in the the SC balance (12-6-4-1=1)
-        sc_bal_n2 = self.nodes[2].getscinfo(scid)['items'][0]['balance']
-        mark_logs("sc balance from Node2 view is: {}".format(sc_bal_n2), self.nodes, DEBUG_MODE)
+        sc_bal_n2 = self.nodes[ISOLATED_NODE].getscinfo(scid)['items'][0]['balance']
+        mark_logs(f"sc balance from Node {ISOLATED_NODE} view is: {sc_bal_n2}", self.nodes, DEBUG_MODE)
         assert_equal(Decimal(sc_bal_n2), Decimal('1.0'))
         
 
@@ -463,30 +475,30 @@ class CswNullifierTest(BitcoinTestFramework):
         self.join_network()
         mark_logs("Network joined", self.nodes, DEBUG_MODE)
 
-        self.nodes[2].generate(5)
+        self.nodes[ISOLATED_NODE].generate(5)
         self.sync_all()
 
         # Node2 should have prevailed therefore nullifier n0 should have disappeared
-        mark_logs("Check nullifier used by Node0 is not in MC...", self.nodes, DEBUG_MODE)
-        res = self.nodes[2].checkcswnullifier(scid, null_n0)
+        mark_logs(f"Check nullifier used by Node {MAIN_NODE} is not in MC...", self.nodes, DEBUG_MODE)
+        res = self.nodes[ISOLATED_NODE].checkcswnullifier(scid, null_n0)
         assert_equal(res['data'], 'false')
 
-        mark_logs("Check nullifier used by Node2 is in MC also from Node0 perspective...", self.nodes, DEBUG_MODE)
-        res = self.nodes[0].checkcswnullifier(scid, null_n2)
+        mark_logs(f"Check nullifier used by Node {ISOLATED_NODE} is in MC also from Node {MAIN_NODE} perspective...", self.nodes, DEBUG_MODE)
+        res = self.nodes[MAIN_NODE].checkcswnullifier(scid, null_n2)
         assert_equal(res['data'], 'true')
 
-        mark_logs("Check tx {} is no more in mempool".format(tx_1_0), self.nodes, DEBUG_MODE)
-        assert_false(tx_1_0 in self.nodes[0].getrawmempool()) 
-        assert_false(tx_1_0 in self.nodes[1].getrawmempool()) 
+        mark_logs(f"Check tx {tx_1_0} is no more in mempool", self.nodes, DEBUG_MODE)
+        assert_false(tx_1_0 in self.nodes[MAIN_NODE].getrawmempool()) 
+        assert_false(tx_1_0 in self.nodes[NET_NODES[1]].getrawmempool()) 
 
-        mark_logs("Check it is in no more in Node0 wallet too", self.nodes, DEBUG_MODE)
-        utxos = self.nodes[0].listunspent(0)
+        mark_logs(f"Check it is in no more in Node {MAIN_NODE} wallet too", self.nodes, DEBUG_MODE)
+        utxos = self.nodes[MAIN_NODE].listunspent(0)
         for x in utxos:
             if x['txid'] == tx_1_0:
                 assert_true(False)
 
-        n1_bal = self.nodes[1].z_gettotalbalance()['total']
-        mark_logs("Node1 has {} confirmed balance".format(n1_bal), self.nodes, DEBUG_MODE)
+        n1_bal = self.nodes[NET_NODES[1]].z_gettotalbalance()['total']
+        mark_logs(f"Node {NET_NODES[1]} has {n1_bal} confirmed balance", self.nodes, DEBUG_MODE)
         assert_equal(Decimal(n1_bal), Decimal(amount_2_1)) 
 
         mark_logs("Checking mempools...", self.nodes, DEBUG_MODE)
@@ -494,16 +506,16 @@ class CswNullifierTest(BitcoinTestFramework):
             assert_equal(0, len(self.nodes[i].getrawmempool()))
 
         mark_logs("Checking sc balance...", self.nodes, DEBUG_MODE)
-        sc_bal_n0 = self.nodes[0].getscinfo(scid)['items'][0]['balance']
-        sc_bal_n1 = self.nodes[1].getscinfo(scid)['items'][0]['balance']
-        sc_bal_n2 = self.nodes[2].getscinfo(scid)['items'][0]['balance']
+        sc_bal_n0 = self.nodes[MAIN_NODE].getscinfo(scid)['items'][0]['balance']
+        sc_bal_n1 = self.nodes[NET_NODES[1]].getscinfo(scid)['items'][0]['balance']
+        sc_bal_n2 = self.nodes[ISOLATED_NODE].getscinfo(scid)['items'][0]['balance']
         assert_equal(Decimal('1.0'), sc_bal_n0)
         assert_equal(sc_bal_n1, sc_bal_n0)
         assert_equal(sc_bal_n2, sc_bal_n0)
 
-        n0_bal = self.nodes[0].z_gettotalbalance()['total']
-        n1_bal = self.nodes[1].z_gettotalbalance()['total']
-        n2_bal = self.nodes[2].z_gettotalbalance()['total']
+        n0_bal = self.nodes[MAIN_NODE].z_gettotalbalance()['total']
+        n1_bal = self.nodes[NET_NODES[1]].z_gettotalbalance()['total']
+        n2_bal = self.nodes[ISOLATED_NODE].z_gettotalbalance()['total']
 
         mark_logs("\nChecking persistance stopping and restarting nodes", self.nodes, DEBUG_MODE)
         stop_nodes(self.nodes)
@@ -511,24 +523,24 @@ class CswNullifierTest(BitcoinTestFramework):
         self.setup_network(False)
 
         mark_logs("Checking nodes balance...", self.nodes, DEBUG_MODE)
-        assert_equal(n0_bal, self.nodes[0].z_gettotalbalance()['total'])
-        assert_equal(n1_bal, self.nodes[1].z_gettotalbalance()['total'])
-        assert_equal(n2_bal, self.nodes[2].z_gettotalbalance()['total'])
+        assert_equal(n0_bal, self.nodes[MAIN_NODE].z_gettotalbalance()['total'])
+        assert_equal(n1_bal, self.nodes[NET_NODES[1]].z_gettotalbalance()['total'])
+        assert_equal(n2_bal, self.nodes[ISOLATED_NODE].z_gettotalbalance()['total'])
 
         mark_logs("Checking sc balance...", self.nodes, DEBUG_MODE)
-        assert_equal(sc_bal_n0, self.nodes[0].getscinfo(scid)['items'][0]['balance'])
-        assert_equal(sc_bal_n1, self.nodes[1].getscinfo(scid)['items'][0]['balance'])
-        assert_equal(sc_bal_n2, self.nodes[2].getscinfo(scid)['items'][0]['balance'])
+        assert_equal(sc_bal_n0, self.nodes[MAIN_NODE].getscinfo(scid)['items'][0]['balance'])
+        assert_equal(sc_bal_n1, self.nodes[NET_NODES[1]].getscinfo(scid)['items'][0]['balance'])
+        assert_equal(sc_bal_n2, self.nodes[ISOLATED_NODE].getscinfo(scid)['items'][0]['balance'])
 
         mark_logs("Checking nullifiers...", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].checkcswnullifier(scid, null1)['data'], 'true')
-        assert_equal(self.nodes[0].checkcswnullifier(scid, null2)['data'], 'true')
-        assert_equal(self.nodes[0].checkcswnullifier(scid, null_n0)['data'], 'false')
-        assert_equal(self.nodes[0].checkcswnullifier(scid, null_n2)['data'], 'true')
+        assert_equal(self.nodes[MAIN_NODE].checkcswnullifier(scid, null1)['data'], 'true')
+        assert_equal(self.nodes[MAIN_NODE].checkcswnullifier(scid, null2)['data'], 'true')
+        assert_equal(self.nodes[MAIN_NODE].checkcswnullifier(scid, null_n0)['data'], 'false')
+        assert_equal(self.nodes[MAIN_NODE].checkcswnullifier(scid, null_n2)['data'], 'true')
 
         mark_logs("\nVerify we need a valid active cert data hash  for a CSW to be legal...", self.nodes, DEBUG_MODE)
         
-        prev_epoch_hash = self.nodes[0].getbestblockhash()
+        prev_epoch_hash = self.nodes[MAIN_NODE].getbestblockhash()
         vk2 = certMcTest.generate_params("sc2")
         cswVk2 = cswMcTest.generate_params("sc2")
         constant2 = generate_random_field_element_hex()
@@ -543,51 +555,51 @@ class CswNullifierTest(BitcoinTestFramework):
             'wCeasedVk': cswVk2,
         }
 
-        ret = self.nodes[0].sc_create(cmdInput)
+        ret = self.nodes[MAIN_NODE].sc_create(cmdInput)
         creating_tx = ret['txid']
-        mark_logs("Node 0 created SC spending {} coins via tx1 {}.".format(sc_cr_amount, creating_tx), self.nodes, DEBUG_MODE)
+        mark_logs(f"Node {MAIN_NODE} created SC spending {sc_cr_amount} coins via tx1 {creating_tx}", self.nodes, DEBUG_MODE)
         self.sync_all()
-        scid2 = self.nodes[0].getrawtransaction(creating_tx, 1)['vsc_ccout'][0]['scid']
-        mark_logs("==> created SC ids {}".format(scid2), self.nodes, DEBUG_MODE)
+        scid2 = self.nodes[MAIN_NODE].getrawtransaction(creating_tx, 1)['vsc_ccout'][0]['scid']
+        mark_logs(f"==> created SC ids {scid2}", self.nodes, DEBUG_MODE)
             
         # advance two epochs and cease it
-        mark_logs("\nLet 2 epochs pass by...".  format(sc_epoch_len), self.nodes, DEBUG_MODE)
+        mark_logs("\nLet 2 epochs pass by...", self.nodes, DEBUG_MODE)
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
             scid2, "sc2", constant2, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
         
 
         cert, epoch_number = advance_epoch(
-            certMcTest, self.nodes[0], self.sync_all,
+            certMcTest, self.nodes[MAIN_NODE], self.sync_all,
             scid2, "sc2", constant2, sc_epoch_len)
 
-        mark_logs("\n==> certificate for epoch {} {}".format(epoch_number, cert), self.nodes, DEBUG_MODE)
+        mark_logs(f"\n==> certificate for epoch {epoch_number} {cert}", self.nodes, DEBUG_MODE)
 
-        mark_logs("Let SC cease... ".format(scid2), self.nodes, DEBUG_MODE)
+        mark_logs("Let SC cease... ", self.nodes, DEBUG_MODE)
 
         nbl = int(sc_epoch_len * 1.5)
-        mark_logs("Node0 generates {} blocks".format(nbl), self.nodes, DEBUG_MODE)
-        self.nodes[0].generate(nbl)
+        mark_logs(f"Node {MAIN_NODE} generates {nbl} blocks", self.nodes, DEBUG_MODE)
+        self.nodes[MAIN_NODE].generate(nbl)
         self.sync_all()
 
         # check it is really ceased
-        ret = self.nodes[0].getscinfo(scid2, False, False)['items'][0]
+        ret = self.nodes[MAIN_NODE].getscinfo(scid2, False, False)['items'][0]
         assert_equal(ret['state'], "CEASED")
 
         # and has the expected balance
-        sc_bal = self.nodes[0].getscinfo(scid2, False, False)['items'][0]['balance']
+        sc_bal = self.nodes[MAIN_NODE].getscinfo(scid2, False, False)['items'][0]['balance']
         assert_equal(sc_bal, sc_cr_amount)
 
         # Try to create a CSW with a wrong act cert data hash
         mark_logs("\nTrying to send a csw with a wrong active cert data hash (expecting failure...)", self.nodes, DEBUG_MODE)
-        csw_mc_address = self.nodes[0].getnewaddress()
+        csw_mc_address = self.nodes[MAIN_NODE].getnewaddress()
         sc_csw_amount = sc_bal
         null3 = generate_random_field_element_hex()
         actCertData3 = generate_random_field_element_hex()
-        ceasingCumScTxCommTree2 = self.nodes[0].getceasingcumsccommtreehash(scid2)['ceasingCumScTxCommTree']
+        ceasingCumScTxCommTree2 = self.nodes[MAIN_NODE].getceasingcumsccommtreehash(scid2)['ceasingCumScTxCommTree']
 
         scid2_swapped = str(swap_bytes(scid2))
         sc_proof2 = cswMcTest.create_test_proof("sc2",
@@ -612,35 +624,35 @@ class CswNullifierTest(BitcoinTestFramework):
 
         out_amount = sc_csw_amount / Decimal("2.0")
         sc_csw_tx_outs = {taddr_2: out_amount}
-        rawtx = self.nodes[0].createrawtransaction([], sc_csw_tx_outs, sc_csws)
-        funded_tx = self.nodes[0].fundrawtransaction(rawtx)
-        sigRawtx = self.nodes[0].signrawtransaction(funded_tx['hex'])
+        rawtx = self.nodes[MAIN_NODE].createrawtransaction([], sc_csw_tx_outs, sc_csws)
+        funded_tx = self.nodes[MAIN_NODE].fundrawtransaction(rawtx)
+        sigRawtx = self.nodes[MAIN_NODE].signrawtransaction(funded_tx['hex'])
         try:
-            tx = self.nodes[0].sendrawtransaction(sigRawtx['hex'])
-            pprint.pprint(self.nodes[0].getrawtransaction(tx, 1))
+            tx = self.nodes[MAIN_NODE].sendrawtransaction(sigRawtx['hex'])
+            pprint.pprint(self.nodes[MAIN_NODE].getrawtransaction(tx, 1))
             assert(False)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("Send csw failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"Send csw failed with reason {errorString}", self.nodes, DEBUG_MODE)
 
         # check we have all cert data hash for both sc ids
         mark_logs("Check we have an active cert data hashe for sidechain 1", self.nodes, DEBUG_MODE)
         try:
-            assert_true(self.nodes[1].getactivecertdatahash(scid)['certDataHash'])
+            assert_true(self.nodes[NET_NODES[1]].getactivecertdatahash(scid)['certDataHash'])
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("{}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"{errorString}", self.nodes, DEBUG_MODE)
             assert (False)
 
-        ret = self.nodes[0].getscinfo(scid2, False, True)['items'][0]
+        ret = self.nodes[MAIN_NODE].getscinfo(scid2, False, True)['items'][0]
         assert_equal(ret['state'], "CEASED")
         assert_equal(ret['lastCertificateEpoch'], 1)
 
         try:
-            assert_true(self.nodes[1].getactivecertdatahash(scid2)['certDataHash'])
+            assert_true(self.nodes[NET_NODES[1]].getactivecertdatahash(scid2)['certDataHash'])
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs("{}".format(errorString), self.nodes, DEBUG_MODE)
+            mark_logs(f"{errorString}", self.nodes, DEBUG_MODE)
             assert (False)
 
 

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
@@ -22,7 +22,7 @@ CERT_FEE      = Decimal('0.015')
 
 NUM_TXS       = 10
 
-class provaFee(BitcoinTestFramework):
+class SidechainFeeUpdate(BitcoinTestFramework):
 
     def setup_chain(self, split=False):
         print("Initializing test directory " + self.options.tmpdir)
@@ -611,4 +611,4 @@ class provaFee(BitcoinTestFramework):
         self.run_test_non_ceasable(2, False, False)
 
 if __name__ == '__main__':
-    provaFee().main()
+    SidechainFeeUpdate().main()

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
@@ -7,11 +7,10 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_greater_than, initialize_chain_clean, \
     start_nodes, stop_nodes, wait_bitcoinds, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
-    get_epoch_data, swap_bytes, disconnect_nodes ##, colorize as cc
+    get_epoch_data, swap_bytes, disconnect_nodes, colorize as cc
 from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import CertTestUtils, generate_random_field_element_hex
 from decimal import Decimal
-import math
 
 DEBUG_MODE    = 1
 NUMB_OF_NODES = 4
@@ -22,13 +21,6 @@ MBTR_SC_FEE   = Decimal('0.03')
 CERT_FEE      = Decimal('0.015')
 
 NUM_TXS       = 10
-
-#### temporary logs functions
-def cc(c, inp):
-    return inp
-def mark_logs_temp(msg, nodes, debug = 0, color = 'n'):
-    return mark_logs(msg, nodes, debug)
-####
 
 class provaFee(BitcoinTestFramework):
 
@@ -86,7 +78,7 @@ class provaFee(BitcoinTestFramework):
         epoch_length = 0 if not ceasable else EPOCH_LENGTH
 
         if (self.firstRound):
-            mark_logs_temp(f"Node 0 generates {ForkHeights['MINIMAL_SC']} block", self.nodes, DEBUG_MODE, color='e')
+            mark_logs(f"Node 0 generates {ForkHeights['MINIMAL_SC']} block", self.nodes, DEBUG_MODE, color='e')
             self.nodes[0].generate(ForkHeights['MINIMAL_SC'])
             self.sync_all()
             self.firstRound = False
@@ -113,10 +105,10 @@ class provaFee(BitcoinTestFramework):
         ret = self.nodes[0].sc_create(cmdInput)
         scid = ret['scid']
         scid_swapped = str(swap_bytes(scid))
-        mark_logs_temp(cc('g',"Node 0 created a SC: ") + scid, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('g',"Node 0 created a SC: ") + scid, self.nodes, DEBUG_MODE, color='n')
 
         ### Sidechain confirmation
-        mark_logs_temp(f"Node 0 mines 1 block to confirm the sidechain", self.nodes, DEBUG_MODE, color='e')
+        mark_logs("Node 0 mines 1 block to confirm the sidechain", self.nodes, DEBUG_MODE, color='e')
         self.nodes[0].generate(1)
         self.sync_all()
         # Ensure that the SC is alive
@@ -124,7 +116,7 @@ class provaFee(BitcoinTestFramework):
         assert_equal(sc_info['items'][0]['state'], 'ALIVE')
 
         # Send some funds to node 2 to create a certificate
-        mark_logs_temp("Node 0 sends some funds to nodes 1 and 2", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 0 sends some funds to nodes 1 and 2", self.nodes, DEBUG_MODE, color='g')
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10.0)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20.0)
         self.nodes[0].generate(1)
@@ -132,7 +124,7 @@ class provaFee(BitcoinTestFramework):
 
         # Mine blocks until reaching new epoch
         blocksToBeGen = sc_info['items'][0]['endEpochHeight'] - self.nodes[0].getblockcount() + 1
-        mark_logs_temp(f"Node 0 mines {blocksToBeGen} blocks until a new epoch begins", self.nodes, DEBUG_MODE, color='e')
+        mark_logs(f"Node 0 mines {blocksToBeGen} blocks until a new epoch begins", self.nodes, DEBUG_MODE, color='e')
         self.nodes[0].generate(blocksToBeGen)
         self.sync_all()
 
@@ -157,16 +149,16 @@ class provaFee(BitcoinTestFramework):
 
         amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-        mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
         try:
             cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
             assert(len(cert_epoch_0) > 0)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+            mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
             assert(False)
-        mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
         self.nodes[2].generate(1)
         self.sync_all()
 
@@ -181,12 +173,12 @@ class provaFee(BitcoinTestFramework):
         loopfirstround = True
         for _ in range(blocksToBeGen):
             # 1.
-            mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+            mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
             self.split_network()
 
             # 2.
             if loopfirstround:
-                mark_logs_temp(f"Node 0 adds {NUM_TXS} transactions to nodes 0 and 1 mempools", self.nodes, DEBUG_MODE, color='g')
+                mark_logs(f"Node 0 adds {NUM_TXS} transactions to nodes 0 and 1 mempools", self.nodes, DEBUG_MODE, color='g')
                 initial_balances = [self.nodes[x].getbalance() for x in range(NUMB_OF_NODES)]
                 ft_address_1 = self.nodes[1].getnewaddress() # = mc_return_address
                 forwardTransferOuts = [{'toaddress': address, 'amount': Decimal(float(FT_SC_FEE) + 0.05), "scid": scid, "mcReturnAddress": ft_address_1}]
@@ -201,14 +193,14 @@ class provaFee(BitcoinTestFramework):
             assert_equal(float(self.nodes[1].getbalance()), float(initial_balances[1]))
 
             # 3.
-            mark_logs_temp("Node 2 mines 1 block", self.nodes, DEBUG_MODE, color='e')
+            mark_logs("Node 2 mines 1 block", self.nodes, DEBUG_MODE, color='e')
             self.nodes[2].generate(1)
             sync_blocks(self.nodes[2:])
             sync_mempools(self.nodes[2:])
             self.assert_chain_height_difference(1)      # Test that the newly mined block is only on nodes 2 and 3
 
             # 4.
-            mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+            mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
             self.join_network()
             sync_blocks(self.nodes)
 
@@ -225,7 +217,7 @@ class provaFee(BitcoinTestFramework):
         ### 8. rejoin the network and check block heights and txs
         ### 9. repeat the loop for advancing blocks until entering epoch 3
         # 6.
-        mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
         self.split_network()
         # 7.
         malicious_ft_fees = Decimal('0.07')
@@ -245,22 +237,22 @@ class provaFee(BitcoinTestFramework):
 
         amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-        mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
         try:
             cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
             assert(len(cert_epoch_0) > 0)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+            mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
             assert(False)
-        mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
         self.nodes[2].generate(1)
         sync_blocks(self.nodes[2:])
         sync_mempools(self.nodes[2:])
         self.assert_chain_height_difference(1)          # Test that the newly mined block is only on nodes 2 and 3
         # 8.
-        mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
         self.join_network()
         sync_blocks(self.nodes)
         self.assert_chain_height_difference(0)          # Make sure that block is propagated to nodes 0 and 1
@@ -269,20 +261,20 @@ class provaFee(BitcoinTestFramework):
         blocksToBeGen = self.nodes[0].getscinfo(scid)['items'][0]['endEpochHeight'] - self.nodes[0].getblockcount() + 1
         for _ in range(blocksToBeGen):
             # 1.
-            mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+            mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
             self.split_network()
             # 2.
             self.assert_txs_in_mempool(NUM_TXS)         # Make sure that txs are only in nodes 0 and 1 mempool
             assert_greater_than(float(self.nodes[0].getbalance()), float(initial_balances[0]))
             assert_equal(float(self.nodes[1].getbalance()), float(initial_balances[1]))
             # 3.
-            mark_logs_temp("Node 2 mines a block", self.nodes, DEBUG_MODE, color='e')
+            mark_logs("Node 2 mines a block", self.nodes, DEBUG_MODE, color='e')
             self.nodes[2].generate(1)
             sync_blocks(self.nodes[2:])
             sync_mempools(self.nodes[2:])
             self.assert_chain_height_difference(1)      # Test that the newly mined block is only on nodes 2 and 3
             # 4.
-            mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+            mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
             self.join_network()
             sync_blocks(self.nodes)
             # 5.
@@ -297,7 +289,7 @@ class provaFee(BitcoinTestFramework):
         ### 12. mine a block on node 2 to confirm the cert
         ### 13. rejoin the net and sync everything
         # 10.
-        mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
         self.split_network()
         # 11.
         malicious_ft_fees = Decimal('0.1')
@@ -317,24 +309,24 @@ class provaFee(BitcoinTestFramework):
 
         amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-        mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
         try:
             cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
             assert(len(cert_epoch_0) > 0)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+            mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
             assert(False)
         # 12.
-        mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
         self.nodes[2].generate(1)
         sync_blocks(self.nodes[2:])
         sync_mempools(self.nodes[2:])
         self.assert_chain_height_difference(1)          # Test that the newly mined block is only on nodes 2 and 3
 
         # 13.
-        mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
         self.join_network()
         sync_blocks(self.nodes)
 
@@ -345,7 +337,7 @@ class provaFee(BitcoinTestFramework):
         # a.
         self.assert_chain_height_difference(0)          # Make sure that block is propagated to nodes 0 and 1
         # b.
-        mark_logs_temp("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
+        mark_logs("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
         self.assert_txs_in_mempool(0)                   # BOOM! Transactions should no longer be in mempool
         # c.
         assert_greater_than(float(self.nodes[0].getbalance()), float(initial_balances[0]))  # and balance is unaffected
@@ -374,7 +366,7 @@ class provaFee(BitcoinTestFramework):
         epoch_length = 0 if not ceasable else EPOCH_LENGTH
 
         if (self.firstRound):
-            mark_logs_temp(f"Node 0 generates {ForkHeights['NON_CEASING_SC']} block", self.nodes, DEBUG_MODE, color='e')
+            mark_logs(f"Node 0 generates {ForkHeights['NON_CEASING_SC']} block", self.nodes, DEBUG_MODE, color='e')
             self.nodes[0].generate(ForkHeights['NON_CEASING_SC'])
             self.sync_all()
             self.firstRound = False
@@ -396,10 +388,10 @@ class provaFee(BitcoinTestFramework):
         ret = self.nodes[0].sc_create(cmdInput)
         scid = ret['scid']
         scid_swapped = str(swap_bytes(scid))
-        mark_logs_temp(cc('g',"Node 0 created a SC: ") + scid, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('g',"Node 0 created a SC: ") + scid, self.nodes, DEBUG_MODE, color='n')
 
         ### Sidechain confirmation
-        mark_logs_temp(f"Node 0 generating 1 block to confirm the sidechain", self.nodes, DEBUG_MODE, color='e')
+        mark_logs("Node 0 generating 1 block to confirm the sidechain", self.nodes, DEBUG_MODE, color='e')
         self.nodes[0].generate(1)
         self.sync_all()
         # Ensure that the SC is alive
@@ -408,7 +400,7 @@ class provaFee(BitcoinTestFramework):
 
         # Send some funds to node 2 to create a certificate and
         # generate a few blocks for allowing correct block referencing
-        mark_logs_temp("Node 0 sends some funds to nodes 1 and 2", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 0 sends some funds to nodes 1 and 2", self.nodes, DEBUG_MODE, color='g')
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10.0)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20.0)
         self.nodes[0].generate(6)
@@ -422,7 +414,7 @@ class provaFee(BitcoinTestFramework):
         ### 5. rejoin the network
         ### 6. mined block should be broadcasted to nodes 0 and 1, but transactions shouldn't
         # 1.
-        mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
         self.split_network()
 
         # 2.
@@ -435,7 +427,7 @@ class provaFee(BitcoinTestFramework):
         assert_greater_than(float(initial_balances[0]), float(self.nodes[0].getbalance()))  # balance is unaffected
         self.assert_txs_in_mempool(NUM_TXS)
         assert_equal(float(self.nodes[1].getbalance()), float(initial_balances[1]))  # balance is unaffected
-        mark_logs_temp(f"Node 0 added {NUM_TXS} transactions to nodes 0 and 1 mempools", self.nodes, DEBUG_MODE, color='c')
+        mark_logs(f"Node 0 added {NUM_TXS} transactions to nodes 0 and 1 mempools", self.nodes, DEBUG_MODE, color='c')
 
         # 3.
         # node 2 send a ceritificate to node 3
@@ -459,25 +451,25 @@ class provaFee(BitcoinTestFramework):
 
         amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-        mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
         try:
             cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
             assert(len(cert_epoch_0) > 0)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+            mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
             assert(False)
 
         # 4.
-        mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
         self.nodes[2].generate(1)
         sync_blocks(self.nodes[2:])
         sync_mempools(self.nodes[2:])
         self.assert_chain_height_difference(1)      # Test that the newly mined block is only on nodes 2 and 3
 
         # 5.
-        mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
         self.join_network()
         sync_blocks(self.nodes)
 
@@ -489,7 +481,7 @@ class provaFee(BitcoinTestFramework):
 
         ### Repeat the same process, minus tx generation
         # 1.
-        mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
         self.split_network()
         # 3.
         # node 2 sends a ceritificate to node 3
@@ -511,25 +503,25 @@ class provaFee(BitcoinTestFramework):
 
         amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-        mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+        mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
         try:
             cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                 epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
             assert(len(cert_epoch_0) > 0)
         except JSONRPCException as e:
             errorString = e.error['message']
-            mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+            mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
             assert(False)
 
         # 4.
-        mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+        mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
         self.nodes[2].generate(1)
         sync_blocks(self.nodes[2:])
         sync_mempools(self.nodes[2:])
         self.assert_chain_height_difference(1)      # Test that the newly mined block is only on nodes 2 and 3
 
         # 5.
-        mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+        mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
         self.join_network()
         sync_blocks(self.nodes)
         self.assert_chain_height_difference(0)      # Make sure that block is propagated to nodes 0 and 1
@@ -537,7 +529,7 @@ class provaFee(BitcoinTestFramework):
         # Before the update, txs should be removed here as soon as we sync the split
         if old_version:
             # 6.
-            mark_logs_temp("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
+            mark_logs("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
             self.assert_txs_in_mempool(0)               # BOOM! Transactions should no longer be in mempool
             assert_greater_than(float(self.nodes[0].getbalance()), float(initial_balances[0]))  # and balance is unaffected
             assert_equal(float(self.nodes[1].getbalance()), float(initial_balances[1]))
@@ -549,7 +541,7 @@ class provaFee(BitcoinTestFramework):
             for i in range(9):
                 self.assert_txs_in_mempool(NUM_TXS)         # Make sure that txs are only in nodes 0 and 1 mempool
 
-                mark_logs_temp(f"Net split", self.nodes, DEBUG_MODE, color='c')
+                mark_logs("Net split", self.nodes, DEBUG_MODE, color='c')
                 self.split_network()
 
                 incremental_fees = incremental_fees + 0.05
@@ -570,29 +562,29 @@ class provaFee(BitcoinTestFramework):
 
                 amount_cert_3 = [{"address": addr_node3, "amount": bwt_amount}]
 
-                mark_logs_temp("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
+                mark_logs("Node 2 sends a certificate with increased fees", self.nodes, DEBUG_MODE, color='g')
                 try:
                     cert_epoch_0 = self.nodes[2].sc_send_certificate(scid, epoch_number, quality,
                         epoch_cum_tree_hash, proof, amount_cert_3, malicious_ft_fees, malicious_mbtr_fees, CERT_FEE)
                     assert(len(cert_epoch_0) > 0)
                 except JSONRPCException as e:
                     errorString = e.error['message']
-                    mark_logs_temp(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
+                    mark_logs(f"Send certificate failed with reason {errorString}", self.nodes, DEBUG_MODE, color='r')
                     assert(False)
 
-                mark_logs_temp(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
+                mark_logs(cc('e',"Node 2 mines 1 block to validate cert: ") + cert_epoch_0, self.nodes, DEBUG_MODE, color='n')
                 self.nodes[2].generate(1)
                 sync_blocks(self.nodes[2:])
                 sync_mempools(self.nodes[2:])
                 self.assert_chain_height_difference(1)      # Test that the newly mined block is only on nodes 2 and 3
 
-                mark_logs_temp(f"Net join", self.nodes, DEBUG_MODE, color='c')
+                mark_logs("Net join", self.nodes, DEBUG_MODE, color='c')
                 self.join_network()
                 sync_blocks(self.nodes)
                 self.assert_chain_height_difference(0)      # Make sure that block is propagated to nodes 0 and 1
 
             # Finally, we are over the minScFeesBlocksUpdate border
-            mark_logs_temp("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
+            mark_logs("Assert txs are no longer in mempool", self.nodes, DEBUG_MODE, color='y')
             self.assert_txs_in_mempool(0)                   # BOOM! Transactions should no longer be in mempool
             assert_greater_than(float(self.nodes[0].getbalance()), float(initial_balances[0]))  # and balance is unaffected
             assert_equal(float(self.nodes[1].getbalance()), float(initial_balances[1]))
@@ -611,11 +603,11 @@ class provaFee(BitcoinTestFramework):
 
 
     def run_test(self):
-        mark_logs_temp("*** SC version 0", self.nodes, DEBUG_MODE, color='b')
+        mark_logs("*** SC version 0", self.nodes, DEBUG_MODE, color='b')
         self.run_test_with_scversion(0)
-        mark_logs_temp("*** SC version 2 - ceasable SC", self.nodes, DEBUG_MODE, color='b')
+        mark_logs("*** SC version 2 - ceasable SC", self.nodes, DEBUG_MODE, color='b')
         self.run_test_with_scversion(2, True)
-        mark_logs_temp("*** SC version 2 - non-ceasable SC", self.nodes, DEBUG_MODE, color='b')
+        mark_logs("*** SC version 2 - non-ceasable SC", self.nodes, DEBUG_MODE, color='b')
         self.run_test_non_ceasable(2, False, False)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR modifies a few Python tests by adding a flexible way of dividing the node network.

Many test scenarios involve network splits and joins, and usually the last (ordinal) node among those launched by the test plays the role of isolated / dishonest actor.
This PR modifies these tests so that any node can play the role of isolated / dishonest node.