### PR TITLE
Use rust 1.70.0 to compile rust dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,7 @@ case $host in
      fi
 
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB"
+     LIBS="$LIBS -lntdll"
      LEVELDB_TARGET_FLAGS="TARGET_OS=OS_WINDOWS_CROSSCOMPILE"
      if test "x$CXXFLAGS_overridden" = "xno"; then
        CXXFLAGS="$CXXFLAGS -w"

--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,7 @@ case $host in
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([userenv],      [main],, AC_MSG_ERROR(lib missing))
+     AC_CHECK_LIB([ntdll],      [main],, AC_MSG_ERROR(lib missing))
 
      # -static is interpreted by libtool, where it has a different meaning.
      # In libtool-speak, it's -all-static.
@@ -304,7 +305,6 @@ case $host in
      fi
 
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB"
-     LIBS="$LIBS -lntdll"
      LEVELDB_TARGET_FLAGS="TARGET_OS=OS_WINDOWS_CROSSCOMPILE"
      if test "x$CXXFLAGS_overridden" = "xno"; then
        CXXFLAGS="$CXXFLAGS -w"

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -28,7 +28,24 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-  cargo build $($(package)_build_opts)
+  # Shutting down warning generated with the newer rust version 
+  #   --> src/rustzcash.rs:61:38
+  #    |
+  # 61 |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
+  #    |                                      ^^                  ^^
+  #    |
+  #    = note: `#[warn(unused_braces)]` on by default
+  # 
+  #   warning: use of deprecated constant `std::sync::ONCE_INIT`: the `new` function is now preferred
+  #   --> src/rustzcash.rs:60:1
+  #    |
+  # 60 | / lazy_static! {
+  # 61 | |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
+  # 62 | | }
+  #    | |_^
+  #    |
+  # 
+  RUSTFLAGS="-A unused_braces -A deprecated" cargo build $($(package)_build_opts)
 endef
 
 define $(package)_stage_cmds

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -27,24 +27,24 @@ define $(package)_preprocess_cmds
   rm toml.temp 
 endef
 
+# Shutting down warning generated with the newer rust version 
+#   --> src/rustzcash.rs:61:38
+#    |
+# 61 |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
+#    |                                      ^^                  ^^
+#    |
+#    = note: `#[warn(unused_braces)]` on by default
+# 
+#   warning: use of deprecated constant `std::sync::ONCE_INIT`: the `new` function is now preferred
+#   --> src/rustzcash.rs:60:1
+#    |
+# 60 | / lazy_static! {
+# 61 | |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
+# 62 | | }
+#    | |_^
+#    |
+# 
 define $(package)_build_cmds
-  # Shutting down warning generated with the newer rust version 
-  #   --> src/rustzcash.rs:61:38
-  #    |
-  # 61 |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
-  #    |                                      ^^                  ^^
-  #    |
-  #    = note: `#[warn(unused_braces)]` on by default
-  # 
-  #   warning: use of deprecated constant `std::sync::ONCE_INIT`: the `new` function is now preferred
-  #   --> src/rustzcash.rs:60:1
-  #    |
-  # 60 | / lazy_static! {
-  # 61 | |     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
-  # 62 | | }
-  #    | |_^
-  #    |
-  # 
   RUSTFLAGS="-A unused_braces -A deprecated" cargo build $($(package)_build_opts)
 endef
 

--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -1,10 +1,10 @@
 package=libzendoo
-$(package)_version=0.3.0
+$(package)_version=0.4.0
 $(package)_download_path=https://github.com/HorizenOfficial/zendoo-mc-cryptolib/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=2304b80f5442f96f91b6cdc696b795a9844342fb279dadc47d4edf4359be52f3
-$(package)_git_commit=273e6998d5454208dd889a12a0c41525d6647492
+$(package)_sha256_hash=e6941f27a1d8612b5a5c61f9d9f3fe0c6c977bb67726819440dc4c4f19f2c733
+$(package)_git_commit=7a1496312b1bcef259aa336e8477e3724a5e0df3
 $(package)_dependencies=rust
 $(package)_patches=cargo.config
 

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,12 +1,12 @@
 package=rust
-$(package)_version=1.51.0
+$(package)_version=1.70.0
 $(package)_download_path=https://static.rust-lang.org/dist
 $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash_linux=9e125977aa13f012a68fdc6663629c685745091ae244f0587dd55ea4e3a3e42f
+$(package)_sha256_hash_linux=8499c0b034dd881cd9a880c44021632422a28dc23d7a81ca0a97b04652245982
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-$(package)_sha256_hash_darwin=765212098a415996b767d1e372ce266caf94027402b269fec33291fffc085ca4
+$(package)_sha256_hash_darwin=e5819fdbfc7f1a4d5d82cb4c3b7662250748450b45a585433bfb75648bc45547
 $(package)_file_name_mingw32=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
-$(package)_sha256_hash_mingw32=5a571ded9b870bcb25a64dfd37d4ba4863ebb9ed467219374ccd0147d491561f
+$(package)_sha256_hash_mingw32=52945bf6ab861d05be100e88a95766760d2daff1a0c0a2eff32a7fd8071495bd
 
 ifeq ($(host_os),mingw32)
 $(package)_build_subdir=buildos


### PR DESCRIPTION
Updated the rust version to 1.70.0

Also updated zendoo-mc-cryptolib to 0.4.0. The pk/vk generate with this version are different to the ones generate by the previous one but

- the old saved pk/vk will continue to work also with this version
- If a use would to che the old vk/pk should use the old version library

The `librustzcash` compilation emit 2 (trivial) warning that I shouted down with `RUSTFLAGS` env variable