### PR TITLE
Clean (when possible) shutdown of TLS socket(s) connected with peers

### DIFF
--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -72,12 +72,20 @@ class NodeHandlingTest (BitcoinTestFramework):
         print("Connection to self stress test. " \
               "Constantly trying to connect to self every 0.5 sec. " \
               "The whole test takes approx 5 mins")
-        for x in range(600):
+        total_duration = 300 # 5 min
+        start_time = time.time()
+        connections_count = 0
+        while time.time() - start_time < total_duration:
             connect_nodes(self.nodes[0], 0)
-            time.sleep(0.5)
-            # self-connection should be disconnected during the version checking
+            connections_count += 1
+            time.sleep(0.1)
             for node in self.nodes[0].getpeerinfo():
                 assert(node['addr'] != url.hostname+":"+str(p2p_port(0)))
+            if(connections_count % 10 == 0):
+                print(f"Connections count: {connections_count} in {time.time() - start_time:.2f} seconds")
+
+        print(f"Total connections count: {connections_count} in {total_duration:.2f} seconds")
+
 
 if __name__ == '__main__':
     NodeHandlingTest ().main ()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -329,13 +329,12 @@ def connect_nodes(from_connection, node_num):
     from_connection.addnode(ip_port, "onetry")
     # poll until version handshake complete to avoid race conditions
     # with transaction relaying
-    start_time = time.time()
-    loops = 0
-    while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
+    while True:
         time.sleep(0.1)
-        loops += 1
-    print(f"[debug] connect_nodes op peerinfo time: {(time.time() - start_time)} seconds {loops}")
-    #print "Connected node%d %s" % (node_num, ip_port)
+        peer_info = from_connection.getpeerinfo()
+        zero_version_peers = [peer for peer in peer_info if peer['version'] == 0]
+        if len(zero_version_peers) == 0:
+            break
     
 def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -327,27 +327,15 @@ def wait_bitcoinds():
 def connect_nodes(from_connection, node_num):
     ip_port = "127.0.0.1:"+str(p2p_port(node_num))
     from_connection.addnode(ip_port, "onetry")
-
-    loop_count = 0
-    while True:
+    # poll until version handshake complete to avoid race conditions
+    # with transaction relaying
+    start_time = time.time()
+    loops = 0
+    while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
         time.sleep(0.1)
-        start_time = time.time()
-        loop_count += 1
-        peer_info = from_connection.getpeerinfo()
-        print(f"[debug] connect_nodes op peerinfo attempt #{loop_count} got {len(peer_info)} in {(time.time() - start_time)} seconds")
-        zero_version_peers = [peer for peer in peer_info if peer['version'] == 0]
-        if len(zero_version_peers) == 0:
-            break
-        
-    # # poll until version handshake complete to avoid race conditions
-    # # with transaction relaying
-    # start_time = time.time()
-    # loops = 0
-    # while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
-    #     time.sleep(0.1)
-    #     loops += 1
-    # print(f"[debug] connect_nodes op peerinfo time: {(time.time() - start_time)} seconds {loops}")
-    # #print "Connected node%d %s" % (node_num, ip_port)
+        loops += 1
+    print(f"[debug] connect_nodes op peerinfo time: {(time.time() - start_time)} seconds {loops}")
+    #print "Connected node%d %s" % (node_num, ip_port)
     
 def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -327,12 +327,28 @@ def wait_bitcoinds():
 def connect_nodes(from_connection, node_num):
     ip_port = "127.0.0.1:"+str(p2p_port(node_num))
     from_connection.addnode(ip_port, "onetry")
-    # poll until version handshake complete to avoid race conditions
-    # with transaction relaying
-    while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
-        time.sleep(0.1)
-    #print "Connected node%d %s" % (node_num, ip_port)
 
