### PR TITLE
Ap/codacy critical issues fix

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -19,6 +19,8 @@ zend v4.0.99
 - Fix for limitedmap [#538](https://github.com/HorizenOfficial/zen/pull/538)
 - Fix for return value of function mempoolToJSON [#539](https://github.com/HorizenOfficial/zen/pull/539)
 - Fix logfile output for "Leaving block file" statement [#530](https://github.com/HorizenOfficial/zen/pull/530)
+- Fix undefined behavior of a bitshift executed on a signed integer [#532](https://github.com/HorizenOfficial/zen/pull/532)
+- Improve `debug.log` file reopening procedure [#532](https://github.com/HorizenOfficial/zen/pull/532)
 
 ## Contributors
 * [@a-petrini](https://github.com/a-petrini)

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -174,7 +174,7 @@ unsigned int base_uint<BITS>::bits() const
     for (int pos = WIDTH - 1; pos >= 0; pos--) {
         if (pn[pos]) {
             for (int bits = 31; bits > 0; bits--) {
-                if (pn[pos] & 1 << bits)
+                if (pn[pos] & 1U << bits)
                     return 32 * pos + bits + 1;
             }
             return 32 * pos + 1;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -314,8 +314,13 @@ int LogPrintStr(const std::string &str)
             if (fReopenDebugLog) {
                 fReopenDebugLog = false;
                 boost::filesystem::path pathDebug = GetDebugLogPath();
-                if (freopen(pathDebug.string().c_str(),"a", debugLogFp) != NULL)
+                if ((debugLogFp = freopen(pathDebug.string().c_str(),"a", debugLogFp)) != NULL) {
                     setbuf(debugLogFp, NULL); // unbuffered
+                }
+                else {
+                    fprintf(stderr, "Error reopening debug.log file");
+                    return 0;
+                }
             }
 
             ret = FileWriteStr(strTimestamped, debugLogFp);

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -27,6 +27,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         if (rc != 0)
         {
             zmqError("Unable to initialize ZMQ msg");
+            va_end(args);
             return -1;
         }
 
@@ -40,6 +41,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         {
             zmqError("Unable to send ZMQ msg");
             zmq_msg_close(&msg);
+            va_end(args);
             return -1;
         }
 
@@ -50,6 +52,8 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
 
         size = va_arg(args, size_t);
     }
+
+    va_end(args);
     return 0;
 }
 


### PR DESCRIPTION
This PR fixes four issues that were labelled as "critical" by Codacy static analysis tool

- bitshift on a signed integer value may results in undefined behavior (see also https://github.com/bitcoin/bitcoin/pull/14510 )
- remove Python `subrocess`' `Popen` function, as they are insecure when used with `shell=True` option
- do not ignore `freopen` return value
- fix a `var_arg` function that did not feature any call to `va_end()`