### PR TITLE
Limit mempool size

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -163,6 +163,7 @@ testScripts=(
   'sc_big_commitment_tree_getblockmerkleroot.py',11,25
   'p2p_ignore_spent_tx.py',215,455
   'shieldedpooldeprecation_rpc.py',558,1794
+  'mempool_size_limit.py',121,203
 );
 
 testScriptsExt=(

--- a/qa/rpc-tests/mempool_size_limit.py
+++ b/qa/rpc-tests/mempool_size_limit.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ForkHeights
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
+    get_epoch_data, swap_bytes
+from test_framework.mc_test.mc_test import *
+import os
+import zipfile
+import time
+from decimal import Decimal, ROUND_DOWN
+
+USE_SNAPSHOT = True # set to False to regenerate test data.
+
+DEBUG_MODE = 1
+NUMB_OF_NODES = 2
+EPOCH_LENGTH = 10
+
+FT_SC_FEE      = Decimal('0')
+MBTR_SC_FEE    = Decimal('0')
+CERT_FEE       = Decimal('0.00015')
+PARAMS_NAME = "sc"
+
+NODE0_LIMIT_B = 5000000
+NODE1_LIMIT_B = 4000000
+
+NODE0_CERT_LIMIT_B = NODE0_LIMIT_B / 2
+NODE1_CERT_LIMIT_B = NODE1_LIMIT_B / 2
+
+EPSILON = 100000
+MAX_FEE = Decimal("999999")
+
+NUM_CEASING_SIDECHAINS    = 2
+NUM_NONCEASING_SIDECHAINS = 2
+
+class mempool_size_limit(BitcoinTestFramework):
+    def import_data_to_data_dir(self):
+        # importing datadir resource
+        # Tests checkpoint creation (during startup rescan) and usage, checks everything ok with old wallet
+        resource_file = os.sep.join([os.path.dirname(__file__), 'resources', 'mempool_size_limit', 'test_setup_.zip'])
+        with zipfile.ZipFile(resource_file, 'r') as zip_ref:
+            zip_ref.extractall(self.options.tmpdir)
+
+    def setup_chain(self, split=False):
+        if (USE_SNAPSHOT):
+            self.import_data_to_data_dir()
+            os.remove(self.options.tmpdir+'/node0/regtest/debug.log') # make sure that we have only logs from this test
+            os.remove(self.options.tmpdir+'/node1/regtest/debug.log')
+            os.remove(self.options.tmpdir+'/node0/regtest/wallet.dat')
+            os.remove(self.options.tmpdir+'/node1/regtest/wallet.dat')
+
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args =
+            [
+                ['-debug=cert', '-debug=sc', '-debug=mempool', '-maxorphantx=10000', f'-maxmempool={NODE0_LIMIT_B / 1000000}', '-minconf=0', '-allownonstandardtx'],
+                ['-debug=cert', '-debug=sc', '-debug=mempool', '-maxorphantx=10000', f'-maxmempool={NODE1_LIMIT_B / 1000000}', '-minconf=0', '-allownonstandardtx']
+            ])
+
+        connect_nodes_bi(self.nodes, 0, 1)
+        sync_blocks(self.nodes[1:NUMB_OF_NODES])
+        sync_mempools(self.nodes[1:NUMB_OF_NODES])
+        self.sync_all()
+
+    def satoshi_round(self, amount):
+        return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
+
+    def create_sc_certificates(self, scidx, epoch_number, quality, fee, size):
+        certs = []
+        tot_size = 0
+        raw_bwt_outs = []
+        os.makedirs(self.options.tmpdir + "/certs", exist_ok=True)
+        os.makedirs(self.options.tmpdir + f"/certs/{scidx}", exist_ok=True)
+        for i in range(128):
+            raw_bwt_outs.append({"address":self.nodes[1].getnewaddress(), "amount":Decimal("0.0001")})
+        i = 0
+        while (tot_size < size and len(self.utxos) > 0):
+            t = self.utxos.pop()
+            raw_inputs = [{'txid' : t['txid'], 'vout' : t['vout']}]
+            amt = t["amount"] - fee
+            raw_outs = {self.nodes[0].getnewaddress(): amt}
+
+            sc = self.sc[scidx]
+            scid = sc["id"]
+            epoch_len = sc["epoch_len"]
+            par_name = sc["params"]
+            constant = sc["constant"]
+            ref_height = self.nodes[0].getblockcount()
+            ceasing = True if epoch_len > 0 else False
+
+            scid_swapped = str(swap_bytes(scid))
+            _, epoch_cum_tree_hash, prev_cert_hash = get_epoch_data(scid, self.nodes[0], epoch_len, is_non_ceasing = not ceasing, reference_height = ref_height)
+
+            proof = self.mcTest.create_test_proof(par_name,
+                                             scid_swapped,
+                                             epoch_number,
+                                             quality,
+                                             MBTR_SC_FEE,
+                                             FT_SC_FEE,
+                                             epoch_cum_tree_hash,
+                                             prev_cert_hash,
+                                             constant = constant,
+                                             pks      = [raw_bwt_outs[i]["address"] for i in range(128)],
+                                             amounts  = [raw_bwt_outs[i]["amount"] for i in range(128)])
+
+            raw_params = {
+                "scid": scid,
+                "quality": quality,
+                "endEpochCumScTxCommTreeRoot": epoch_cum_tree_hash,
+                "scProof": proof,
+                "withdrawalEpochNumber": epoch_number
+            }
+
+            raw_cert    = self.nodes[0].createrawcertificate(raw_inputs, raw_outs, raw_bwt_outs, raw_params)
+            signed_cert = self.nodes[0].signrawtransaction(raw_cert)
+            certFile = open(self.options.tmpdir + f"/certs/{scidx}/c_{quality}", "wb")
+            certFile.write(bytes(str(fee) + '\n', encoding='utf8'))
+            certFile.write(bytes(signed_cert["hex"], encoding='utf8'))
+            certFile.close()
+            certs.append({'quality': i, 'fee': fee, 'hex': signed_cert["hex"]})
+            tot_size += len(signed_cert['hex'])//2
+            quality += 1
+            print("Tot cert: " + str(tot_size))
+            i += 1
+            if (epoch_len == 0):
+                return certs
+
+        return certs
+
+    def create_tx_script(self):
+        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
+        # So we have big transactions (and therefore can't fit very many into each block)
+        # create one script_pubkey
+        self.script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
+        for i in range (512):
+            self.script_pubkey = self.script_pubkey + "01"
+
+        #script_pubkey = script_pubkey + signature_imposter
+
+        ## concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+        self.txouts = "80"
+        for k in range(128):
+            # add txout value
+            self.txouts = self.txouts + "b816000000000000"
+            # add length of script_pubkey
+            self.txouts = self.txouts + "fd0402"
+            # add script_pubkey
+            self.txouts = self.txouts + self.script_pubkey
+
+    def load_from_file(self, rFile):
+        fee = Decimal(rFile.readline().decode("utf-8"))
+        hex = rFile.readline().decode("utf-8")
+        return {"fee": fee, "hex": hex}
+
+    def load_from_storage(self, path):
+        res = []
+        certs = "certs" in path
+        for rf in os.listdir(path):
+            rFile = open(path + rf, "rb")
+            entry = self.load_from_file(rFile)
+            if (certs):
+                assert(rf.find("c_") == 0)
+                entry["quality"] = int(rf[2:])
+            res.append(entry)
+            rFile.close()
+        return res
+
+
+    def create_chained_transactions(self):
+        os.makedirs(self.options.tmpdir + "/ctxs")
+        addr = self.nodes[0].getnewaddress()
+        txs = []
+
+        low_fee = Decimal("0.0001")
+        high_fee = Decimal("10")
+        amt = Decimal("0")
+        while (amt < high_fee + low_fee):
+            t = self.utxos.pop()
+            amt = t['amount']
+
+        inputs = []
+        inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+        outputs = {}
+        send_value = t['amount'] - low_fee
+        outputs[addr] = self.satoshi_round(send_value)
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")
+        csize = len(signresult['hex']) // 2
+
+        txFile = open(self.options.tmpdir + "/ctxs/ctx0", "wb")
+        txFile.write(bytes(str((low_fee) / csize) + '\n', encoding='utf8'))
+        txFile.write(bytes(signresult["hex"], encoding='utf8'))
+        txFile.close()
+        txs.append({'fee': high_fee / csize, 'hex': signresult["hex"]})
+
+        ptx = self.nodes[0].decoderawtransaction(signresult["hex"])
+
+        assert(high_fee < t['amount'])
+        inputs = []
+        inputs.append({ "txid" : ptx['txid'], "vout" : 0})
+        outputs = {}
+        send_value = t['amount'] - low_fee - high_fee
+        outputs[self.nodes[0].getnewaddress()] = self.satoshi_round(send_value)
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[0].signrawtransaction(rawtx, [{"txid": ptx['txid'], "vout": 0, "scriptPubKey": ptx['vout'][0]['scriptPubKey']['hex']}], None, "NONE")
+        csize = len(signresult['hex']) // 2
+
+        txFile = open(self.options.tmpdir + "/ctxs/ctx1", "wb")
+        txFile.write(bytes(str(high_fee / csize) + '\n', encoding='utf8'))
+        txFile.write(bytes(signresult["hex"], encoding='utf8'))
+        txFile.close()
+        txs.append({'fee': high_fee / csize, 'hex': signresult["hex"]})
+
+        return txs
+
+    def create_big_transactions(self, size):
+        self.create_tx_script()
+        addr = self.nodes[0].getnewaddress()
+        txs = []
+        tot_size = 0
+        i = 0
+        os.makedirs(self.options.tmpdir + "/txs")
+        while (tot_size < size):
+            t = self.utxos.pop()
+            inputs = []
+            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+            outputs = {}
+            send_value = t['amount']
+            outputs[addr] = self.satoshi_round(send_value)
+            rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+            out_num_pos = rawtx.find('ffffffff')
+            script_position = rawtx.find('76a914')
+            script_length = int(rawtx[script_position - 2 : script_position], 16) * 2
+
+            newtx = rawtx[0:out_num_pos + 8]
+            newtx = newtx + self.txouts
+            newtx = newtx + rawtx[script_position + script_length:]
+
+            signresult = self.nodes[0].signrawtransaction(newtx, None, None, "NONE")
+            tsize = len(signresult['hex']) // 2
+            tot_size += tsize
+            txFile = open(self.options.tmpdir + "/txs/tx" + str(i), "wb")
+            txFile.write(bytes(str(t['amount'] / tsize) + '\n', encoding='utf8'))
+            txFile.write(bytes(signresult["hex"], encoding='utf8'))
+            txFile.close()
+            txs.append({'fee': t['amount'] / tsize, 'hex': signresult["hex"]})
+            i += 1
+        print("Created big transaction for a total size: " + str(tot_size))
+        return txs
+
+    def create_sidechains(self, num, ceasing):
+        # generate wCertVk and constant
+        for i in range(num):
+            newsc = {}
+            constant = generate_random_field_element_hex()
+            ep_len = EPOCH_LENGTH if ceasing else 0
+            par_name = PARAMS_NAME + ("c" if ceasing else "nc") + str(i)
+
+            vk = self.mcTest.generate_params(par_name, keyrot=True)
+
+            # generate sidechain
+            cmdInput = {
+                "version": 2,
+                "withdrawalEpochLength": ep_len,
+                "toaddress": "dada",
+                "amount": Decimal("15"),
+                "wCertVk": vk,
+                "constant": constant,
+            }
+
+            ret = self.nodes[0].sc_create(cmdInput)
+            creating_tx = ret['txid']
+            scid = ret['scid']
+            mark_logs("Node 0 created the SC {} via tx {}.".format(scid, creating_tx), self.nodes, DEBUG_MODE)
+            newsc["id"] = scid
+            newsc["params"] = par_name
+            newsc["constant"] = constant
+            newsc["epoch_len"] = ep_len
+            self.sc.append(newsc)
+
+    def setup_test(self):
+        if USE_SNAPSHOT:
+            txs   = self.load_from_storage(self.options.tmpdir + "/txs/")
+            ctxs  = self.load_from_storage(self.options.tmpdir + "/ctxs/")
+            certs = []
+            for s in range(NUM_CEASING_SIDECHAINS):
+                certs.append(self.load_from_storage(self.options.tmpdir + f"/certs/{s}/"))
+            for s in range(NUM_NONCEASING_SIDECHAINS):
+                certs.append(self.load_from_storage(self.options.tmpdir + f"/certs/{s+NUM_CEASING_SIDECHAINS}/"))
+        else:
+            mark_logs("Node 0 generates {} block".format(ForkHeights['NON_CEASING_SC']), self.nodes, DEBUG_MODE)
+            self.nodes[0].generate(ForkHeights['NON_CEASING_SC'] + 800) # TODO: reduce to match the actual number of utxos needed
+            self.sync_all()
+
+            # forward transfer amounts
+            creation_amount = Decimal("50")
+            small_amount    = Decimal("0.000001")
+
+            ## Create sidechains
+            self.mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+            self.sc = []
+            self.create_sidechains(NUM_CEASING_SIDECHAINS, True)
+            self.create_sidechains(NUM_NONCEASING_SIDECHAINS, False)
+            self.nodes[0].generate(EPOCH_LENGTH) # goto end epoch
+            self.sync_all()
+
+            self.utxos = self.nodes[0].listunspent(0)
+            txs = self.create_big_transactions(NODE0_LIMIT_B + EPSILON)
+            ctxs = self.create_chained_transactions()
+
+            certs = []
+            for i in range(NUM_CEASING_SIDECHAINS):
+                certs.append(self.create_sc_certificates(i, 0, 0, CERT_FEE * (i+1), EPSILON + (NODE0_CERT_LIMIT_B * 2 / NUM_CEASING_SIDECHAINS)))
+
+            for i in range(NUM_NONCEASING_SIDECHAINS):
+                certs.append(self.create_sc_certificates(i+2, 0, 0, CERT_FEE, EPSILON)) # not possible to precompute non ceasing certificates
+
+        return txs, ctxs, certs
+
+    def assert_limits_enforced(self):
+        usage0 = int(self.nodes[0].getmempoolinfo()['bytes'])
+        usage1 = int(self.nodes[1].getmempoolinfo()['bytes'])
+        assert(usage0 < NODE0_LIMIT_B or print(f"Limits are not enforced on node0! {usage0}"))
+        assert(usage1 < NODE1_LIMIT_B or print(f"Limits are not enforced on node1! {usage1}"))
+
+
+    def run_test(self):
+        '''
+        This test checks that the mempool size limitation behaves as expected.
+        The default size limit is 400MB, but can be tweaked with the "-maxmempool" CLI parameter (with a lower bound of
+        4MB). In this test we start 2 nodes, with Node0 having a limit of 5MB, and Node1 with a limit of 4MB.
+        The test fills the nodes' mempools with big transactions first, and then with certificates, checking that the
+        expected elements are evicted, or that new elements are rejected.
+        All the transactions and certificates in the test snapshot do not belong to any wallet in use by either node.
+
+        CHECKLIST:
+        - txs can be added normally until mempool reaches the total size limit
+        - new tx with fee lower than min in mempool is rejected
+        - new tx with fee greater than min in mempool is accepted, min in mempool is evicted
+        - [until txs occupy more than 50% of the mempool capacity] new certificates are accepted, with txs being evicted
+        - [when txs occupy less than 50% of the mempool capacity] new certificate with fee lower than min in mempool is rejected
+        - [when txs occupy less than 50% of the mempool capacity] new certificate with fee higher than min in mempool is accepted, min (possibly for other sc) is evicted
+        - [when txs occupy less than 50% of the mempool capacity] new certificate with fee not higher than min in mempool is rejected (duplicate?)
+
+        Q/A:
+        - should non-ceasing SC certificates be evictable? YES
+        - should we accept a higher quality cert (ceasing SC only) if it evicts a low-qual cert with higher fee? NO
+            - what if the new certificate is the first for a given (non-ceasing?) sidechain? NO
+        - should we consider custom priorities for transactions? NO
+        - should we consider sidechain specific minimum fees? NO
+        '''
+
+        print("Loading snapshot...")
+        txs, ctxs, certs = self.setup_test()
+
+        def feeSort(e):
+            return e['fee']
+        def qualitySort(e):
+            return e['quality']
+        ctxs.sort(key=feeSort)
+        txs.sort(key=feeSort)
+        for c in certs:
+            c.sort(key=qualitySort)
+
+        # ctxs sorted by fee
+        # txs sorted by fee
+        # certs sorted by quality, with certs[0] being low fee, certs[1] high fee, and certs[2] and certs[3] low fee but non ceasing
+
+        print("Starting actual test")
+        # Send chained txs first
+        tx_sent = 0
+        mark_logs("Sending chained transactions", self.nodes, DEBUG_MODE)
+        ctransactions = []
+        while (len(ctxs) > 0):
+            tx = ctxs.pop(0)['hex']
+            ctransactions.append(self.nodes[0].sendrawtransaction(tx, True))
+            txid = self.nodes[0].decoderawtransaction(tx)['txid']
+            txinfo = self.nodes[0].getrawmempool(True)[txid]
+            feerate = txinfo['fee'] / txinfo['size']
+            tx_sent += len(tx)//2
+
+        mark_logs("Filling mempools with more transactions...", self.nodes, DEBUG_MODE)
+        tx_sent_size = 0
+        feerates = {}
+        minfeerate = MAX_FEE
+        mininput = MAX_FEE
+        last_tx_size = 0
+        usage = int(self.nodes[0].getmempoolinfo()['bytes'])
+        while (usage < NODE0_LIMIT_B - (last_tx_size + 10000)):
+            assert(len(txs) > 0)
+            tx = txs.pop(len(txs)//2) # pick from the middle, use avg fee
+            tx_hex = tx['hex']
+            tx_input = tx['fee']
+            txid = self.nodes[0].decoderawtransaction(tx_hex)['txid']
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            txinfo = self.nodes[0].getrawmempool(True)[txid]
+            feerate = txinfo['fee'] / txinfo['size']
+            feerates[txid] = feerate
+            if (feerate < minfeerate):
+                minfeerate = feerate
+            if (tx_input < mininput):
+                mininput = tx_input
+            usage = int(self.nodes[0].getmempoolinfo()['bytes'])
+            last_tx_size = len(tx_hex)//2
+            assert_equal(last_tx_size, txinfo['size'])
+            #assert_equal(Decimal("7.5") - tx_input, txinfo['fee'])
+            tx_sent += last_tx_size
+
+        print(f"Mempool almost full: {usage} out of {NODE0_LIMIT_B}")
+        self.assert_limits_enforced()
+
+        mark_logs("Sending low fee transction, expecting failure", self.nodes, DEBUG_MODE)
+        try:
+            tx = txs.pop(0)
+            tx_hex = tx['hex']
+            tx_input = tx['fee']
+            assert(tx_input <= mininput)
+            txid = self.nodes[0].decoderawtransaction(tx_hex)['txid']
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            assert(False)
+        except JSONRPCException as e:
+            print("Ok")
+
+        self.assert_limits_enforced()
+        mpool = self.nodes[0].getrawmempool()
+        assert(txid not in mpool)
+
+        mark_logs("Sending high fee transaction, expecting success", self.nodes, DEBUG_MODE)
+        try:
+            tx = txs.pop()
+            tx_hex = tx['hex']
+            tx_input = tx['fee']
+            assert(tx_input > mininput)
+            txid = self.nodes[0].decoderawtransaction(tx_hex)['txid']
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            print("Ok")
+        except JSONRPCException as e:
+            assert(False)
+
+        prev_mpool = mpool
+        mpool = self.nodes[0].getrawmempool()
+        assert(txid in mpool)
+        assert_equal(len(mpool), len(prev_mpool))
+
+        self.assert_limits_enforced()
+
+        print("Wait for high fee transaction to be present in node1 mempool")
+        timeout = 5
+        waiting = 0
+        mpool1 = self.nodes[1].getrawmempool()
+        while txid not in mpool1 and waiting < timeout:
+            print("Waiting...")
+            waiting += 1
+            time.sleep(1)
+            mpool1 = self.nodes[1].getrawmempool()
+
+        assert(txid in mpool1)
+        assert(len(mpool1) < len(mpool))
+        for tx1 in mpool1:
+            assert(tx1 in mpool)
+            txinfo = self.nodes[1].getrawmempool(True)[tx1]
+            feerate = txinfo['fee'] / txinfo['size']
+            assert(feerate >= minfeerate or tx1 in ctransactions)
+
+        # make sure that chained transactions, known to have aggregated high fee, have not been evicted
+        for ct in ctransactions:
+            assert(ct in mpool)
+            assert(ct in mpool1)
+
+        mark_logs("Sending low fee non ceasing certificates, expecting success", self.nodes, DEBUG_MODE)
+        nc_certs = [self.nodes[0].sendrawtransaction(certs[2][0]['hex']),
+                    self.nodes[0].sendrawtransaction(certs[3][0]['hex'])]
+        cert_sent_size = (len(certs[2][0]['hex']) + len(certs[3][0]['hex'])) // 2
+        cert_sent = 2
+
+        mark_logs("Filling mpool with low fee certificates, expecting success and transaction eviction", self.nodes, DEBUG_MODE)
+        cert_fees = []
+        highest_quality_sc0 = 0
+        last_cert_size = 0
+        min_sc0_fee = MAX_FEE
+        while (cert_sent_size < NODE0_CERT_LIMIT_B or usage < NODE0_LIMIT_B - last_cert_size):
+            assert(len(certs[0]) > 0)
+            c = certs[0].pop(0)
+            high_quality_cert_sc0 = self.nodes[0].sendrawtransaction(c['hex'])
+            last_cert_size = len(c['hex']) // 2
+            cert_fees.append(c['fee'] / last_cert_size)
+            if (c['fee'] / last_cert_size < min_sc0_fee):
+                min_sc0_fee = c['fee'] / last_cert_size
+            cert_sent_size += last_cert_size
+            cert_sent += 1
+            usage = int(self.nodes[0].getmempoolinfo()['bytes'])
+
+        mark_logs("Sending one more low fee certificate, expecting failure", self.nodes, DEBUG_MODE)
+        try:
+            c = certs[0].pop(0)
+            self.nodes[0].sendrawtransaction(c['hex'])
+            assert(False)
+        except JSONRPCException as e:
+            assert_equal(e.error['code'], -7)
+
+        mark_logs("Sending high fee certificates, expecting success and sc0 low quality certificate eviction", self.nodes, DEBUG_MODE)
+        cert_fees.sort()
+        cert_sent_size = 0
+        cert_sent = 0
+        min_sc1_fee = MAX_FEE
+        while (cert_sent_size < NODE0_CERT_LIMIT_B or usage < NODE0_LIMIT_B - last_cert_size):
+            assert(len(certs[1]) > 0)
+            c = certs[1].pop(0)
+            high_quality_cert_sc1 = self.nodes[0].sendrawtransaction(c['hex'])
+            last_cert_size = len(c['hex']) // 2
+            if (c['fee'] / last_cert_size < min_sc1_fee):
+                min_sc1_fee = c['fee'] / last_cert_size
+            # TODO: this might not really be robust with different datasets.
+            # The ultimate solution might be scanning logs to check the evicted cert
+            cert_fees.pop(0)
+            cert_fees.append(c['fee'] / last_cert_size)
+            cert_sent_size += last_cert_size
+            cert_sent += 1
+            usage = int(self.nodes[0].getmempoolinfo()['bytes'])
+
+        cert_fees.sort()
+
+        mark_logs("Sending one more high fee certificate with lower fee, expecting failure", self.nodes, DEBUG_MODE)
+
+        while len(certs[1]) > 0:
+            c = certs[1].pop(0)
+            cfee = c['fee'] / (len(c['hex']) // 2)
+            try:
+                self.nodes[0].sendrawtransaction(c['hex'])
+                assert(cfee > cert_fees.pop(0))
+            except JSONRPCException as e:
+                assert_equal(e.error['code'], -7)
+                assert(cfee <= cert_fees.pop(0))
+                break
+
+        # TODO: how to sync on node1's mempool?
+        #print("Wait for last certificate to be present in node1 mempool")
+        #timeout = 15
+        #waiting = 0
+        #mpool1 = self.nodes[1].getrawmempool()
+        #while high_quality_cert_sc1 not in mpool1 and waiting < timeout:
+        #    print("Waiting...")
+        #    waiting += 1
+        #    time.sleep(1)
+        #    mpool1 = self.nodes[1].getrawmempool()
+        #assert(high_quality_cert_sc1 in mpool1)
+
+        for i in range(1):
+            print(f"Checking composition of mpool{i}")
+            mpool = self.nodes[i].getrawmempool()
+            print(f"Make sure top quality sc0 cert {high_quality_cert_sc0} is still in")
+            assert(high_quality_cert_sc0 in mpool)
+            for ct in ctransactions:
+                assert(ct in mpool) # make sure that chained transactions, known to be high fee, have not been evicted
+
+        self.assert_limits_enforced()
+        for n in range(2):
+            print(f"Final check on node{n}")
+            tx_size = 0
+            cert_size = 0
+            for txid in self.nodes[n].getrawmempool():
+                txinfo = self.nodes[n].getrawmempool(True)[txid]
+                if (txinfo['isCert']):
+                    cert_size += txinfo['size']
+                else:
+                    tx_size += txinfo['size']
+
+            usage = int(self.nodes[n].getmempoolinfo()['bytes'])
+            node_limit = NODE0_LIMIT_B if n == 0 else NODE1_LIMIT_B
+            node_cert_limit = NODE0_CERT_LIMIT_B if n == 0 else NODE1_CERT_LIMIT_B
+
+            print(f"Transactions are using {tx_size} bytes")
+            print(f"Certificates are using {cert_size} bytes")
+            print(f"Mempool_{n} using {usage} out of {node_limit} bytes")
+
+            assert(tx_size <= node_limit - node_cert_limit)
+            assert(tx_size + cert_size <= node_limit)
+            assert(tx_size + cert_size == usage)
+
+
+if __name__ == '__main__':
+    mempool_size_limit().main()
+

--- a/qa/rpc-tests/mempool_size_limit.py
+++ b/qa/rpc-tests/mempool_size_limit.py
@@ -411,6 +411,7 @@ class mempool_size_limit(BitcoinTestFramework):
             tx_sent += last_tx_size
 
         print(f"Mempool almost full: {usage} out of {NODE0_LIMIT_B}")
+        assert_equal(int(self.nodes[0].getmempoolinfo()['bytes-for-cert']), 0)
         self.assert_limits_enforced()
 
         mpool = self.nodes[0].getrawmempool()
@@ -427,6 +428,7 @@ class mempool_size_limit(BitcoinTestFramework):
             assert_equal(mpool, self.nodes[0].getrawmempool())
             print("Ok")
 
+        assert_equal(int(self.nodes[0].getmempoolinfo()['bytes-for-cert']), 0)
         self.assert_limits_enforced()
         mpool = self.nodes[0].getrawmempool()
         assert(txid not in mpool)
@@ -452,6 +454,7 @@ class mempool_size_limit(BitcoinTestFramework):
         for e in evicted:
             assert(tx_fees[e] <= tx['feerate'])
 
+        assert_equal(int(self.nodes[0].getmempoolinfo()['bytes-for-cert']), 0)
         self.assert_limits_enforced()
 
         print("Wait for high fee transaction to be present in node1 mempool")
@@ -593,7 +596,12 @@ class mempool_size_limit(BitcoinTestFramework):
                 else:
                     tx_size += txinfo['size']
 
-            usage = int(self.nodes[n].getmempoolinfo()['bytes'])
+            mpinfo = self.nodes[n].getmempoolinfo()
+            usage = int(mpinfo['bytes'])
+
+            assert_equal(tx_size, int(mpinfo['bytes-for-tx']))
+            assert_equal(cert_size, int(mpinfo['bytes-for-cert']))
+
             node_limit = NODE0_LIMIT_B if n == 0 else NODE1_LIMIT_B
             node_cert_limit = NODE0_CERT_LIMIT_B if n == 0 else NODE1_CERT_LIMIT_B
 

--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -31,3 +31,24 @@ std::string CFeeRate::ToString() const
 {
     return strprintf("%d.%08d %s/kB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
 }
+
+void CRawFeeRate::operator+=(const CRawFeeRate& rhs) {
+    if (isMax() || rhs.isMax()) {
+        fee   = MAX_FEE;
+        bytes = 1;
+    }
+    else {
+        fee += rhs.fee;
+        bytes += rhs.bytes;
+    }
+    SetSatoshisPerK();
+}
+
+void CRawFeeRate::SetSatoshisPerK() {
+    if (isMax()) {
+        nSatoshisPerK = MAX_FEE;
+    }
+    else {
+        nSatoshisPerK = bytes ? ((1000 * fee) / bytes) : 0;
+    }
+}

--- a/src/gtest/test_cumulativehash.cpp
+++ b/src/gtest/test_cumulativehash.cpp
@@ -5,7 +5,9 @@
 class SidechainsTxCumulativeHashTestSuite: public ::testing::Test
 {
 public:
-    SidechainsTxCumulativeHashTestSuite() = default;
+    SidechainsTxCumulativeHashTestSuite() {
+        mempool.reset(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
+    };
     ~SidechainsTxCumulativeHashTestSuite() = default;
 };
 

--- a/src/gtest/test_getblocktemplate.cpp
+++ b/src/gtest/test_getblocktemplate.cpp
@@ -205,6 +205,7 @@ protected:
     boost::filesystem::path pathTemp;
     GetBlockTemplateTest()
     {
+        mempool.reset(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
         SetupParams();
         GenerateChainActive();
     }
@@ -286,11 +287,11 @@ protected:
         for(const CMutableTransaction& tx : transactions)
         {
             //To be able to control the order of adding transactions in the blocktemplate based on the number of inputs we provide different fees.
-            ASSERT_TRUE(mempool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(tx, tx.getOut(0).nValue/0.9 *0.1, 0, 0.00, 1)));
+            ASSERT_TRUE(mempool->addUnchecked(tx.GetHash(), CTxMemPoolEntry(tx, tx.getOut(0).nValue/0.9 *0.1, 0, 0.00, 1)));
 
         }
 
-        ASSERT_EQ(mempool.size(), transactions.size());
+        ASSERT_EQ(mempool->size(), transactions.size());
     }
 
 protected:

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -98,7 +98,7 @@ TEST_F(MempoolTest, PriorityStatsDoNotCrash) {
     FakeCoinsViewDB fakeDB;
     CCoinsViewCache view(&fakeDB);
 
-    CTxMemPool testPool(CFeeRate(0));
+    CTxMemPool testPool(CFeeRate(0), DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
 
     // Values taken from core dump (parameters of entry)
     CAmount nFees = 0;
@@ -116,7 +116,7 @@ TEST_F(MempoolTest, PriorityStatsDoNotCrash) {
 
 TEST_F(MempoolTest, TxInputLimit) {
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
 
     boost::filesystem::path pathTemp(boost::filesystem::temp_directory_path() / boost::filesystem::unique_path());
     boost::filesystem::create_directories(pathTemp);
@@ -203,7 +203,7 @@ TEST_F(MempoolTest, TxInputLimit) {
 TEST_F(MempoolTest, OverwinterNotActiveYet) {
     // UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     bool missingInputs;
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vjoinsplit.resize(0); // no joinsplits
@@ -234,7 +234,7 @@ TEST_F(MempoolTest, SproutV3TxFailsAsExpected) {
     CCoinsViewDB* pChainStateDb = new CCoinsViewDB(chainStateDbSize, DEFAULT_DB_MAX_OPEN_FILES, false, /*fWipe*/true);
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CMutableTransaction mtx = GetValidTransaction(GROTH_TX_VERSION);
     mtx.vjoinsplit.resize(0); // no joinsplits
     CValidationState state1;
@@ -270,7 +270,7 @@ TEST_F(MempoolTest, SproutV3TxWhenGrothNotActive) {
     pcoinsTip = new CCoinsViewCache(pChainStateDb);
 
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CMutableTransaction mtx = GetValidTransaction(GROTH_TX_VERSION);
     mtx.vjoinsplit.resize(0); // no joinsplits
 
@@ -308,7 +308,7 @@ TEST_F(MempoolTest, SproutNegativeVersionTx) {
     chainSettingUtils::ExtendChainActiveToHeight(100);
     pcoinsTip->SetBestBlock(chainActive.Tip()->GetBlockHash());
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CMutableTransaction mtx = GetValidTransaction();
     mtx.vjoinsplit.resize(0); // no joinsplits
 
@@ -447,7 +447,7 @@ TEST(ProcessMempoolMsgTest, TxesInMempoolAreRelayed)
 {
     SelectParams(CBaseChainParams::REGTEST);
 
-    CTxMemPool aMempool(::minRelayTxFee);
+    CTxMemPool aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
 
     // Populate mempool with a tx and a cert
     CTransaction scTx = txCreationUtils::createNewSidechainTxWith(CAmount(0), /*epochLength*/0);

--- a/src/gtest/test_sidechain.cpp
+++ b/src/gtest/test_sidechain.cpp
@@ -1631,7 +1631,7 @@ TEST_F(SidechainsTestSuite, GetScIdsOnChainstateDbSelectOnlySidechains) {
 ////////////////////////////////// GetSidechain /////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////
 TEST_F(SidechainsTestSuite, GetSidechainForFwdTransfersInMempool) {
-    CTxMemPool aMempool(CFeeRate(1));
+    CTxMemPool aMempool(CFeeRate(1), DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
 
     //Confirm a Sidechain
     CAmount creationAmount = 10;
@@ -1679,7 +1679,7 @@ TEST_F(SidechainsTestSuite, GetSidechainForFwdTransfersInMempool) {
 }
 
 TEST_F(SidechainsTestSuite, GetSidechainForScCreationInMempool) {
-    CTxMemPool aMempool(CFeeRate(1));
+    CTxMemPool aMempool(CFeeRate(1), DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
 
     //Confirm a Sidechain
     CAmount creationAmount = 10;

--- a/src/gtest/test_sidechain_certificate_quality.cpp
+++ b/src/gtest/test_sidechain_certificate_quality.cpp
@@ -546,7 +546,7 @@ TEST_F(SidechainsMultipleCertsTestSuite, CheckAcceptsLowerQualityCertsInDifferen
 }
 
 TEST_F(SidechainsMultipleCertsTestSuite, CheckInMempoolDelegateToBackingView) {
-    CTxMemPool aMempool(::minRelayTxFee);
+    CTxMemPool aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CCoinsViewMemPool viewMempool(sidechainsView, aMempool);
 
     CSidechain initialScState;
@@ -584,7 +584,7 @@ TEST_F(SidechainsMultipleCertsTestSuite, CheckInMempoolDelegateToBackingView) {
 }
 
 TEST_F(SidechainsMultipleCertsTestSuite, CertsInMempoolDoNotAffectCheckQuality) {
-    CTxMemPool aMempool(::minRelayTxFee);
+    CTxMemPool aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CCoinsViewMemPool viewMempool(sidechainsView, aMempool);
 
     CSidechain initialScState;

--- a/src/gtest/test_sidechain_certificate_quality.cpp
+++ b/src/gtest/test_sidechain_certificate_quality.cpp
@@ -546,8 +546,8 @@ TEST_F(SidechainsMultipleCertsTestSuite, CheckAcceptsLowerQualityCertsInDifferen
 }
 
 TEST_F(SidechainsMultipleCertsTestSuite, CheckInMempoolDelegateToBackingView) {
-    CTxMemPool aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
-    CCoinsViewMemPool viewMempool(sidechainsView, aMempool);
+    std::shared_ptr<CTxMemPool> aMempool(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
+    CCoinsViewMemPool viewMempool(sidechainsView, *aMempool);
 
     CSidechain initialScState;
     initialScState.balance = CAmount(10);
@@ -584,8 +584,8 @@ TEST_F(SidechainsMultipleCertsTestSuite, CheckInMempoolDelegateToBackingView) {
 }
 
 TEST_F(SidechainsMultipleCertsTestSuite, CertsInMempoolDoNotAffectCheckQuality) {
-    CTxMemPool aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
-    CCoinsViewMemPool viewMempool(sidechainsView, aMempool);
+    std::shared_ptr<CTxMemPool> aMempool(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
+    CCoinsViewMemPool viewMempool(sidechainsView, *aMempool);
 
     CSidechain initialScState;
     initialScState.balance = CAmount(10);
@@ -603,7 +603,7 @@ TEST_F(SidechainsMultipleCertsTestSuite, CertsInMempoolDoNotAffectCheckQuality) 
     mempoolCert.quality = initialScState.lastTopQualityCertQuality * 2;
     mempoolCert.epochNumber = initialScState.lastTopQualityCertReferencedEpoch + 1 ;
     CCertificateMemPoolEntry certEntry(mempoolCert, /*fee*/CAmount(5), /*time*/ 1000, /*priority*/1.0, /*height*/1987);
-    ASSERT_TRUE(aMempool.addUnchecked(mempoolCert.GetHash(), certEntry));
+    ASSERT_TRUE(aMempool->addUnchecked(mempoolCert.GetHash(), certEntry));
 
     CMutableScCertificate trialCert;
     trialCert.scId = scId;

--- a/src/gtest/test_sidechain_to_mempool.cpp
+++ b/src/gtest/test_sidechain_to_mempool.cpp
@@ -46,7 +46,7 @@ public:
 class SidechainsInMempoolTestSuite: public ::testing::Test {
 public:
     SidechainsInMempoolTestSuite():
-        aMempool(::minRelayTxFee),
+        aMempool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000),
         pathTemp(boost::filesystem::temp_directory_path() / boost::filesystem::unique_path()),
         chainStateDbSize(2 * 1024 * 1024),
         pChainStateDb(nullptr),

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -668,7 +668,7 @@ MempoolReturnValue BlockchainTestManager::TestAcceptTxToMemoryPool(CValidationSt
 {
     CCoinsViewCache* saved_pcoinsTip = pcoinsTip;
 
-    CTxMemPool pool(::minRelayTxFee);
+    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     pcoinsTip = viewCache.get();
     pcoinsTip->SetBestBlock(chainActive.Tip()->GetBlockHash());
     pindexBestHeader = chainActive.Tip();

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -668,7 +668,7 @@ MempoolReturnValue BlockchainTestManager::TestAcceptTxToMemoryPool(CValidationSt
 {
     CCoinsViewCache* saved_pcoinsTip = pcoinsTip;
 
-    CTxMemPool pool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
+    std::unique_ptr<CTxMemPool> pool(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
     pcoinsTip = viewCache.get();
     pcoinsTip->SetBestBlock(chainActive.Tip()->GetBlockHash());
     pindexBestHeader = chainActive.Tip();
@@ -676,7 +676,7 @@ MempoolReturnValue BlockchainTestManager::TestAcceptTxToMemoryPool(CValidationSt
     CCoinsViewCache view(pcoinsTip);
 
     LOCK(cs_main);
-    MempoolReturnValue val = AcceptTxToMemoryPool(pool, state, tx, LimitFreeFlag::OFF, RejectAbsurdFeeFlag::OFF, MempoolProofVerificationFlag::SYNC);
+    MempoolReturnValue val = AcceptTxToMemoryPool(*pool, state, tx, LimitFreeFlag::OFF, RejectAbsurdFeeFlag::OFF, MempoolProofVerificationFlag::SYNC);
 
     pcoinsTip = saved_pcoinsTip;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -359,6 +359,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-mempooltxinputlimit=<n>", _("Set the maximum number of transparent inputs in a transaction that the mempool will accept (default: 0 = no limit applied)"));
+    strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE_MB));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32
@@ -1094,6 +1095,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     mempool.setSanityCheck(GetBoolArg("-checkmempool", chainparams.DefaultConsistencyChecks()));
     fCheckBlockIndex = GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = GetBoolArg("-checkpoints", true);
+
+    // -mempoollimit limits
+    int64_t nMempoolSizeLimit = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE_MB) * 1000000;
+    if (nMempoolSizeLimit < 4 * 1000000) {
+        return InitError(strprintf(_("Error: -maxmempool must be at least %d MB"), 4));
+    }
+    mempool.setMaxSize(nMempoolSizeLimit);
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);

--- a/src/main.h
+++ b/src/main.h
@@ -135,6 +135,8 @@ static const bool DEFAULT_ADDRESSINDEX = false;
 static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const bool DEFAULT_SPENTINDEX = false;
 
+static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB = 400;
+
 // Sanity check the magic numbers when we change them
 BOOST_STATIC_ASSERT(DEFAULT_BLOCK_MAX_SIZE <= MAX_BLOCK_SIZE);
 BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE > MAX_CERT_SIZE);
@@ -369,7 +371,7 @@ void alertNotify(const std::string& strMessage, bool fThread);
 // Accept Tx/Cert ToMempool parameters types and signature
 enum class LimitFreeFlag       { ON, OFF };
 enum class RejectAbsurdFeeFlag { ON, OFF };
-enum class MempoolReturnValue  { INVALID, MISSING_INPUT, VALID, PARTIALLY_VALIDATED };
+enum class MempoolReturnValue  { INVALID, MISSING_INPUT, MEMPOOL_FULL, VALID, PARTIALLY_VALIDATED };
 
 /**
  * @brief The enumeration of possible states of the sidechain proof verification

--- a/src/main.h
+++ b/src/main.h
@@ -151,7 +151,7 @@ BOOST_STATIC_ASSERT(DEFAULT_BLOCK_PRIORITY_SIZE_BEFORE_SC <= DEFAULT_BLOCK_MAX_S
 
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
-extern CTxMemPool mempool;
+extern std::unique_ptr<CTxMemPool> mempool;
 typedef boost::unordered_map<uint256, CBlockIndex*, ObjectHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 typedef boost::unordered_map<uint256, int, ObjectHasher> ScCumTreeRootMap;

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -225,7 +225,7 @@ int printStats(bool mining)
         connections = vNodes.size();
         tlsConnections = std::count_if(vNodes.begin(), vNodes.end(), [](CNode* n) {return n->ssl != NULL;});
     }
-    unsigned long mempool_count = mempool.size();
+    unsigned long mempool_count = mempool->size();
 /*
     // OpenSSL related statistics
     tlsvalidate = GetArg("-tlsvalidate","");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -491,13 +491,13 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     std::string bitmapStringRepresentation;
     boost::dynamic_bitset<unsigned char> hits(vOutPoints.size());
     {
-        LOCK2(cs_main, mempool.cs);
+        LOCK2(cs_main, mempool->cs);
 
         CCoinsView viewDummy;
         CCoinsViewCache view(&viewDummy);
 
         CCoinsViewCache& viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CCoinsViewMemPool viewMempool(&viewChain, *mempool);
 
         if (fCheckMemPool)
             view.SetBackend(viewMempool); // switch cache backend to db+mempool in case user likes to query mempool
@@ -506,7 +506,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
             CCoins coins;
             uint256 hash = vOutPoints[i].hash;
             if (view.GetCoins(hash, coins)) {
-                mempool.pruneSpent(hash, coins);
+                mempool->pruneSpent(hash, coins);
                 if (coins.IsAvailable(vOutPoints[i].n)) {
                     hits[i] = true;
                     // Safe to index into vout here because IsAvailable checked if it's off the end of the array, or if

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1414,9 +1414,12 @@ UniValue mempoolInfoToJSON()
     ret.pushKV("size", (int64_t) mempool->size());
     ret.pushKV("bytes", (int64_t) mempool->GetTotalSize());
     ret.pushKV("usage", (int64_t) mempool->DynamicMemoryUsage());
+    ret.pushKV("bytes-for-tx", (int64_t) mempool->GetTotalTxSize());
+    ret.pushKV("bytes-for-cert", (int64_t) mempool->GetTotalCertificateSize());
 
     if (Params().NetworkIDString() == "regtest") {
         ret.pushKV("fullyNotified", mempool->IsFullyNotified());
+        assert(mempool->GetTotalSize() == mempool->GetTotalTxSize() + mempool->GetTotalCertificateSize());
     }
 
     return ret;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -380,7 +380,7 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
 
 static void AddDependancy(const CTransactionBase& root, UniValue& info)
 {
-    std::vector<uint256> sDepHash = mempool.mempoolDirectDependenciesFrom(root);
+    std::vector<uint256> sDepHash = mempool->mempoolDirectDependenciesFrom(root);
     UniValue depends(UniValue::VARR);
     for(const uint256& hash: sDepHash)
     {
@@ -394,9 +394,9 @@ UniValue mempoolToJSON(bool fVerbose = false)
 {
     if (fVerbose)
     {
-        LOCK(mempool.cs);
+        LOCK(mempool->cs);
         UniValue o(UniValue::VOBJ);
-        BOOST_FOREACH(const PAIRTYPE(uint256, CTxMemPoolEntry)& entry, mempool.mapTx)
+        BOOST_FOREACH(const PAIRTYPE(uint256, CTxMemPoolEntry)& entry, mempool->mapTx)
         {
             const uint256& hash = entry.first;
             const CTxMemPoolEntry& e = entry.second;
@@ -413,7 +413,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             AddDependancy(tx, info);
             o.pushKV(hash.ToString(), info);
         }
-        BOOST_FOREACH(const PAIRTYPE(uint256, CCertificateMemPoolEntry)& entry, mempool.mapCertificate)
+        BOOST_FOREACH(const PAIRTYPE(uint256, CCertificateMemPoolEntry)& entry, mempool->mapCertificate)
         {
             const uint256& hash = entry.first;
             const auto& e = entry.second;
@@ -430,7 +430,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             AddDependancy(cert, info);
             o.pushKV(hash.ToString(), info);
         }
-        BOOST_FOREACH(const auto& entry, mempool.mapDeltas)
+        BOOST_FOREACH(const auto& entry, mempool->mapDeltas)
         {
             const uint256& hash = entry.first;
             const auto& p = entry.second.first;
@@ -447,7 +447,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
     else
     {
         vector<uint256> vtxid;
-        mempool.queryHashes(vtxid);
+        mempool->queryHashes(vtxid);
 
         UniValue a(UniValue::VARR);
         BOOST_FOREACH(const uint256& hash, vtxid)
@@ -1104,11 +1104,11 @@ UniValue gettxout(const UniValue& params, bool fHelp)
 
     CCoins coins;
     if (fMempool) {
-        LOCK(mempool.cs);
-        CCoinsViewMemPool view(pcoinsTip, mempool);
+        LOCK(mempool->cs);
+        CCoinsViewMemPool view(pcoinsTip, *mempool);
         if (!view.GetCoins(hash, coins))
             return NullUniValue;
-        mempool.pruneSpent(hash, coins); // TODO: this should be done by the CCoinsViewMemPool
+        mempool->pruneSpent(hash, coins); // TODO: this should be done by the CCoinsViewMemPool
     } else {
         if (!pcoinsTip->GetCoins(hash, coins))
             return NullUniValue;
@@ -1411,12 +1411,12 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 UniValue mempoolInfoToJSON()
 {
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("size", (int64_t) mempool.size());
-    ret.pushKV("bytes", (int64_t) mempool.GetTotalSize());
-    ret.pushKV("usage", (int64_t) mempool.DynamicMemoryUsage());
+    ret.pushKV("size", (int64_t) mempool->size());
+    ret.pushKV("bytes", (int64_t) mempool->GetTotalSize());
+    ret.pushKV("usage", (int64_t) mempool->DynamicMemoryUsage());
 
     if (Params().NetworkIDString() == "regtest") {
-        ret.pushKV("fullyNotified", mempool.IsFullyNotified());
+        ret.pushKV("fullyNotified", mempool->IsFullyNotified());
     }
 
     return ret;
@@ -1531,14 +1531,14 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
 
 static void addScUnconfCcData(const uint256& scId, UniValue& sc)
 {
-    if (mempool.mapSidechains.count(scId) == 0)
+    if (mempool->mapSidechains.count(scId) == 0)
         return;
 
     UniValue ia(UniValue::VARR);
-    if (mempool.hasSidechainCreationTx(scId))
+    if (mempool->hasSidechainCreationTx(scId))
     {
-        const uint256& hash = mempool.mapSidechains.at(scId).scCreationTxHash;
-        const CTransaction & scCrTx = mempool.mapTx.at(hash).GetTx();
+        const uint256& hash = mempool->mapSidechains.at(scId).scCreationTxHash;
+        const CTransaction & scCrTx = mempool->mapTx.at(hash).GetTx();
         for (const auto& scCrAmount : scCrTx.GetVscCcOut())
         {
             if (scId == scCrAmount.GetScId())
@@ -1550,9 +1550,9 @@ static void addScUnconfCcData(const uint256& scId, UniValue& sc)
         }
     }
 
-    for (const auto& fwdHash: mempool.mapSidechains.at(scId).fwdTxHashes)
+    for (const auto& fwdHash: mempool->mapSidechains.at(scId).fwdTxHashes)
     {
-        const CTransaction & fwdTx = mempool.mapTx.at(fwdHash).GetTx();
+        const CTransaction & fwdTx = mempool->mapTx.at(fwdHash).GetTx();
         for (const auto& fwdAmount : fwdTx.GetVftCcOut())
         {
             if (scId == fwdAmount.scId)
@@ -1564,9 +1564,9 @@ static void addScUnconfCcData(const uint256& scId, UniValue& sc)
         }
     }
 
-    for (const auto& mbtrHash: mempool.mapSidechains.at(scId).mcBtrsTxHashes)
+    for (const auto& mbtrHash: mempool->mapSidechains.at(scId).mcBtrsTxHashes)
     {
-        const CTransaction & mbtrTx = mempool.mapTx.at(mbtrHash).GetTx();
+        const CTransaction & mbtrTx = mempool->mapTx.at(mbtrHash).GetTx();
         for (const auto& mbtrAmount : mbtrTx.GetVBwtRequestOut())
         {
             if (scId == mbtrAmount.scId)
@@ -1692,10 +1692,10 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
         sc.pushKV("scFees", sf);
 
         // get unconfirmed data if any
-        if (mempool.hasSidechainCertificate(scId))
+        if (mempool->hasSidechainCertificate(scId))
         {
-            const uint256& topQualCertHash    = mempool.mapSidechains.at(scId).GetTopQualityCert()->second;
-            const CScCertificate& topQualCert = mempool.mapCertificate.at(topQualCertHash).GetCertificate();
+            const uint256& topQualCertHash    = mempool->mapSidechains.at(scId).GetTopQualityCert()->second;
+            const CScCertificate& topQualCert = mempool->mapCertificate.at(topQualCertHash).GetCertificate();
  
             sc.pushKV("unconfTopQualityCertificateEpoch",    topQualCert.epochNumber);
             sc.pushKV("unconfTopQualityCertificateHash",     topQualCertHash.GetHex());
@@ -1708,10 +1708,10 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
     }
     else
     {
-        if (mempool.hasSidechainCreationTx(scId))
+        if (mempool->hasSidechainCreationTx(scId))
         {
-            const uint256& scCreationHash = mempool.mapSidechains.at(scId).scCreationTxHash;
-            const CTransaction & scCreationTx = mempool.mapTx.at(scCreationHash).GetTx();
+            const uint256& scCreationHash = mempool->mapSidechains.at(scId).scCreationTxHash;
+            const CTransaction & scCreationTx = mempool->mapTx.at(scCreationHash).GetTx();
 
             CSidechain info;
             for (const auto& scCreation : scCreationTx.GetVscCcOut())
@@ -1803,8 +1803,8 @@ int FillScList(UniValue& scItems, bool bOnlyAlive, bool bVerbose, int from=0, in
 {
     std::set<uint256> sScIds;
     {
-        LOCK(mempool.cs);
-        CCoinsViewMemPool scView(pcoinsTip, mempool);
+        LOCK(mempool->cs);
+        CCoinsViewMemPool scView(pcoinsTip, *mempool);
 
         scView.GetScIds(sScIds);
     }
@@ -2597,13 +2597,13 @@ UniValue getcertmaturityinfo(const UniValue& params, bool fHelp)
     CScCertificate certOut;
 
     {
-        LOCK(mempool.cs);
-        if (mempool.lookup(hash, certOut))
+        LOCK(mempool->cs);
+        if (mempool->lookup(hash, certOut))
         {
             ret.pushKV("maturityHeight", -1);
             ret.pushKV("blocksToMaturity", -1);
             std::string s;
-            mempool.CertQualityStatusString(certOut, s);
+            mempool->CertQualityStatusString(certOut, s);
             ret.pushKV("certificateState", s);
             return ret;
         }
@@ -2697,7 +2697,7 @@ UniValue clearmempool(const UniValue& params, bool fHelp)
     }
 
     LOCK(cs_main);
-    mempool.clear();
+    mempool->clear();
 
     return NullUniValue;
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -355,8 +355,8 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.pushKV("localsolps"  ,     getlocalsolps(params, false));
     obj.pushKV("networksolps",     getnetworksolps(params, false));
     obj.pushKV("networkhashps",    getnetworksolps(params, false));
-    obj.pushKV("pooledtx",         (uint64_t)mempool.sizeTx());
-    obj.pushKV("pooledcert",       (uint64_t)mempool.sizeCert());
+    obj.pushKV("pooledtx",         (uint64_t)mempool->sizeTx());
+    obj.pushKV("pooledcert",       (uint64_t)mempool->sizeCert());
     obj.pushKV("testnet",          Params().TestnetToBeDeprecatedFieldRPC());
     obj.pushKV("chain",            Params().NetworkIDString());
 #ifdef ENABLE_MINING
@@ -396,7 +396,7 @@ UniValue prioritisetransaction(const UniValue& params, bool fHelp)
     uint256 hash = ParseHashStr(params[0].get_str(), "txid");
     CAmount nAmount = params[2].get_int64();
 
-    mempool.PrioritiseTransaction(hash, params[0].get_str(), params[1].get_real(), nAmount);
+    mempool->PrioritiseTransaction(hash, params[0].get_str(), params[1].get_real(), nAmount);
     return true;
 }
 
@@ -603,7 +603,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
                 if (!cvBlockChange.timed_wait(lock, checktxtime))
                 {
                     // Timeout: Check transactions for update
-                    if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
+                    if (mempool->GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
                         break;
                     checktxtime += boost::posix_time::seconds(10);
                 }
@@ -621,13 +621,13 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     static int64_t nStart;
     static CBlockTemplate* pblocktemplate;
     if (pindexPrev != chainActive.Tip() ||
-        (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+        (mempool->GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = NULL;
 
         // Store the pindexBest used before CreateNewBlockWithKey, to avoid races
-        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
+        nTransactionsUpdatedLast = mempool->GetTransactionsUpdated();
         CBlockIndex* pindexPrevNew = chainActive.Tip();
         nStart = GetTime();
 
@@ -905,7 +905,7 @@ UniValue estimatefee(const UniValue& params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
-    CFeeRate feeRate = mempool.estimateFee(nBlocks);
+    CFeeRate feeRate = mempool->estimateFee(nBlocks);
     if (feeRate == CFeeRate(0))
         return -1.0;
 
@@ -941,7 +941,7 @@ UniValue estimatepriority(const UniValue& params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
-    return mempool.estimatePriority(nBlocks);
+    return mempool->estimatePriority(nBlocks);
 }
 
 UniValue getblocksubsidy(const UniValue& params, bool fHelp)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -590,7 +590,7 @@ UniValue getaddressmempool(const UniValue& params, bool fHelp)
     }
 
     std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > indexes;
-    if (!mempool.getAddressIndex(addresses, indexes)) {
+    if (!mempool->getAddressIndex(addresses, indexes)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1856,6 +1856,11 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 
                 throw JSONRPCError(RPC_TRANSACTION_ERROR, state.GetRejectReason());
             }
+
+            if (res == MempoolReturnValue::MEMPOOL_FULL)
+            {
+                throw JSONRPCError(RPC_OUT_OF_MEMORY, "mempool full, transaction not accepted to mempool");
+            }
         } else if (fHaveChain)
             throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
 
@@ -1891,6 +1896,11 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
                             strprintf("%i: %s", CValidationState::CodeToChar(state.GetRejectCode()), state.GetRejectReason()));
 
                 throw JSONRPCError(RPC_TRANSACTION_ERROR, "certificate not accepted to mempool");
+            }
+
+            if (res == MempoolReturnValue::MEMPOOL_FULL)
+            {
+                throw JSONRPCError(RPC_OUT_OF_MEMORY, "mempool full, certificate not accepted to mempool");
             }
         }
         else if (fHaveChain)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1544,9 +1544,9 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
     std::vector<CTxIn> txInputs = (txVersion != SC_CERT_VERSION) ? txVariants[0].vin : certificate.vin;
     // Fetch previous transactions (inputs):
     {
-        LOCK(mempool.cs);
+        LOCK(mempool->cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CCoinsViewMemPool viewMempool(&viewChain, *mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         BOOST_FOREACH(const CTxIn& txin, txInputs) {
@@ -1836,13 +1836,13 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
     if (txVersion != SC_CERT_VERSION) {
         uint256 hashTx = tx.GetHash();
         const CCoins* existingCoins = view.AccessCoins(hashTx);
-        bool fHaveMempool = mempool.exists(hashTx);
+        bool fHaveMempool = mempool->exists(hashTx);
         bool fHaveChain = existingCoins && existingCoins->nHeight < 1000000000;
         if (!fHaveMempool && !fHaveChain)
         {
             // push to local node and sync with wallets
             CValidationState state;
-            MempoolReturnValue res = AcceptTxToMemoryPool(mempool, state, tx, LimitFreeFlag::OFF, fRejectAbsurdFee,
+            MempoolReturnValue res = AcceptTxToMemoryPool(*mempool, state, tx, LimitFreeFlag::OFF, fRejectAbsurdFee,
                                                           MempoolProofVerificationFlag::SYNC);
 
             if (res == MempoolReturnValue::MISSING_INPUT)
@@ -1871,7 +1871,7 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
         const CCoins* existingCoins = view.AccessCoins(hashCertificate);
         // check that we do not have it already somewhere
         bool fHaveChain = existingCoins;
-        bool fHaveMempool = mempool.existsCert(hashCertificate);
+        bool fHaveMempool = mempool->existsCert(hashCertificate);
 
         if (!fHaveMempool && !fHaveChain)
         {
@@ -1884,7 +1884,7 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
                 flag = MempoolProofVerificationFlag::DISABLED;
             }
 
-            MempoolReturnValue res = AcceptCertificateToMemoryPool(mempool, state, cert, LimitFreeFlag::OFF, fRejectAbsurdFee, flag);
+            MempoolReturnValue res = AcceptCertificateToMemoryPool(*mempool, state, cert, LimitFreeFlag::OFF, fRejectAbsurdFee, flag);
 
             if (res == MempoolReturnValue::MISSING_INPUT)
                 throw JSONRPCError(RPC_TRANSACTION_ERROR, "Missing inputs");

--- a/src/sc/sidechainrpc.cpp
+++ b/src/sc/sidechainrpc.cpp
@@ -1130,7 +1130,7 @@ bool ScRpcCmd::checkFeeRate()
     // This value is anyway not lower than minRelayFee.
 
     // Therefore, using default values, the fee needed is the one corresponding to the minTxFee rate of 1000 Zat / Kbyte
-    _feeNeeded = CWallet::GetMinimumFee(nSize, nTxConfirmTarget, mempool);
+    _feeNeeded = CWallet::GetMinimumFee(nSize, nTxConfirmTarget, *mempool);
 
     if (_fee < _feeNeeded)
     {

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     }
 
 
-    CTxMemPool testPool(CFeeRate(0));
+    CTxMemPool testPool(CFeeRate(0), DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     std::list<CTransaction>   removedTxs;
     std::list<CScCertificate> removedCerts;
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -6,6 +6,7 @@
 #include "txmempool.h"
 #include "uint256.h"
 #include "util.h"
+#include "main.h" // DEFAULT_MAX_MEMPOOL_SIZE_MB
 
 #include "test/test_bitcoin.h"
 
@@ -15,7 +16,7 @@ BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {
-    CTxMemPool mpool(CFeeRate(1000));
+    CTxMemPool mpool(CFeeRate(1000), DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000);
     CAmount basefee(2000);
     double basepri = 1e6;
     CAmount deltaFee(100);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -83,6 +83,7 @@ TestingSetup::TestingSetup()
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
+        mempool.reset(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
         pblocktree = new CBlockTreeDB(1 << 20, DEFAULT_DB_MAX_OPEN_FILES, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, DEFAULT_DB_MAX_OPEN_FILES, true);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -17,8 +17,8 @@
 #include "validationinterface.h"
 #include <undo.h>
 
-#include <vector>
 #include <stack>
+#include <unordered_set>
 
 CMemPoolEntry::CMemPoolEntry():
     nFee(0), nModSize(0), nUsageSize(0), nTime(0), dPriority(0.0)
@@ -609,13 +609,13 @@ std::vector<uint256> CTxMemPool::mempoolDependenciesOf(const CTransactionBase& o
     return res;
 }
 
-CRawFeeRate CTxMemPool::avgFeeRateWithDeps(const uint256& rootTx, const bool certificatesAllowed, std::map<uint256, CRawFeeRate>& cache) const
+CRawFeeRate CTxMemPool::avgFeeRateWithDeps(const uint256& rootTx, const bool certificatesAllowed, std::unordered_map<uint256, CRawFeeRate>& cache) const
 {
     // depth first graph traversal with cache
 
     CRawFeeRate res;
     std::stack<std::pair<uint256, bool>> to_visit;
-    std::set<uint256> already_visited;
+    std::unordered_set<uint256> already_visited;
     to_visit.push({rootTx, false});
     while (!to_visit.empty()) {
         std::pair<uint256, bool>& curr = to_visit.top();
@@ -2088,7 +2088,7 @@ bool CTxMemPool::trimToSize(const CMemPoolEntry* entry, size_t max_size) {
     // we must either reject incoming tx, or remove something
     int64_t size_to_be_removed = current_usage + new_entry_usage - max_size;
     std::multimap<CRawFeeRate, uint256> raw_fee_rates;
-    std::map<uint256, CRawFeeRate> rates_cache;
+    std::unordered_map<uint256, CRawFeeRate> rates_cache;
     const bool certificatesAllowed = certificate || totalCertificateSize > m_max_size / 2;
     LogPrint("mempool", "%s():%d - Trying to remove something to make room (certificatesAllowed: %d, size: %d)\n", __func__, __LINE__, certificatesAllowed, size_to_be_removed);
     for (const auto& tx: mapTx) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1115,7 +1115,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
 
         const uint256& txHash = cswNullifierTx->second;
         const auto& it = mapTx.find(txHash);
-        // If CSW nullifier was present in cswNullifers, the containing tx must be present in the mempool.
+        // If CSW nullifier was present in cswNullifers, the containing tx must be present in the mempool->
         assert(it != mapTx.end());
 
         const CTransaction &txConflict = it->second.GetTx();
@@ -1144,7 +1144,7 @@ void CTxMemPool::removeStaleTransactions(const CCoinsViewCache * const pCoinsVie
 
         for(const CTxForwardTransferOut& ft: tx.GetVftCcOut())
         {
-            // pCoinsView does not encompass mempool.
+            // pCoinsView does not encompass mempool->
             // Hence we need to checks explicitly for unconfirmed scCreations
             if (hasSidechainCreationTx(ft.scId))
                 continue;
@@ -1158,7 +1158,7 @@ void CTxMemPool::removeStaleTransactions(const CCoinsViewCache * const pCoinsVie
 
         for(const CBwtRequestOut& mbtr: tx.GetVBwtRequestOut())
         {
-            // pCoinsView does not encompass mempool.
+            // pCoinsView does not encompass mempool->
             // Hence we need to checks explicitly for unconfirmed scCreations
             if (hasSidechainCreationTx(mbtr.scId))
                 continue;
@@ -1554,7 +1554,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             CValidationState state;
             assert(::ContextualCheckCertInputs(cert, state, mempoolDuplicateCert, false, chainActive, 0, false, Params().GetConsensus(), NULL));
             CTxUndo dummyUndo;
-            bool isTopQualityCert = mempool.mapSidechains.at(cert.GetScId()).GetTopQualityCert()->second == cert.GetHash();
+            bool isTopQualityCert = mempool->mapSidechains.at(cert.GetScId()).GetTopQualityCert()->second == cert.GetHash();
             UpdateCoins(cert, mempoolDuplicateCert, dummyUndo, 1000000, isTopQualityCert);
         }
     }
@@ -1572,7 +1572,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             const CScCertificate& cert = entry->GetCertificate();
             assert(::ContextualCheckCertInputs(cert, state, mempoolDuplicateCert, false, chainActive, 0, false, Params().GetConsensus(), NULL));
             CTxUndo dummyUndo;
-            bool isTopQualityCert = mempool.mapSidechains.at(cert.GetScId()).GetTopQualityCert()->second == cert.GetHash();
+            bool isTopQualityCert = mempool->mapSidechains.at(cert.GetScId()).GetTopQualityCert()->second == cert.GetHash();
             UpdateCoins(entry->GetCertificate(), mempoolDuplicateCert, dummyUndo, 1000000, isTopQualityCert);
             stepsSinceLastRemoveCert = 0;
         }
@@ -1964,7 +1964,7 @@ bool CTxMemPool::IsFullyNotified() {
     return nRecentlyAddedSequence == nNotifiedSequence;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
+CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
 bool CCoinsViewMemPool::GetNullifier(const uint256 &nf) const {
     if (mempool.mapNullifiers.count(nf))

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -17,6 +17,9 @@
 #include "validationinterface.h"
 #include <undo.h>
 
+#include <vector>
+#include <stack>
+
 CMemPoolEntry::CMemPoolEntry():
     nFee(0), nModSize(0), nUsageSize(0), nTime(0), dPriority(0.0)
 {
@@ -110,8 +113,8 @@ bool CSidechainMemPoolEntry::HasCert(const uint256& hash) const
     return GetCert(hash) != mBackwardCertificates.end();
 }
 
-CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
-    nTransactionsUpdated(0), nCertificatesUpdated(0), cachedInnerUsage(0)
+CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee, uint64_t max_size) :
+    nTransactionsUpdated(0), nCertificatesUpdated(0), cachedInnerUsage(0), m_max_size(max_size)
 {
     // Sanity checks off by default for performance, because otherwise
     // accepting transactions becomes O(N^2) where N is the number
@@ -158,6 +161,13 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     // Used by main.cpp AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
     LOCK(cs);
+
+    if (!trimToSize(&entry, m_max_size)) {
+        LogPrint("mempool", "trimToSize: Not accepting new tx into mempool\n");
+        // not accepted into mempool
+        return false;
+    }
+
     mapTx[hash] = entry;
     const CTransaction& tx = mapTx[hash].GetTx();
 
@@ -209,6 +219,13 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
 bool CTxMemPool::addUnchecked(const uint256& hash, const CCertificateMemPoolEntry &entry, bool fCurrentEstimate)
 {
     LOCK(cs);
+
+    if (!trimToSize(&entry, m_max_size)) {
+        LogPrint("mempool", "trimToSize: Not accepting new cert into mempool\n");
+        // not accepted into mempool
+        return false;
+    }
+
     mapCertificate[hash] = entry;
     const CScCertificate& cert = mapCertificate[hash].GetCertificate();
 
@@ -592,6 +609,74 @@ std::vector<uint256> CTxMemPool::mempoolDependenciesOf(const CTransactionBase& o
     return res;
 }
 
+CRawFeeRate CTxMemPool::avgFeeRateWithDeps(const uint256& rootTx, const bool certificatesAllowed, std::map<uint256, CRawFeeRate>& cache) const
+{
+    // depth first graph traversal with cache
+
+    CRawFeeRate res;
+    std::stack<std::pair<uint256, bool>> to_visit;
+    std::set<uint256> already_visited;
+    to_visit.push({rootTx, false});
+    while (!to_visit.empty()) {
+        std::pair<uint256, bool>& curr = to_visit.top();
+        const uint256& curr_hash = curr.first;
+        CRawFeeRate curr_rate;
+        if (cache.find(curr_hash) != cache.end()) {
+            curr_rate = cache.at(curr_hash);
+        }
+        else {
+            bool is_certificate = mapCertificate.find(curr_hash) != mapCertificate.end();
+            if (!curr.second) {
+                // First explore descendants
+                std::vector<uint256> deps = is_certificate ?
+                                                mempoolDirectDependenciesOf(mapCertificate.at(curr_hash).GetCertificate())
+                                                : mempoolDirectDependenciesOf(mapTx.at(curr_hash).GetTx());
+                for (uint256& hash: deps) {
+                    auto ires = already_visited.insert(std::move(hash));
+                    if (ires.second) {
+                        to_visit.push({*ires.first, false});
+                    }
+                }
+                curr.second = true;
+                continue;
+            }
+
+            // Then process the feerate
+            if (is_certificate && !certificatesAllowed) {
+                LogPrint("mempool", "%s():%d - Setting max fee for cert %s\n", __func__, __LINE__, curr_hash.ToString());
+                curr_rate = CRawFeeRate(CRawFeeRate::MAX_FEE, 1);
+            }
+            else {
+                const CMemPoolEntry* entry = is_certificate ?
+                                                dynamic_cast<const CMemPoolEntry*>(&mapCertificate.at(curr_hash))
+                                                : dynamic_cast<const CMemPoolEntry*>(&mapTx.at(curr_hash));
+                curr_rate = CRawFeeRate(entry->GetFee(), entry->GetSize());
+            }
+
+            assert(cache.find(curr_hash) == cache.end());
+            cache.insert({curr_hash, curr_rate});
+        }
+        res += curr_rate;
+
+        to_visit.pop();
+    }
+
+    return res;
+}
+
+void CTxMemPool::remove(const uint256& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive)
+{
+    auto tx = mapTx.find(origTx);
+    if (tx != mapTx.end()) {
+        remove(tx->second.GetTx(), removedTxs, removedCerts, fRecursive);
+        return;
+    }
+    auto cert = mapCertificate.find(origTx);
+    if (cert != mapCertificate.end()) {
+        remove(cert->second.GetCertificate(), removedTxs, removedCerts, fRecursive);
+    }
+}
+
 void CTxMemPool::remove(const CTransactionBase& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive)
 {
     // Remove transaction from memory pool
@@ -605,9 +690,11 @@ void CTxMemPool::remove(const CTransactionBase& origTx, std::list<CTransaction>&
 
     for(const uint256& hash : objToRemove)
     {
-        if (mapTx.count(hash))
+        const auto& entry_it = mapTx.find(hash);
+        if (entry_it != mapTx.end())
         {
-            const CTransaction& tx = mapTx[hash].GetTx();
+            const CTxMemPoolEntry& entry = entry_it->second;
+            const CTransaction& tx = entry.GetTx();
             mapRecentlyAddedTxBase.erase(hash);
 
             for(const CTxIn& txin: tx.GetVin())
@@ -665,8 +752,8 @@ void CTxMemPool::remove(const CTransactionBase& origTx, std::list<CTransaction>&
             }
 
             removedTxs.push_back(tx);
-            totalTxSize -= mapTx[hash].GetTxSize();
-            cachedInnerUsage -= mapTx[hash].DynamicMemoryUsage();
+            totalTxSize -= entry.GetTxSize();
+            cachedInnerUsage -= entry.DynamicMemoryUsage();
 
             LogPrint("mempool", "%s():%d - removing tx [%s] from mempool\n", __func__, __LINE__, hash.ToString() );
             mapTx.erase(hash);
@@ -678,7 +765,6 @@ void CTxMemPool::remove(const CTransactionBase& origTx, std::list<CTransaction>&
                 removeAddressIndex(hash);
             if (fSpentIndex)
                 removeSpentIndex(hash);
-
         } else if (mapCertificate.count(hash))
         {
             const CScCertificate& cert = mapCertificate[hash].GetCertificate();
@@ -2007,6 +2093,67 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
           memusage::DynamicUsage(mapCertificate) +
           memusage::DynamicUsage(mapSidechains) +
           cachedInnerUsage);
+}
+
+bool CTxMemPool::trimToSize(const CMemPoolEntry* entry, size_t max_size) {
+    LOCK(cs);
+    size_t new_entry_usage = entry ? entry->GetSize() : 0;
+    assert(new_entry_usage < max_size);
+    size_t current_usage = totalTxSize + totalCertificateSize;
+    // If the mempool size is within the limits, do nothing and return immediately.
+    if (current_usage + new_entry_usage <= max_size) return true;
+
+    const CCertificateMemPoolEntry* certificate = dynamic_cast<const CCertificateMemPoolEntry*>(entry);
+    if (certificate && totalTxSize > m_max_size / 2) {
+        LogPrint("mempool", "%s():%d - Trying to remove transactions to make room for certificate (tot_tx: %zu, max: %zu)\n", __func__, __LINE__, totalTxSize, m_max_size / 2);
+        trimToSize(nullptr, m_max_size - new_entry_usage);
+        current_usage = totalTxSize + totalCertificateSize;
+        if (current_usage + new_entry_usage <= m_max_size) return true;
+    }
+
+    // we must either reject incoming tx, or remove something
+    int64_t size_to_be_removed = current_usage + new_entry_usage - max_size;
+    std::multimap<CRawFeeRate, uint256> raw_fee_rates;
+    std::map<uint256, CRawFeeRate> rates_cache;
+    const bool certificatesAllowed = certificate || totalCertificateSize > m_max_size / 2;
+    LogPrint("mempool", "%s():%d - Trying to remove something to make room (certificatesAllowed: %d, size: %d)\n", __func__, __LINE__, certificatesAllowed, size_to_be_removed);
+    for (const auto& tx: mapTx) {
+        CRawFeeRate feerate = avgFeeRateWithDeps(tx.first, certificatesAllowed, rates_cache);
+        raw_fee_rates.insert({feerate, tx.first});
+    }
+    for (const auto& cert: mapCertificate) {
+        CRawFeeRate feerate = avgFeeRateWithDeps(cert.first, certificatesAllowed, rates_cache);
+        raw_fee_rates.insert({feerate, cert.first});
+    }
+
+    // Check what should be removed, and if this selection includes entry...
+    std::vector<uint256*> to_be_removed;
+    for (auto remove_candidate = raw_fee_rates.begin(); remove_candidate != raw_fee_rates.end() && size_to_be_removed > 0; ++remove_candidate) {
+        // If it includes entry (i.e. the incoming tx/cert has a fee eq/lower than other elements that would be evicted),
+        // then just reject the incoming transaction and do nothing else
+        if (entry && remove_candidate->first >= CFeeRate(entry->GetFee(), entry->GetSize())) return false;
+
+        to_be_removed.push_back(&remove_candidate->second);
+        size_to_be_removed -= remove_candidate->first.GetBytes();
+    }
+
+    // Actually remove things from mempool
+    for (const uint256* r: to_be_removed) {
+        std::list<CTransaction> removed_txs;
+        std::list<CScCertificate> removed_certs;
+        remove(*r, removed_txs, removed_certs, true);
+        // Might even remove nothing at one iteration, if r was removed as a dependency in a previous iteration already.
+        LogPrint("mempool", "%s():%d - Removed %s and its dependants\n", __func__, __LINE__, r->ToString());
+        for(const CTransaction &t: removed_txs) {
+            LogPrint("mempool", "%s():%d - Syncing tx %s\n", __func__, __LINE__, t.GetHash().ToString());
+            SyncWithWallets(t, nullptr);
+        }
+        for(const CScCertificate &c: removed_certs) {
+            LogPrint("mempool", "%s():%d - Syncing cert %s\n", __func__, __LINE__, c.GetHash().ToString());
+            SyncWithWallets(c, nullptr);
+        }
+    }
+    return true;
 }
 
 std::pair<uint256, CAmount> CTxMemPool::FindCertWithQuality(const uint256& scId, int64_t certQuality) const

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -938,13 +938,7 @@ void CTxMemPool::removeCertificatesWithoutRef(const CCoinsViewCache * const pCoi
     std::list<CTransaction> dummyTxs;
     for (const auto& hash: certsToRemove)
     {
-        // there can be dependencies also between certs, so check that a cert is still in map during the loop
-        const auto& cert_it = mapCertificate.find(hash);
-        if (cert_it != mapCertificate.end())
-        {
-            const CScCertificate& cert = cert_it->second.GetCertificate();
-            remove(cert, dummyTxs, outdatedCerts, true);
-        }
+        remove(hash, dummyTxs, outdatedCerts, true);
     }
     LogPrint("mempool", "%s():%d - removed %zu certs and %zu txes\n", __func__, __LINE__, outdatedCerts.size(), dummyTxs.size());
 
@@ -1002,12 +996,7 @@ void CTxMemPool::removeStaleCertificates(const CCoinsViewCache * const pCoinsVie
     std::list<CTransaction> dummyTxs;
     for(const auto& hash: certsToRemove)
     {
-        // there can be dependancy also between certs, so check that a cert is still in map during the loop
-        if (mapCertificate.count(hash))
-        {
-            const CScCertificate& cert = mapCertificate.at(hash).GetCertificate();
-            remove(cert, dummyTxs, outdatedCerts, true);
-        }
+        remove(hash, dummyTxs, outdatedCerts, true);
     }
     LogPrint("mempool", "%s():%d - removed %d certs and %d txes\n", __func__, __LINE__, outdatedCerts.size(), dummyTxs.size());
 }
@@ -1065,12 +1054,7 @@ void CTxMemPool::removeOutOfScBalanceCsw(const CCoinsViewCache * const pCoinsVie
 
     for(const auto& hash: txesToRemove)
     {
-        // there can be dependancy also between txes, so check that a tx is still in map during the loop
-        if (mapTx.count(hash))
-        {
-            const CTransaction& tx = mapTx.at(hash).GetTx();
-            remove(tx, removedTxs, removedCerts, true);
-        }
+        remove(hash, removedTxs, removedCerts, true);
     }
 }
 
@@ -1182,12 +1166,7 @@ void CTxMemPool::removeStaleTransactions(const CCoinsViewCache * const pCoinsVie
 
     for(const auto& hash: txesToRemove)
     {
-        // there can be dependancy also between txes, so check that a tx is still in map during the loop
-        if (mapTx.count(hash))
-        {
-            const CTransaction& tx = mapTx.at(hash).GetTx();
-            remove(tx, outdatedTxs, outdatedCerts, true);
-        }
+        remove(hash, outdatedTxs, outdatedCerts, true);
     }
     
     LogPrint("mempool", "%s():%d - removed %d certs and %d txes\n", __func__, __LINE__, outdatedCerts.size(), outdatedTxs.size());
@@ -1259,12 +1238,7 @@ void CTxMemPool::removeConflicts(const CScCertificate &cert, std::list<CTransact
 
     for(const auto& hash: lowerQualCerts)
     {
-        // there can be dependancy also between certs, so check that a cert is still in map during the loop
-        if (mapCertificate.count(hash))
-        {
-            const CScCertificate& cert = mapCertificate.at(hash).GetCertificate();
-            remove(cert, removedTxs, removedCerts, true);
-        }
+        remove(hash, removedTxs, removedCerts, true);
     }
 }
 
@@ -2182,10 +2156,9 @@ bool CTxMemPool::RemoveCertAndSync(const uint256& certToRmHash)
     if(mapCertificate.count(certToRmHash) == 0)
         return true; //nothing to remove
 
-    CScCertificate certToRm = mapCertificate.at(certToRmHash).GetCertificate();
     std::list<CTransaction> conflictingTxs;
     std::list<CScCertificate> conflictingCerts;
-    remove(certToRm, conflictingTxs, conflictingCerts, true);
+    remove(certToRmHash, conflictingTxs, conflictingCerts, true);
 
     // Tell wallet about transactions and certificates that went from mempool to conflicted:
     for(const auto &t: conflictingTxs) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -165,7 +165,7 @@ private:
     uint64_t totalTxSize = 0; //! sum of all mempool tx' byte sizes
     uint64_t totalCertificateSize = 0; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
-    /*const*/ uint64_t m_max_size;
+    const uint64_t m_max_size;
 
     bool checkTxImmatureExpenditures(const CTransaction& tx, const CCoinsViewCache * const pcoins);
     bool checkCertImmatureExpenditures(const CScCertificate& cert, const CCoinsViewCache * const pcoins);
@@ -216,7 +216,6 @@ public:
     bool checkIncomingCertConflicts(const CScCertificate& incomingCert) const;
 
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
-    void setMaxSize(uint64_t max_size) { m_max_size = max_size; }
 
     std::pair<uint256, CAmount> FindCertWithQuality(const uint256& scId, int64_t certQuality) const;
     bool RemoveCertAndSync(const uint256& certToRmHash);
@@ -399,10 +398,10 @@ public:
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
-    CTxMemPool &mempool;
+    CTxMemPool& mempool;
 
 public:
-    CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
+    CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool& mempoolIn);
 
     bool GetNullifier(const uint256 &txid)                              const override;
     bool GetCoins(const uint256 &txid, CCoins &coins)                   const override;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -165,9 +165,8 @@ private:
     CBlockPolicyEstimator* minerPolicyEstimator;
 
     uint64_t totalTxSize = 0; //! sum of all mempool tx' byte sizes
-    uint64_t totalCertificateSize = 0; //! sum of all mempool tx' byte sizes
+    uint64_t totalCertificateSize = 0; //! sum of all mempool certificates' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
-    const uint64_t m_max_size;
 
     bool checkTxImmatureExpenditures(const CTransaction& tx, const CCoinsViewCache * const pcoins);
     bool checkCertImmatureExpenditures(const CScCertificate& cert, const CCoinsViewCache * const pcoins);
@@ -189,6 +188,7 @@ private:
     mapSpentIndexInserted mapSpentInserted;
 
 public:
+    const uint64_t m_max_size;
     mutable CCriticalSection cs;
     std::map<uint256, CTxMemPoolEntry> mapTx;
     std::map<uint256, CCertificateMemPoolEntry> mapCertificate;
@@ -241,7 +241,7 @@ public:
     std::vector<uint256> mempoolDependenciesFrom(const CTransactionBase& origTx) const;
     std::vector<uint256> mempoolDependenciesOf(const CTransactionBase& origTx) const;
 
-    CRawFeeRate avgFeeRateWithDeps(const uint256& rootTx, const bool certificatesAllowed, std::map<uint256, CRawFeeRate>& cache) const;
+    CRawFeeRate avgFeeRateWithDeps(const uint256& rootTx, const bool certificatesAllowed, std::unordered_map<uint256, CRawFeeRate>& cache) const;
 
     void remove(const CTransactionBase& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive = false);
     void remove(const uint256& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive = false);
@@ -390,7 +390,7 @@ public:
     bool ReadFeeEstimates(CAutoFile& filein);
 
     size_t DynamicMemoryUsage() const;
-    bool trimToSize(const CMemPoolEntry* entry, size_t max_size);
+    bool trimToSize(const CMemPoolEntry* entry, size_t max_size, bool dryrun);
 };
 
 /** 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -7,6 +7,8 @@
 #define BITCOIN_TXMEMPOOL_H
 
 #include <list>
+#include <vector>
+#include <unordered_map>
 
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -124,7 +124,8 @@ public:
     uint64_t GetCheapHash() const
     {
         uint64_t result;
-        memcpy((void*)&result, (void*)data, 8);
+        static_assert(WIDTH >= sizeof(result));
+        memcpy((void*)&result, (void*)data, sizeof(result));
         return result;
     }
 
@@ -132,6 +133,12 @@ public:
      * @note This hash is not stable between little and big endian.
      */
     uint64_t GetHash(const uint256& salt) const;
+};
+
+template<> struct std::hash<uint256> {
+    size_t operator()(uint256 const& in) const noexcept {
+        return in.GetCheapHash();
+    }
 };
 
 /* uint256 from const char *.

--- a/src/wallet/gtest/test_wallet_cert.cpp
+++ b/src/wallet/gtest/test_wallet_cert.cpp
@@ -375,7 +375,7 @@ TEST_F(SidechainsCertInWalletTestSuite, IsOutputMature_TransparentTx_InMemoryPoo
     chainSettingUtils::ExtendChainActiveToHeight(txCreationHeight);
 
     CTxMemPoolEntry mempoolEntry(transparentTx, /*fee*/CAmount(0), int64_t(0), double(0.0), int(0), false);
-    mempool.addUnchecked(transparentTx.GetHash(), mempoolEntry , /*fCurrentEstimate*/false);
+    mempool->addUnchecked(transparentTx.GetHash(), mempoolEntry , /*fCurrentEstimate*/false);
 
     CWalletTx walletTx(pWallet, transparentTx);
     walletTx.hashBlock.SetNull();
@@ -401,7 +401,7 @@ TEST_F(SidechainsCertInWalletTestSuite, IsOutputMature_Certificate_InMemoryPool)
     chainSettingUtils::ExtendChainActiveToHeight(txCreationHeight);
 
     CCertificateMemPoolEntry mempoolEntry(cert, /*fee*/CAmount(0), int64_t(0), double(0.0), int(0));
-    mempool.addUnchecked(cert.GetHash(), mempoolEntry , /*fCurrentEstimate*/false);
+    mempool->addUnchecked(cert.GetHash(), mempoolEntry , /*fCurrentEstimate*/false);
 
     CWalletCert walletCert(pWallet, cert);
     walletCert.hashBlock.SetNull();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1314,8 +1314,8 @@ UniValue sc_send(const UniValue& params, bool fHelp)
         }
 
         {
-            LOCK(mempool.cs);
-            CCoinsViewMemPool scView(pcoinsTip, mempool);
+            LOCK(mempool->cs);
+            CCoinsViewMemPool scView(pcoinsTip, *mempool);
             if (!scView.HaveSidechain(scId))
             {
                 LogPrint("sc", "scid[%s] not yet created\n", scId.ToString() );
@@ -1518,8 +1518,8 @@ UniValue sc_request_transfer(const UniValue& params, bool fHelp)
         }
 
         {
-            LOCK(mempool.cs);
-            CCoinsViewMemPool scView(pcoinsTip, mempool);
+            LOCK(mempool->cs);
+            CCoinsViewMemPool scView(pcoinsTip, *mempool);
             if (!scView.HaveSidechain(scId))
             {
                 LogPrint("sc", "scid[%s] not yet created\n", scId.ToString() );
@@ -5513,7 +5513,7 @@ UniValue sc_send_certificate(const UniValue& params, bool fHelp)
     // sanity check of the side chain ID
     CCoinsView dummy;
     CCoinsViewCache scView(&dummy);
-    CCoinsViewMemPool vm(pcoinsTip, mempool);
+    CCoinsViewMemPool vm(pcoinsTip, *mempool);
     scView.SetBackend(vm);
     CSidechain sidechain;
     if (!scView.GetSidechain(scId, sidechain))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1243,10 +1243,10 @@ bool CWallet::UpdatedNoteData(const CWalletTransactionBase& wtxIn, CWalletTransa
  *
  * If pblock is null, this transaction has either recently entered the mempool from the
  * network, is re-entering the mempool after a block was disconnected, or is exiting the
- * mempool because it conflicts with another transaction. In all these cases, if there is
- * an existing wallet transaction, the wallet transaction's Merkle branch data is _not_
- * updated; instead, the transaction being in the mempool or conflicted is determined on
- * the fly in CMerkleTx::GetDepthInMainChain().
+ * mempool because it conflicts with another transaction, or the mempool is full. In all these
+ * cases, if there is an existing wallet transaction, the wallet transaction's Merkle branch
+ * data is _not_ updated; instead, the transaction being in the mempool or conflicted is
+ * determined on the fly in CMerkleTx::GetDepthInMainChain().
  */
 bool CWallet::AddToWalletIfInvolvingMe(const CTransactionBase& obj, const CBlock* pblock, int bwtMaturityDepth, bool fUpdate)
 {

--- a/src/zen/websocket_server.cpp
+++ b/src/zen/websocket_server.cpp
@@ -550,11 +550,11 @@ private:
                 return INVALID_PARAMETER;
             }
         
-            if (mempool.hasSidechainCertificate(scId))
+            if (mempool->hasSidechainCertificate(scId))
             {
-                const uint256& topQualCertHash = mempool.mapSidechains.at(scId).GetTopQualityCert()->second;
-                const CScCertificate& topQualCert = mempool.mapCertificate.at(topQualCertHash).GetCertificate();
-                const CAmount certFee = mempool.mapCertificate.at(topQualCertHash).GetFee();
+                const uint256& topQualCertHash = mempool->mapSidechains.at(scId).GetTopQualityCert()->second;
+                const CScCertificate& topQualCert = mempool->mapCertificate.at(topQualCertHash).GetCertificate();
+                const CAmount certFee = mempool->mapCertificate.at(topQualCertHash).GetFee();
                 CDataStream ssCert(SER_NETWORK, PROTOCOL_VERSION);
                 ssCert << topQualCert;
                 std::string certHex = HexStr(ssCert.begin(), ssCert.end());


### PR DESCRIPTION
This PR adds a new CLI parameter, `-maxmempool`, that allows setting an upper limit on the size in bytes of the content of the mempool.
In order to respect such limit, transactions or certificates can be rejected/evicted according to context specific rules.