### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,14 @@ Building from source
     ```
     For a detailed list of dependencies, please refer to the [dependencies section](doc/dependencies.md).
 
-    2. Cross compilation for Windows target
+    2. Mac OS
+    ```
+    xcode-select --install
+    brew install \
+    autoconf coreutils automake libtool pkg-config cmake
+    ```
+
+    3. Cross compilation for Windows target
     ```{r, engine='bash'}
     sudo apt-get install \
     build-essential pkg-config libc6-dev m4 g++-multilib \
@@ -87,8 +94,10 @@ cd zen
 
 * Install for Mac OS (using clang)
 
-Read and follow the README.md at https://github.com/HorizenOfficial/zencash-apple
-
+```
+# Build. Add -jN parameter (where N is the number of cpu cores) to speed up compilation.
+./zcutil/build-mac-clang.sh
+```
 
 * Install for Windows (Cross-Compiled, building on Windows is not supported yet)
 
@@ -113,7 +122,7 @@ Running Regression Tests
 
     2. MacOS
     ```{r, engine='bash'}
-    brew install python@2
+    brew install python
     pip install --upgrade pyblake2 pyzmq websocket-client requests
     ```
 

--- a/contrib/ci-horizen/scripts/common/setup_environment.sh
+++ b/contrib/ci-horizen/scripts/common/setup_environment.sh
@@ -71,8 +71,6 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   fi
   if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Build" ]; then
     export PIP3_INSTALL="${PIP3_INSTALL} b2"
-    export B2_DL_DECOMPRESS_FOLDER="${HOME}/zencash-apple"
-    export B2_DL_FILENAME="${TRAVIS_CPU_ARCH}-${TRAVIS_OS_NAME}-${TRAVIS_OSX_IMAGE}-${TRAVIS_BUILD_ID}-${TRAVIS_COMMIT}-zencash-apple.tar.gz"
     export B2_UL_COMPRESS_FOLDER="${TRAVIS_BUILD_DIR}"
     # shellcheck disable=SC2001,SC2155
     export B2_UL_FILENAME="${TRAVIS_CPU_ARCH}-${TRAVIS_OS_NAME}-${TRAVIS_OSX_IMAGE}-${TRAVIS_BUILD_ID}-${TRAVIS_COMMIT}$(sed 's/ //g' <<< "${MAKEFLAGS:-}").tar.gz"


### PR DESCRIPTION
This PR updates build instructions to reflect the latest changes.
- when building on MacOS, zencash-apple repository is not needed anymore, as we rely on system tools for building
- CMake is now a requirement, as it is used to build gtests