### PR TITLE
Pyblake2 package removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ Running Regression Tests
     sudo apt-get install \
     python python-dev python-pip python-setuptools \
     python-wheel python-wheel-common python-zmq
-    pip install --upgrade pyblake2 websocket-client requests
+    pip install --upgrade websocket-client requests
     ```
 
     2. MacOS
     ```{r, engine='bash'}
     brew install python
-    pip install --upgrade pyblake2 pyzmq websocket-client requests
+    pip install --upgrade pyzmq websocket-client requests
     ```
 
 2. Start test suite

--- a/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_focal/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_focal/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils build-essential ca-certificates \
        cmake curl dirmngr fakeroot git g++-multilib gnupg2 help2man libc6-dev libgomp1 libtool lintian m4 ncurses-dev \
        pigz pkg-config pv python3-dev python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install pycryptodome b2 pyblake2 pyzmq websocket-client pyzmq \
+    && pip3 install pycryptodome b2 pyzmq websocket-client pyzmq \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_focal/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_focal/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils build-essential ca-certificates \
        cmake curl dirmngr fakeroot git g++-multilib gnupg2 help2man libc6-dev libgomp1 libtool lintian m4 ncurses-dev \
        pigz pkg-config pv python3-dev python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install pycryptodome b2 pyzmq websocket-client pyzmq \
+    && pip3 install pycryptodome b2 pyzmq websocket-client \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_jammy/Dockerfile
+++ b/contrib/ci-horizen/dockerfiles/amd64/linux/ubuntu_jammy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
     && apt-get -y --no-install-recommends install aria2 autoconf automake bsdmainutils bear build-essential ca-certificates \
        clang-tidy cmake curl dirmngr fakeroot git g++-multilib gnupg2 help2man lcov libc6-dev libgomp1 libtool lintian m4 ncurses-dev \
        pigz pkg-config pv python3-dev python3-pip python3-setuptools python3-wheel time unzip wget zlib1g-dev \
-    && pip3 install pycryptodome b2sdk==1.14.1 b2==3.2.1 pyblake2 websocket-client pyzmq \
+    && pip3 install pycryptodome b2sdk==1.14.1 b2==3.2.1 websocket-client pyzmq \
     && BASEURL="https://github.com/tianon/gosu/releases/download/" \
     && GOSU_VERSION="1.13" \
     && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \

--- a/contrib/ci-horizen/scripts/common/setup_environment.sh
+++ b/contrib/ci-horizen/scripts/common/setup_environment.sh
@@ -77,7 +77,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     NEED_B2_CREDS="true"
   fi
   if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]; then
-    export PIP3_INSTALL="${PIP3_INSTALL} pycryptodome pyblake2 pyzmq websocket-client requests"
+    export PIP3_INSTALL="${PIP3_INSTALL} pycryptodome pyzmq websocket-client requests"
     export B2_DL_DECOMPRESS_FOLDER="${TRAVIS_BUILD_DIR}"
     # shellcheck disable=SC2001,SC2155
     export B2_DL_FILENAME="${TRAVIS_CPU_ARCH}-${TRAVIS_OS_NAME}-${TRAVIS_OSX_IMAGE}-${TRAVIS_BUILD_ID}-${TRAVIS_COMMIT}$(sed 's/ //g' <<< "${MAKEFLAGS:-}").tar.gz"

--- a/contrib/ci-workers/vars/default.yml
+++ b/contrib/ci-workers/vars/default.yml
@@ -42,7 +42,6 @@ buildbot_modules:
 
 # Python modules required to run the Zcash RPC test suite
 rpc_test_modules:
-  - pyblake2
   - pyzmq
 
 # Environment variables

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -31,7 +31,6 @@ from threading import RLock
 from threading import Thread
 import logging
 import copy
-from pyblake2 import blake2b
 
 from .equihash import (
     gbp_basic,
@@ -754,7 +753,7 @@ class CBlock(CBlockHeader):
 
     def is_valid(self, n=48, k=5):
         # H(I||...
-        digest = blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
+        digest = hashlib.blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
         digest.update(super(CBlock, self).serialize()[:108])
         hash_nonce(digest, self.nNonce)
         if not gbp_validate(self.nSolution, digest, n, k):
@@ -773,7 +772,7 @@ class CBlock(CBlockHeader):
     def solve(self, n=48, k=5):
         target = uint256_from_compact(self.nBits)
         # H(I||...
-        digest = blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
+        digest = hashlib.blake2b(digest_size=(512//n)*n//8, person=zcash_person(n, k))
         digest.update(super(CBlock, self).serialize()[:108])
         self.nNonce = 0
         while True:

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -254,17 +254,17 @@ TEST(joinsplit, h_sig)
 /*
 // by Taylor Hornby
 
-import pyblake2
 import binascii
+import hashlib
 
 def hSig(randomSeed, nf1, nf2, joinSplitPubKey):
-    return pyblake2.blake2b(
-        data=(randomSeed + nf1 + nf2 + joinSplitPubKey),
+    return hashlib.blake2b(
+        (randomSeed + nf1 + nf2 + joinSplitPubKey),
         digest_size=32,
         person=b"ZcashComputehSig"
     ).digest()
 
-INCREASING = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"
+INCREASING = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"
 
 TEST_VECTORS = [
     [b"a" * 32, b"b" * 32, b"c" * 32, b"d" * 32],
@@ -274,12 +274,12 @@ TEST_VECTORS = [
 ]
 
 for test_input in TEST_VECTORS:
-    print "---"
-    print "\"" + binascii.hexlify(test_input[0][::-1]) + "\""
-    print "\"" + binascii.hexlify(test_input[1][::-1]) + "\""
-    print "\"" + binascii.hexlify(test_input[2][::-1]) + "\""
-    print "\"" + binascii.hexlify(test_input[3][::-1]) + "\""
-    print "\"" + binascii.hexlify(hSig(test_input[0], test_input[1], test_input[2], test_input[3])[::-1]) + "\""
+    print("---")
+    print("\"" + str(binascii.hexlify(test_input[0][::-1])) + "\"")
+    print("\"" + str(binascii.hexlify(test_input[1][::-1])) + "\"")
+    print("\"" + str(binascii.hexlify(test_input[2][::-1])) + "\"")
+    print("\"" + str(binascii.hexlify(test_input[3][::-1])) + "\"")
+    print("\"" + str(binascii.hexlify(hSig(test_input[0], test_input[1], test_input[2], test_input[3])[::-1])) + "\"")
 */
 
     std::vector<std::vector<std::string>> tests = {


### PR DESCRIPTION
Pyblake features are now integrated into the standard "hashlib" module, so `pyblake2` is not required to be installed/imported anymore.