+    loop_count = 0
+    while True:
+        time.sleep(0.1)
+        start_time = time.time()
+        loop_count += 1
+        peer_info = from_connection.getpeerinfo()
+        print(f"[debug] connect_nodes op peerinfo attempt #{loop_count} got {len(peer_info)} in {(time.time() - start_time)} seconds")
+        zero_version_peers = [peer for peer in peer_info if peer['version'] == 0]
+        if len(zero_version_peers) == 0:
+            break
+        
+    # # poll until version handshake complete to avoid race conditions
+    # # with transaction relaying
+    # start_time = time.time()
+    # loops = 0
+    # while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
+    #     time.sleep(0.1)
+    #     loops += 1
+    # print(f"[debug] connect_nodes op peerinfo time: {(time.time() - start_time)} seconds {loops}")
+    # #print "Connected node%d %s" % (node_num, ip_port)
+    
 def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
     connect_nodes(nodes[b], a)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2441,7 +2441,6 @@ CNode::~CNode()
         {
             unsigned long err_code = 0;
             tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, 0 /*no retries here make no sense on destructor*/, err_code);
-
             SSL_free(ssl);
             ssl = NULL;
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -551,7 +551,7 @@ void CNode::CloseSocketDisconnect()
             if (ssl)
             {
                 unsigned long err_code = 0;
-                tlsmanager.waitFor(SSL_SHUTDOWN, hSocket, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
+                tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
                 SSL_free(ssl);
                 ssl = NULL;
             }
@@ -2440,7 +2440,7 @@ CNode::~CNode()
         if (ssl)
         {
             unsigned long err_code = 0;
-            tlsmanager.waitFor(SSL_SHUTDOWN, hSocket, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
+            tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
             
             SSL_free(ssl);
             ssl = NULL;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -551,7 +551,7 @@ void CNode::CloseSocketDisconnect()
             if (ssl)
             {
                 unsigned long err_code = 0;
-                tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
+                tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, 100 /*double of avg roundtrip on decent connection*/, err_code);
                 SSL_free(ssl);
                 ssl = NULL;
             }
@@ -2440,8 +2440,8 @@ CNode::~CNode()
         if (ssl)
         {
             unsigned long err_code = 0;
-            tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
-            
+            tlsmanager.waitFor(SSL_SHUTDOWN, addr, ssl, 0 /*no retries here make no sense on destructor*/, err_code);
+
             SSL_free(ssl);
             ssl = NULL;
         }

--- a/src/zen/tlsmanager.cpp
+++ b/src/zen/tlsmanager.cpp
@@ -186,143 +186,132 @@ int tlsCertVerificationCallback(int preverify_ok, X509_STORE_CTX* chainContext)
  * @param timeoutSec timeout in seconds.
  * @return int returns nError corresponding to the connection event.
  */
-int TLSManager::waitFor(SSLConnectionRoutine eRoutine, SOCKET hSocket, SSL* ssl, int timeoutSec, unsigned long& err_code)
+int TLSManager::waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, SSL* ssl, int timeoutSec, unsigned long& err_code)
 {
-    int retOp = 0;
+    std::string eRoutine_str{};
+    int retOp{0};
+    const SOCKET hSocket = SSL_get_fd(ssl);
+
     err_code = 0;
+    fd_set socketSet;
+    struct timeval timeout {
+        timeoutSec, 0
+    };
+
+    FD_ZERO(&socketSet);
+    FD_SET(hSocket, &socketSet);
 
     while (true) {
+
         // clear the current thread's error queue
         ERR_clear_error();
+        retOp = 0;
 
         switch (eRoutine) {
-            case SSL_CONNECT:
-            {
-                retOp = SSL_connect(ssl);
-                if (retOp == 0)
-                {
-                    err_code = ERR_get_error();
-                    const char* error_str = ERR_error_string(err_code, NULL);
-                    LogPrint("tls", "TLS: WARNING: %s: %s():%d - SSL_CONNECT err: %s\n",
-                        __FILE__, __func__, __LINE__, error_str);
-                    return -1;
-                }
-            }
+        case SSL_CONNECT:
+            eRoutine_str = "SSL_CONNECT";
+            LogPrint("tls", "TLS: %s initiated, fd=%d, peer=%s\n", eRoutine_str, hSocket, peerAddress.ToString());
+            retOp = SSL_connect(ssl);
             break;
-         
-            case SSL_ACCEPT:
-            {
-                retOp = SSL_accept(ssl);
-                if (retOp == 0)
-                {
-                    err_code = ERR_get_error();
-                    const char* error_str = ERR_error_string(err_code, NULL);
-                    LogPrint("tls", "TLS: WARNING: %s: %s():%d - SSL_ACCEPT err: %s\n",
-                        __FILE__, __func__, __LINE__, error_str);
-                    return -1;
-                }
-            }
+
+        case SSL_ACCEPT:
+            eRoutine_str = "SSL_ACCEPT";
+            LogPrint("tls", "TLS: %s initiated, fd=%d, peer=%s\n", eRoutine_str, hSocket, peerAddress.ToString());
+            retOp = SSL_accept(ssl);
             break;
-         
-            case SSL_SHUTDOWN:
+
+        case SSL_SHUTDOWN:
+            eRoutine_str = "SSL_SHUTDOWN";
+            LogPrint("tls", "TLS: %s initiated, fd=%d, peer=%s\n", eRoutine_str, hSocket, peerAddress.ToString());
             {
-                if (hSocket != INVALID_SOCKET)
-                {
-                    std::string disconnectedPeer("no info");
-                    struct sockaddr_in addr;
-                    socklen_t serv_len = sizeof(addr);
-                    int ret = getpeername(hSocket, (struct sockaddr *)&addr, &serv_len);
-                    if (ret == 0)
-                    {
-                        disconnectedPeer = std::string(inet_ntoa(addr.sin_addr)) + ":" + std::to_string(ntohs(addr.sin_port));
+                int shutDownStatus(SSL_get_shutdown(ssl)); // Bitmask of shutdown state
+                if(shutDownStatus == 3 /* 1 & 2*/) {
+                    retOp = 1;// already shut down
+                } else {
+                    for (int i{1}; i < 3; ++i) {
+                        if (!(shutDownStatus & i)) {
+                            retOp = SSL_shutdown(ssl); // Send/receive close_notify
+                            MilliSleep(5);
+                        }
+                        shutDownStatus = SSL_get_shutdown(ssl);
                     }
-                    LogPrint("tls", "TLS: shutting down fd=%d, peer=%s\n", hSocket, disconnectedPeer);
                 }
-                retOp = SSL_shutdown(ssl);
             }
             break;
-         
-            default:
-                return -1;
+
+        default:
+            assert(false); // should never happen
         }
 
-        if (eRoutine == SSL_SHUTDOWN) {
-            if (retOp == 0)
-            {
-                LogPrint("tls", "TLS: WARNING: %s: %s():%d - SSL_SHUTDOWN: The close_notify was sent but the peer did not send it back yet.\n",
-                        __FILE__, __func__, __LINE__);
-                // do not call SSL_get_error() because it may misleadingly indicate an error even though no error occurred.
-                break;
-            }
-            else
-            if (retOp == 1)
-            {
-                LogPrint("tls", "TLS: %s: %s():%d - SSL_SHUTDOWN completed\n", __FILE__, __func__, __LINE__);
-                break;
-            }
-            else
-            {
-                LogPrint("tls", "TLS: %s: %s():%d - SSL_SHUTDOWN failed\n", __FILE__, __func__, __LINE__);
-                // the error will be read afterwards
-            }
-        } else {
-            if (retOp == 1)
-            {
-                LogPrint("tls", "TLS: %s: %s():%d - %s completed\n", __FILE__, __func__, __LINE__,
-                    eRoutine == SSL_CONNECT ? "SSL_CONNECT" : "SSL_ACCEPT");
-                break;
-            }
+        if (retOp == 1 /*success for any of the three operations*/) {
+            err_code = 0;
+            LogPrint("tls", "TLS: %s completed, fd=%d, peer=%s\n", eRoutine_str, hSocket, peerAddress.ToString());
+            break;
         }
-
+        
+        // Examine error
         int sslErr = SSL_get_error(ssl, retOp);
 
-        if (sslErr != SSL_ERROR_WANT_READ && sslErr != SSL_ERROR_WANT_WRITE) {
+        // if (sslErr != SSL_ERROR_WANT_READ && sslErr != SSL_ERROR_WANT_WRITE) {
+        //     err_code = ERR_get_error();
+        //     const char* error_str = ERR_error_string(err_code, NULL);
+        //     LogPrint("tls", "TLS: WARNING: %s: %s():%d - routine(%s), sslErr[0x%x], retOp[%d], errno[0x%x], lib[0x%x], func[0x%x], reas[0x%x]-> err: %s\n",
+        //              __FILE__, __func__, __LINE__,
+        //              eRoutine_str, sslErr, retOp, errno, ERR_GET_LIB(err_code), ERR_GET_FUNC(err_code), ERR_GET_REASON(err_code), error_str);
+        //     retOp = -1;
+        //     break;
+        // }
+
+        
+        std::string ssl_error_str{};
+        int result{0};
+
+        switch (sslErr) {
+        case SSL_ERROR_SSL:
+            // Handle the case for shutdown sent while the peer still sending data after we've sent close_notify
+            // we should temporarily ignore this error and continue reading until the peer closes the connection
+            // For other errors we intentionally do fail (no retries)
             err_code = ERR_get_error();
-            const char* error_str = ERR_error_string(err_code, NULL);
-            LogPrint("tls", "TLS: WARNING: %s: %s():%d - routine(%d), sslErr[0x%x], retOp[%d], errno[0x%x], lib[0x%x], func[0x%x], reas[0x%x]-> err: %s\n",
-                __FILE__, __func__, __LINE__,
-                eRoutine, sslErr, retOp, errno, ERR_GET_LIB(err_code), ERR_GET_FUNC(err_code), ERR_GET_REASON(err_code), error_str);
+            if (auto reason{ERR_GET_REASON(err_code)}; reason != SSL_R_APPLICATION_DATA_AFTER_CLOSE_NOTIFY) {
+                ssl_error_str = "SSL_ERROR_SSL:" + std::to_string(reason);
+                result = -1;
+                break;
+            }
+            [[fallthrough]]; // Need to read more
+        case SSL_ERROR_WANT_READ:
+            ssl_error_str = "SSL_ERROR_WANT_READ";
+            result = select(hSocket + 1, &socketSet, NULL, NULL, &timeout);
+            break;
+        case SSL_ERROR_WANT_WRITE:
+            ssl_error_str = "SSL_ERROR_WANT_WRITE";
+            result = select(hSocket + 1, NULL, &socketSet, NULL, &timeout);
+            break;
+        default:
+            // For all othe errors we intentionally do fail (no retries)
+            err_code = ERR_get_error();
+            {
+                const char* error_str = ERR_error_string(err_code, NULL);
+                LogPrint("tls", "TLS: %s: %s():%d - routine(%s), sslErr[0x%x], retOp[%d], errno[0x%x], lib[0x%x], func[0x%x], reas[0x%x]-> err: %s\n",
+                         __FILE__, __func__, __LINE__,
+                         eRoutine_str, sslErr, retOp, errno, ERR_GET_LIB(err_code), ERR_GET_FUNC(err_code), ERR_GET_REASON(err_code), "unknown");
+            }
+            return -1;
+        }
+
+        if (result == 0 /*timeout*/) {
+            LogPrint("tls", "TLS: %s: %s():%d - %s timeout on %s\n", __FILE__, __func__, __LINE__,
+                     ssl_error_str, eRoutine_str);
+            retOp = -1;
+            break;
+        } else if (result == -1 /*error*/) {
+            LogPrint("tls", "TLS: %s: %s: %s ssl_err_code: 0x%x; errno: %s\n",
+                     __FILE__, __func__, eRoutine_str, sslErr, strerror(errno));
             retOp = -1;
             break;
         }
 
-        fd_set socketSet;
-        FD_ZERO(&socketSet);
-        FD_SET(hSocket, &socketSet);
+        // Something happened on the socket hence we continue the loop
 
-        struct timeval timeout = {timeoutSec, 0};
-
-        if (sslErr == SSL_ERROR_WANT_READ) {
-            int result = select(hSocket + 1, &socketSet, NULL, NULL, &timeout);
-            if (result == 0) {
-                LogPrint("tls", "TLS: ERROR: %s: %s():%d - WANT_READ timeout on %s\n", __FILE__, __func__, __LINE__,
-                    (eRoutine == SSL_CONNECT ? "SSL_CONNECT" : 
-                        (eRoutine == SSL_ACCEPT ? "SSL_ACCEPT" : "SSL_SHUTDOWN" )));
-                err_code = SELECT_TIMEDOUT;
-                retOp = -1;
-                break;
-            } else if (result == -1) {
-                LogPrint("tls", "TLS: ERROR: %s: %s: WANT_READ ssl_err_code: 0x%x; errno: %s\n",
-                    __FILE__, __func__, sslErr, strerror(errno));
-                retOp = -1;
-                break;
-            }
-        } else {
-            int result = select(hSocket + 1, NULL, &socketSet, NULL, &timeout);
-            if (result == 0) {
-                LogPrint("tls", "TLS: ERROR: %s: %s():%d - WANT_WRITE timeout on %s\n", __FILE__, __func__, __LINE__,
-                    (eRoutine == SSL_CONNECT ? "SSL_CONNECT" : 
-                        (eRoutine == SSL_ACCEPT ? "SSL_ACCEPT" : "SSL_SHUTDOWN" )));
-                err_code = SELECT_TIMEDOUT;
-                retOp = -1;
-                break;
-            } else if (result == -1) {
-                LogPrint("tls", "TLS: ERROR: %s: %s: WANT_WRITE ssl_err_code: 0x%x; errno: %s\n",
-                    __FILE__, __func__, sslErr, strerror(errno));
-                retOp = -1;
-                break;
-            }
-        }
     }
 
     return retOp;
@@ -346,7 +335,7 @@ SSL* TLSManager::connect(SOCKET hSocket, const CAddress& addrConnect, unsigned l
 
     if ((ssl = SSL_new(tls_ctx_client))) {
         if (SSL_set_fd(ssl, hSocket)) {
-            int ret = TLSManager::waitFor(SSL_CONNECT, hSocket, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
+            int ret = TLSManager::waitFor(SSL_CONNECT, addrConnect, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
             if (ret == 1)
             {
                 bConnectedTLS = true;
@@ -537,7 +526,7 @@ SSL* TLSManager::accept(SOCKET hSocket, const CAddress& addr, unsigned long& err
 
     if ((ssl = SSL_new(tls_ctx_server))) {
         if (SSL_set_fd(ssl, hSocket)) {
-            int ret = TLSManager::waitFor(SSL_ACCEPT, hSocket, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
+            int ret = TLSManager::waitFor(SSL_ACCEPT, addr, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000), err_code);
             if (ret == 1)
             {
                 bAcceptedTLS = true;

--- a/src/zen/tlsmanager.cpp
+++ b/src/zen/tlsmanager.cpp
@@ -297,7 +297,6 @@ success:
             // For all othe errors we intentionally do fail (no retries)
             err_code = ERR_get_error();
             {
-                const char* error_str = ERR_error_string(err_code, NULL);
                 LogPrint("tls", "TLS: %s: %s():%d - routine(%s), sslErr[0x%x], retOp[%d], errno[0x%x], lib[0x%x], func[0x%x], reas[0x%x]-> err: %s\n",
                          __FILE__, __func__, __LINE__,
                          eRoutine_str, sslErr, retOp, errno, ERR_GET_LIB(err_code), ERR_GET_FUNC(err_code), ERR_GET_REASON(err_code), "unknown");

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -43,7 +43,7 @@ public:
         function code and reason code. */
      static const long SELECT_TIMEDOUT = 0xFFFFFFFF;
 
-     int waitFor(SSLConnectionRoutine eRoutine, SOCKET hSocket, SSL* ssl, int timeoutSec, unsigned long& err_code);
+     int waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, SSL* ssl, int timeoutSec, unsigned long& err_code);
 
      SSL* connect(SOCKET hSocket, const CAddress& addrConnect, unsigned long& err_code);
      SSL_CTX* initCtx(

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -43,7 +43,7 @@ public:
         function code and reason code. */
      static const long SELECT_TIMEDOUT = 0xFFFFFFFF;
 
-     int waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, SSL* ssl, int timeoutSec, unsigned long& err_code);
+     int waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, SSL* ssl, int timeoutMilliSec, unsigned long& err_code);
 
      SSL* connect(SOCKET hSocket, const CAddress& addrConnect, unsigned long& err_code);
      SSL_CTX* initCtx(


### PR DESCRIPTION
This pr addresses the issue of half backed close of TLS connections

- revised the loop in tlsManager's waitFor
- adjusted timeouts
- amended nodehandling.py test

