### PR TITLE
Gp/coins selection algorithm

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -163,6 +163,7 @@ testScripts=(
   'sc_big_commitment_tree_getblockmerkleroot.py',11,25
   'p2p_ignore_spent_tx.py',215,455
   'shieldedpooldeprecation_rpc.py',558,1794
+  'oversized_tx_cert.py',300,800
 );
 
 testScriptsExt=(

--- a/qa/rpc-tests/oversized_tx_cert.py
+++ b/qa/rpc-tests/oversized_tx_cert.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+import codecs
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, assert_greater_or_equal_than, initialize_chain_clean,\
+    get_epoch_data, start_nodes, connect_nodes_bi, stop_node, wait_and_assert_operationid_status, swap_bytes
+import os
+import zipfile
+import time
+from test_framework.test_framework import MINER_REWARD_POST_H200
+from test_framework.mc_test.mc_test import *
+
+EPS = Decimal(0.00000001)
+
+class OversizedTxCert(BitcoinTestFramework):
+
+    def import_data_to_data_dir(self):
+
+        # importing datadir resource
+        #
+        # 101 blocks generated on node2 + (0.001 sent from node2 to node0) * 2000 +
+        # 1 block generated on node2 + 200 blocks generated on node1 +
+        # (single shielding on node1 coinbase + 1 block generated on node2) * 200
+        #
+        # node0:
+        # +] ztoEcvcprfPWbfzYXUAFaA12BFCck9hXVYw                                                             -> 2.00000000 {2000 utxos}
+        #
+        # node1:
+        # +] ztjUrw6vnos7grPAFHh98w1Qct2LjX3zxE2                                                             -> 0.00000000
+        # +] ztni5Ykn2RCkojLQX1QdDR4iEGYnBYaH7HMNXo12xYoy5isQfBTLpNeoEjm6LhgeCtbNhCtNcrDpqp8ReR1cwjqadrmhdxV -> 1625.73000000 {200 utxos}
+        #
+        # node2:
+        # +] zta36sLgzD3H81nWXkv3qfLnSBXbXsrg1oW                                                             -> 0.00000000
+        # +] ztr1k6dK5D3XqizVSBhekFMx45NdWeo3gbJ                                                             -> 761.01592000 (+750.01000000 immature) {101 utxos (+100 immature)}
+        # +] ztoap92Ej7A13F3uhBbT81QEvzVNkTgwC6Q                                                             -> 1143.31225000 {101 utxos}
+        # +] ztfUjF8wQfJkzuJYAMSMVgamKGNEacUozb5                                                             -> 9.43158000 {1 utxos}
+        #
+
+        resource_file = os.sep.join([os.path.dirname(__file__), 'resources', 'oversized_tx_cert', 'test_setup_.zip'])
+        with zipfile.ZipFile(resource_file, 'r') as zip_ref:
+            zip_ref.extractall(self.options.tmpdir)
+
+    def setup_chain(self):
+        self.import_data_to_data_dir()
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 3)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-debug=zrpcunsafe', '-debug=selectcoins', '-maxtipage=36000000']] * 3 )
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def swap_bytes(input_buf):
+        return codecs.encode(codecs.decode(input_buf, 'hex')[::-1], 'hex').decode()
+
+    def run_test (self):
+
+        nt0 = self.nodes[0].listaddresses()[0]
+        nt1 = self.nodes[1].listaddresses()[0]
+        nz1 = self.nodes[1].z_listaddresses()[0]
+        nt2 = self.nodes[2].listaddresses()[0]
+
+        nt0b = self.nodes[0].z_getbalance(nt0)
+        nt1b = self.nodes[1].z_getbalance(nt1)
+        nz1b = self.nodes[1].z_getbalance(nz1)
+        nt2b = self.nodes[2].z_getbalance(nt2)
+
+
+        # ---------- testing sendtoaddress (sendfrom is analogous) ----------
+        try:
+            # not enough funds for transaction
+            self.nodes[0].sendtoaddress(nt2, nt0b + EPS)
+            assert_equal(False) # impossibile to create transaction (as expected)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print("Impossible to create transaction (as expected): {}".format(errorString))
+
+        try:
+            # no middle value coin is sent, hence it will be impossible (due to oversize) to create next transaction
+            # using only small coins
+            self.nodes[0].sendtoaddress(nt2, 0.7)
+            assert_equal(False) # impossibile to create transaction (as expected)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print("Impossible to create transaction (as expected): {}".format(errorString))
+
+        # a middle value coin is sent which will be later used in next transaction (together with other coins)
+        # no oversized transaction error is expected ("JSONRPC error: Transaction too large")
+        self.nodes[2].sendtoaddress(nt0, 0.5)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.5)) < EPS, listunspent0))), 1) # coin unspent
+        self.nodes[0].sendtoaddress(nt2, 0.7)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.5)) < EPS, listunspent0))), 0) # coin spent
+
+        # a big value coin is sent which will be later used in next transaction as the only coin (possibly with few
+        # more due to change levels) because it would be impossible (due to oversize) to create next transaction using
+        # only small coins
+        self.nodes[2].sendtoaddress(nt0, 1.0)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(1.0)) < EPS, listunspent0))), 1) # coin unspent
+        txid = self.nodes[0].sendtoaddress(nt2, 1.0)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(1.0)) < EPS, listunspent0))), 0) # coin spent
+        hex = self.nodes[0].gettransaction(txid)['hex']
+        vins = self.nodes[0].decoderawtransaction(hex)['vin']
+        assert_greater_or_equal_than(len(vins), 1)
+
+        # a big value coin is sent which will be later used in next transaction as the only coin because it would be
+        # impossible (due to oversize) to create next transaction using only small coins; this time an exact match can
+        # be found because coin gross value is used (instead of net value)
+        self.nodes[2].sendtoaddress(nt0, 1.0)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(1.0)) < EPS, listunspent0))), 1) # coin unspent
+        txid = self.nodes[0].sendtoaddress(nt2, 1.0, "", "", True)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(1.0)) < EPS, listunspent0))), 0) # coin spent
+        hex = self.nodes[0].gettransaction(txid)['hex']
+        vins = self.nodes[0].decoderawtransaction(hex)['vin']
+        assert_equal(len(vins), 1)
+
+
+        # ---------- testing sendmany ----------
+        # two middle value coins are sent but will not suffice (due to oversize) for creating next transaction (even if
+        # mixed with other small coins)
+        self.nodes[2].sendtoaddress(nt0, 0.5)
+        self.sync_all()
+        self.nodes[2].sendtoaddress(nt0, 0.5)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0)
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.5)) < EPS, listunspent0))), 2) # coins unspent
+        try:
+            self.nodes[0].sendmany("", {nt2: 1.0, self.nodes[2].getnewaddress(): 1.0}, 0, "", [])
+            assert_equal(False) # impossibile to create transaction (as expected)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print("Impossible to create transaction (as expected): {}".format(errorString))
+
+        # two middle value coins previously sent are selected (together with other small coins) for creating next transaction
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0)
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.5)) < EPS, listunspent0))), 2) # coins unspent
+        self.nodes[0].sendmany("", {nt2: 0.7, self.nodes[2].getnewaddress(): 0.7}, 0, "", [])
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0)
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.5)) < EPS, listunspent0))), 0) # coins spent
+        
+
+        # ---------- testing sc_create and sc_send_certificate ----------
+        # emptying node0 wallet (with some txs, not in a single tx otherwise we would incur in oversized tx)
+        partialBalance0 = 0
+        listunspent0 = self.nodes[0].listunspent(0)
+        while(len(listunspent0) > 0):
+            partialBalance0 = sum(item['amount'] for item in listunspent0[:600]) # an "almost void" transaction supports approximately up to 650 inputs
+            self.nodes[0].sendtoaddress(nt2, partialBalance0, "", "", True)
+            self.sync_all()
+            self.nodes[2].generate(1)
+            self.sync_all()
+            listunspent0 = self.nodes[0].listunspent(0)
+
+        # sending a lot of small coins to node0 wallet (syncing only at loop end, since only node2 is involved)
+        for i in range(1100): # an "almost void" certificate supports approximately up to 1000 inputs
+            self.nodes[2].sendtoaddress(nt0, 0.000005)
+            if ((i + 1) % 600 == 0 or i == 1100 - 1):
+                self.nodes[2].generate(1)
+        self.sync_all()
+        
+        EPOCH_LENGTH = 10
+        FT_SC_FEE = Decimal('0')
+        MBTR_SC_FEE = Decimal('0')
+        CERT_FEE = Decimal('0.005400')
+        creation_amount = Decimal("0.00005")
+        mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+        vk = mcTest.generate_params("sc0")
+        constant = generate_random_field_element_hex()
+        cmdInput = {
+            "version": 0,
+            "withdrawalEpochLength":EPOCH_LENGTH,
+            "toaddress":"aaaa",
+            "amount":creation_amount,
+            "wCertVk":vk,
+            "constant":constant,
+            "fee":0
+        }
+
+        # only the small coins will be selected for satisfying sc creation amount
+        ret = self.nodes[0].sc_create(cmdInput)
+        creating_tx = ret['txid']
+        scid = ret['scid']
+        scid_swapped = str(swap_bytes(scid))
+        self.sync_all()
+        self.nodes[2].generate(EPOCH_LENGTH)
+        self.sync_all()
+        scid = self.nodes[0].getscinfo("*")["items"][0]["scid"]
+        scid_swapped = str(swap_bytes(scid))
+        constant = self.nodes[0].getscinfo("*")["items"][0]["constant"]
+        epoch_number, epoch_cum_tree_hash, _ = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
+        quality = 1
+        mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+        amount_cert = []
+        proof = mcTest.create_test_proof("sc0", scid_swapped, epoch_number, quality, MBTR_SC_FEE, FT_SC_FEE, epoch_cum_tree_hash, None, constant, [], [])
+        
+        try:
+            # using only small coins results in an oversized certificate
+            cert = self.nodes[0].sc_send_certificate(scid, epoch_number, quality, epoch_cum_tree_hash, proof, amount_cert, FT_SC_FEE, MBTR_SC_FEE, CERT_FEE)
+            assert_equal(False) # impossibile to create certificate (as expected)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print("Impossible to create certificate (as expected): {}".format(errorString))
+
+        # sending one big coin to node0 wallet
+        self.nodes[2].sendtoaddress(nt0, 0.005445)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        # the big coin together with small coins will be selected for satisfying certificate fee
+        listunspent0 = self.nodes[0].listunspent(0)
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.005445)) < EPS, listunspent0))), 1) # coin unspent
+        cert = self.nodes[0].sc_send_certificate(scid, epoch_number, quality, epoch_cum_tree_hash, proof, amount_cert, FT_SC_FEE, MBTR_SC_FEE, CERT_FEE)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0)
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.005445)) < EPS, listunspent0))), 0) # coin spent
+
+
+        # ---------- testing z_sendmany (from_t part) ----------
+        # failure due to too many transparents inputs selected even if single recipient
+        errorCode = 0
+        trecipients = []
+        trecipients.append({"address":self.nodes[0].getnewaddress(), "amount": 0.000005 * 700})
+        myopid = self.nodes[0].z_sendmany(nt0, trecipients)
+        result = wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "")
+        errorCode = result["error"]["code"]
+        print("Impossible to create transaction (as expected): {}".format(result["error"]["message"]))
+        assert_equal(errorCode, -6)
+
+        # failure due to too many transparent inputs and transparent outputs selected
+        errorCode = 0
+        trecipients = []
+        for i in range (600):
+            trecipients.append({"address":self.nodes[0].getnewaddress(), "amount": 0.000005})
+        myopid = self.nodes[0].z_sendmany(nt0, trecipients)
+        result = wait_and_assert_operationid_status(self.nodes[0], myopid, "failed", "")
+        errorCode = result["error"]["code"]
+        print("Impossible to create transaction (as expected): {}".format(result["error"]["message"]))
+        assert_equal(errorCode, -6)
+        # sending one big coin to node0 wallet (should satisfy approximately 500 over 600 recipients)
+        self.nodes[2].sendtoaddress(nt0, 0.0025)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        # the big coin together with small coins will be selected
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.0025)) < EPS, listunspent0))), 1) # coin unspent
+        myopid = self.nodes[0].z_sendmany(nt0, trecipients)
+        wait_and_assert_operationid_status(self.nodes[0], myopid)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        listunspent0 = self.nodes[0].listunspent(0, 9999999, [nt0])
+        assert_equal(len(list(filter(lambda x : abs(x["amount"] - Decimal(0.0025)) < EPS, listunspent0))), 0) # coin spent
+
+        # failure due to too many transparent inputs and shielded outputs selected
+        errorCode = 0
+        zrecipients = []
+        for i in range (100):
+            zrecipients.append({"address":self.nodes[0].z_getnewaddress(), "amount": 0.000005})
+        try:
+            myopid = self.nodes[0].z_sendmany(nt0, zrecipients)
+            assert_equal(False)
+        except JSONRPCException as e:
+            errorCode = e.error["code"]
+            errorString = e.error['message']
+            assert_equal(-8, errorCode)
+            print("Impossible to create transaction (as expected): {}".format(errorString))
+        # reducing the number of recipients allows the transaction to be created
+        errorCode = 0
+        zrecipients = []
+        for i in range (10):
+            zrecipients.append({"address":self.nodes[0].z_getnewaddress(), "amount": 0.000005})
+        myopid = self.nodes[0].z_sendmany(nt0, zrecipients)
+        result = wait_and_assert_operationid_status(self.nodes[0], myopid, timeout=600) # longer timeout because 5=10/2 joinsplits have to be performed
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+
+
+        # ---------- testing z_sendmany (from_z part) ----------
+        # failure due to notes selection resulting in too many joinsplits (as input) even if single recipient
+        z_listunspent_1 = self.nodes[1].z_listunspent(0, 9999999, False, [nz1])
+        errorCode = 0
+        zrecipients = []
+        zrecipients.append({"address":self.nodes[1].z_getnewaddress(), "amount": self.nodes[1].z_getbalance(nz1)})
+        myopid = self.nodes[1].z_sendmany(nz1, zrecipients, 1, 0)
+        result = wait_and_assert_operationid_status(self.nodes[1], myopid, "failed", "")
+        errorCode = result["error"]["code"]
+        print("Impossible to create transaction (as expected): {}".format(result["error"]["message"]))
+        assert_equal(errorCode, -6)
+
+        # but reducing single recipient amount, less notes are selected and transaction can be created
+        if (len(z_listunspent_1) > 5):
+            z_listunspent_1_asc = sorted(z_listunspent_1, key=lambda x: x["amount"], reverse=False)
+            zrecipients = []
+            zrecipients.append({"address":self.nodes[1].z_getnewaddress(), "amount": z_listunspent_1_asc[0]["amount"] +
+                                                                                     z_listunspent_1_asc[1]["amount"] +
+                                                                                     z_listunspent_1_asc[2]["amount"] +
+                                                                                     z_listunspent_1_asc[3]["amount"] +
+                                                                                     z_listunspent_1_asc[4]["amount"]})
+            myopid = self.nodes[1].z_sendmany(nz1, zrecipients, 1, 0)
+            self.sync_all()
+            self.nodes[2].generate(1)
+            self.sync_all()
+            txid = wait_and_assert_operationid_status(self.nodes[1], myopid)
+            self.sync_all()
+            self.nodes[2].generate(1)
+            self.sync_all()
+            hex = self.nodes[1].gettransaction(txid)['hex']
+            vjoinsplit = self.nodes[1].decoderawtransaction(hex)['vjoinsplit']
+            assert_equal(len(vjoinsplit), 3) # joinsplit inputs chaining: 2 -> +2 (no change) -> +1
+
+        # try to send minimum amount and check that selection is optimal (trivial quantity maximization, change minimization in case of ties)
+        z_listunspent_1 = self.nodes[1].z_listunspent(0, 9999999, False, [nz1])
+        z_listunspent_1_asc = sorted(z_listunspent_1, key=lambda x: x["amount"], reverse=False)
+        z_listunspent_1_min = z_listunspent_1_asc[0]["amount"]
+        z_listunspent_1_max = z_listunspent_1_asc[len(z_listunspent_1_asc) - 1]["amount"]
+        z_listunspent_1_min_count = len(list(filter(lambda x : abs(x["amount"] - Decimal(z_listunspent_1_min)) < EPS, z_listunspent_1)))
+        z_listunspent_1_max_count = len(list(filter(lambda x : abs(x["amount"] - Decimal(z_listunspent_1_max)) < EPS, z_listunspent_1)))
+        zrecipients = []
+        zrecipients.append({"address":self.nodes[1].z_getnewaddress(), "amount": z_listunspent_1_min})
+        myopid = self.nodes[1].z_sendmany(nz1, zrecipients, 1, 0)
+        wait_and_assert_operationid_status(self.nodes[1], myopid)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        z_listunspent_1_pre = z_listunspent_1
+        z_listunspent_1 = self.nodes[1].z_listunspent(0, 9999999, False, [nz1])
+        # this shows exactly one note was used
+        assert_equal(len(z_listunspent_1_pre) - 1, len(z_listunspent_1))
+        z_listunspent_1_asc = sorted(z_listunspent_1, key=lambda x: x["amount"], reverse=False)
+        # this shows the smallest note was used (in order to minimize change); in previous implementation biggest note was always used (resulting in high change)
+        assert_equal(z_listunspent_1_min_count - 1, len(list(filter(lambda x : abs(x["amount"] - Decimal(z_listunspent_1_min)) < EPS, z_listunspent_1))))
+        assert_equal(z_listunspent_1_max_count, len(list(filter(lambda x : abs(x["amount"] - Decimal(z_listunspent_1_max)) < EPS, z_listunspent_1))))
+
+if __name__ == '__main__':
+        OversizedTxCert().main()

--- a/qa/rpc-tests/sc_create.py
+++ b/qa/rpc-tests/sc_create.py
@@ -388,7 +388,7 @@ class SCCreateTest(BitcoinTestFramework):
         missing_balance_string = f"{(DUST_THRESHOLD - amount_below_dust_threshold):.10f}".rstrip('0').rstrip('.')
         invalid_amount_string = f"{amount_below_dust_threshold:.10f}".rstrip('0').rstrip('.')
         dust_threshold_string = f"{DUST_THRESHOLD:.10f}".rstrip('0').rstrip('.')
-        expected_error_message = f"Insufficient transparent funds, have {current_balance_string}, need {missing_balance_string} more to avoid creating invalid change output {invalid_amount_string} (dust threshold is {dust_threshold_string})"
+        expected_error_message = f"Insufficient transparent funds for taddr[{node1_other_address}], have {current_balance_string}, need {missing_balance_string} more to avoid creating invalid change output {invalid_amount_string} (dust threshold is {dust_threshold_string})"
         self.try_sidechain_creation(1, cmdInput, expected_error_message)
 
         # ---------------------------------------------------------------------------------------

--- a/qa/rpc-tests/sc_rpc_cmds_fee_handling.py
+++ b/qa/rpc-tests/sc_rpc_cmds_fee_handling.py
@@ -147,7 +147,7 @@ class ScRpcCmdsFeeHandling(BitcoinTestFramework):
         self.sync_all()
 
         mc_return_address = self.nodes[2].getnewaddress()
-        outputs = [{'toaddress': toaddress, 'amount': Decimal(0.000001), "scid":scid, "mcReturnAddress": mc_return_address}]
+        outputs = [{'toaddress': toaddress, 'amount': Decimal(0.000002), "scid":scid, "mcReturnAddress": mc_return_address}]
         cmdParms = {}
 
         # A similar failure is expected also for SC related commands if the fee is not set by the user
@@ -160,7 +160,20 @@ class ScRpcCmdsFeeHandling(BitcoinTestFramework):
             mark_logs(errorString,self.nodes,DEBUG_MODE)
 
         # set the fee and resend
+        # the fee manually set would be lesser than needed fee, and in particular lesser than minRelayTxFee resulting in an error
         fee = Decimal('0.0000009')
+        cmdParms = {"fee":fee}
+        mark_logs("\nNode 2 sends funds to sc", self.nodes, DEBUG_MODE)
+        try:
+            tx = self.nodes[2].sc_send(outputs, cmdParms)
+            assert_true(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            mark_logs(errorString,self.nodes,DEBUG_MODE)
+
+        # set the fee and resend
+        # the fee manually set would be lesser than needed fee, but in particular greater than minRelayTxFee resulting in a warning
+        fee = Decimal('0.00000135')
         cmdParms = {"fee":fee}
         mark_logs("\nNode 2 sends funds to sc", self.nodes, DEBUG_MODE)
         try:

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -464,6 +464,10 @@ def assert_greater_or_equal_than(thing1, thing2):
     if thing1 < thing2:
         raise AssertionError("%s < %s"%(str(thing1),str(thing2)))
 
+def assert_greater_or_equal_than(thing1, thing2):
+    if thing1 < thing2:
+        raise AssertionError("%s <= %s"%(str(thing1),str(thing2)))
+
 def assert_raises(exc, fun, *args, **kwds):
     try:
         fun(*args, **kwds)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -47,7 +47,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance("*"), 11.4375)
         assert_equal(self.nodes[2].getbalance("*"), 0)
 
-        # Send 12 BTC from 0 to 2 using sendtoaddress call.
+        # Send 12 and 11.4375 BTC from 0 to 2 using sendtoaddress call.
         # Second transaction will be child of first, and will require a fee
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 12)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11.4375)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ BITCOIN_CORE_H = \
   clientversion.h \
   coincontrol.h \
   coins.h \
+  coinsselectionalgorithm.hpp \
   compat.h \
   compat/byteswap.h \
   compat/endian.h \
@@ -326,6 +327,7 @@ libbitcoin_wallet_a_SOURCES = \
   paymentdisclosuredb.cpp \
   wallet/rpcdisclosure.cpp \
   wallet/rpcdump.cpp \
+  coinsselectionalgorithm.cpp \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \
   wallet/wallet_ismine.cpp \

--- a/src/coinsselectionalgorithm.cpp
+++ b/src/coinsselectionalgorithm.cpp
@@ -1,0 +1,646 @@
+#include "coinsselectionalgorithm.hpp"
+#include <cstdio>
+#include <iostream>
+#include <string>
+#if COINS_SELECTION_ALGORITHM_PROFILING
+#include <chrono>
+#endif
+
+/* ---------- CCoinsSelectionAlgorithmBase ---------- */
+
+CCoinsSelectionAlgorithmBase::CCoinsSelectionAlgorithmBase(CoinsSelectionAlgorithmType _type,
+                                                           std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                                           CAmount _targetAmount,
+                                                           CAmount _targetAmountPlusOffset,
+                                                           size_t _availableTotalSize,
+                                                           uint64_t _executionTimeoutMilliseconds)
+                                                           : type {_type},
+                                                             problemDimension {(unsigned int)_amountsAndSizesAndIds.size()},
+                                                             maxIndex {(unsigned int)_amountsAndSizesAndIds.size() - 1},
+                                                             amounts {PrepareAmounts(_amountsAndSizesAndIds)},
+                                                             // sizes must be initialized after amounts (PrepareSizes leverages sorting done by PrepareAmounts)
+                                                             sizes {PrepareSizes(_amountsAndSizesAndIds)},
+                                                             // ids must be initialized after amounts (PrepareSizes leverages sorting done by PrepareAmounts)
+                                                             ids {PrepareIds(_amountsAndSizesAndIds)},
+                                                             targetAmount {_targetAmount},
+                                                             targetAmountPlusOffset {_targetAmountPlusOffset},
+                                                             availableTotalSize {_availableTotalSize},
+                                                             executionTimeoutMilliseconds {_executionTimeoutMilliseconds}
+{
+    tempSelection = std::vector<char>(problemDimension, 0);
+    optimalSelection = std::vector<char>(problemDimension, 0);
+}
+
+CCoinsSelectionAlgorithmBase::~CCoinsSelectionAlgorithmBase()
+{
+    StopSolving();
+}
+
+std::vector<CAmount> CCoinsSelectionAlgorithmBase::PrepareAmounts(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds)
+{
+    std::sort(amountsAndSizesAndIds.begin(), amountsAndSizesAndIds.end(), std::greater<>());
+    std::vector<CAmount> sortedAmounts(amountsAndSizesAndIds.size(), 0);
+    for (int index = 0; index < problemDimension; ++index)
+    {
+        sortedAmounts[index] = std::get<0>(amountsAndSizesAndIds[index]);
+    }
+    return sortedAmounts;
+}
+
+std::vector<size_t> CCoinsSelectionAlgorithmBase::PrepareSizes(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds)
+{
+    std::vector<size_t> sortedSizes(amountsAndSizesAndIds.size(), 0);
+    for (int index = 0; index < problemDimension; ++index)
+    {
+        sortedSizes[index] = std::get<1>(amountsAndSizesAndIds[index]);
+    }
+    return sortedSizes;
+}
+
+std::vector<int> CCoinsSelectionAlgorithmBase::PrepareIds(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds)
+{
+    std::vector<int> sortedIds(amountsAndSizesAndIds.size(), 0);
+    for (int index = 0; index < problemDimension; ++index)
+    {
+        sortedIds[index] = std::get<2>(amountsAndSizesAndIds[index]);
+    }
+    return sortedIds;
+}
+
+bool CCoinsSelectionAlgorithmBase::Reset()
+{
+    bool resetActuallyDone = false;
+
+    if (isRunning || hasCompleted || stopRequested)
+    {
+        if (isRunning)
+        {
+            StopSolving();
+        }
+        tempSelection.assign(problemDimension, 0);
+        optimalSelection.assign(problemDimension, 0);
+
+        optimalTotalAmount = 0;
+        optimalTotalSize = 0;
+        optimalTotalSelection= 0;
+
+        isRunning = false;
+        asyncStartRequested = false;
+        stopRequested = false;
+        solvingThread = nullptr;
+        hasCompleted = false;
+        executionStartMilliseconds = 0;        
+        executionElapsedMilliseconds = 0;
+        timeoutHit = false;
+        resetActuallyDone = true;
+    }
+
+    return resetActuallyDone;
+}
+
+std::string CCoinsSelectionAlgorithmBase::ToString()
+{
+    return std::string("Input:")
+                                + "{targetAmount=" + std::to_string(targetAmount) +
+                                  ",targetAmountPlusOffset=" + std::to_string(targetAmountPlusOffset) +
+                                  ",availableTotalSize=" + std::to_string(availableTotalSize) + "}\n" +
+                       "Output:"
+                                + "{optimalTotalAmount=" + std::to_string(optimalTotalAmount) +
+                                  ",optimalTotalSize=" + std::to_string(optimalTotalSize) +
+                                  ",optimalTotalSelection=" + std::to_string(optimalTotalSelection) + "}\n";
+}
+
+void CCoinsSelectionAlgorithmBase::StartSolvingAsync()
+{
+    if (!isRunning && !asyncStartRequested)
+    {
+        asyncStartRequested = true;
+        solvingThread = std::unique_ptr<std::thread>(new std::thread(&CCoinsSelectionAlgorithmBase::Solve, this));
+    }
+}
+
+void CCoinsSelectionAlgorithmBase::StopSolving()
+{
+    stopRequested = true;
+    if (solvingThread != nullptr)
+    {
+        solvingThread->join();
+        solvingThread.reset();
+    }
+}
+
+void CCoinsSelectionAlgorithmBase::GetBestAlgorithmBySolution(std::unique_ptr<CCoinsSelectionAlgorithmBase> &left, std::unique_ptr<CCoinsSelectionAlgorithmBase> &right, std::unique_ptr<CCoinsSelectionAlgorithmBase> &best)
+{
+    if ((left->optimalTotalSelection > right->optimalTotalSelection) ||
+        (left->optimalTotalSelection == right->optimalTotalSelection && left->optimalTotalAmount <= right->optimalTotalAmount))
+    {
+        best.swap(left);
+    }
+    else
+    {
+        best.swap(right);
+    }
+}
+
+CoinsSelectionAlgorithmType CCoinsSelectionAlgorithmBase::GetAlgorithmType() const
+{
+    return type;
+}
+
+bool CCoinsSelectionAlgorithmBase::GetHasCompleted() const
+{
+    return hasCompleted;
+}
+
+uint64_t CCoinsSelectionAlgorithmBase::GetExecutionElapsedMilliseconds() const
+{
+    return executionElapsedMilliseconds;
+}
+
+const std::vector<char>& CCoinsSelectionAlgorithmBase::GetOptimalSelection() const
+{
+    return optimalSelection;
+}
+
+CAmount CCoinsSelectionAlgorithmBase::GetOptimalTotalAmount() const
+{
+    return optimalTotalAmount;
+}
+
+size_t CCoinsSelectionAlgorithmBase::GetOptimalTotalSize() const
+{
+    return optimalTotalSize;
+}
+
+unsigned int CCoinsSelectionAlgorithmBase::GetOptimalTotalSelection() const
+{
+    return optimalTotalSelection;
+}
+
+/* ---------- CCoinsSelectionAlgorithmBase ---------- */
+
+/* ---------- CCoinsSelectionSlidingWindow ---------- */
+
+CCoinsSelectionSlidingWindow::CCoinsSelectionSlidingWindow(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                                           CAmount _targetAmount,
+                                                           CAmount _targetAmountPlusOffset,
+                                                           size_t _availableTotalSize,
+                                                           uint64_t _executionTimeoutMilliseconds)
+                                                           : CCoinsSelectionAlgorithmBase(CoinsSelectionAlgorithmType::SLIDING_WINDOW,
+                                                                                          _amountsAndSizesAndIds,
+                                                                                          _targetAmount,
+                                                                                          _targetAmountPlusOffset,
+                                                                                          _availableTotalSize,
+                                                                                          _executionTimeoutMilliseconds)
+{
+}
+
+CCoinsSelectionSlidingWindow::~CCoinsSelectionSlidingWindow()
+{
+}
+
+bool CCoinsSelectionSlidingWindow::Reset()
+{
+    bool resetActuallyDone = CCoinsSelectionAlgorithmBase::Reset();
+
+    if (resetActuallyDone)
+    {
+        #if COINS_SELECTION_ALGORITHM_PROFILING
+        iterations = 0;
+        #endif
+    }
+
+    return resetActuallyDone;
+}
+
+void CCoinsSelectionSlidingWindow::Solve()
+{
+    if (!isRunning)
+    {
+        Reset();
+
+        isRunning = true;
+        executionStartMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        size_t tempTotalSize = 0;
+        CAmount tempTotalAmount = 0;
+        unsigned int tempTotalSelection = 0;
+        int windowFrontIndex = maxIndex;
+        int windowBackIndex = maxIndex;
+        bool admissibleFound = false;
+        bool bestAdmissibleFound = false; // "best" for this specific algorithm implementation
+        for (; !stopRequested && windowFrontIndex >= 0; --windowFrontIndex)
+        {
+            // timeout handling
+            if (executionTimeoutMilliseconds > 0 &&
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds > executionTimeoutMilliseconds)
+            {
+                timeoutHit = true;
+                break;
+            }
+
+            #if COINS_SELECTION_ALGORITHM_PROFILING
+            ++iterations;
+            #endif
+
+            // insert new coin in selection
+            tempSelection[windowFrontIndex] = 1;
+            tempTotalSize += sizes[windowFrontIndex];
+            tempTotalAmount += amounts[windowFrontIndex];
+            tempTotalSelection += 1;
+
+            // check upper-limit constraints
+            while (tempTotalSize > availableTotalSize ||
+                   tempTotalAmount > targetAmountPlusOffset)
+            {
+                #if COINS_SELECTION_ALGORITHM_PROFILING
+                ++iterations;
+                #endif
+       
+                // if admissible solution still not found, pop from back of the sliding window
+                if (!admissibleFound)
+                {
+                    tempSelection[windowBackIndex] = 0;
+                    tempTotalSize -= sizes[windowBackIndex];
+                    tempTotalAmount -= amounts[windowBackIndex];
+                    tempTotalSelection -= 1;
+                    --windowBackIndex;
+                }
+                // if admissible solution already found, pop from front of the sliding window only the element just inserted (and break)
+                else
+                {
+                    tempSelection[windowFrontIndex] = 0;
+                    tempTotalSize -= sizes[windowFrontIndex];
+                    tempTotalAmount -= amounts[windowFrontIndex];
+                    tempTotalSelection -= 1;
+                    bestAdmissibleFound = true;
+                    break; // almost surely it is useless, but kept for better flow
+                }
+            }
+
+            // check lower-limit constraint
+            if (tempTotalAmount >= targetAmount)
+            {
+                admissibleFound = true;
+                // if best admissible solution already found or reached array end, set optimal solution
+                if (bestAdmissibleFound || windowFrontIndex == 0)
+                {
+                    optimalTotalSize = tempTotalSize;
+                    optimalTotalAmount = tempTotalAmount;
+                    optimalTotalSelection = tempTotalSelection;
+                    optimalSelection.assign(tempSelection.begin(), tempSelection.end());
+                    break;
+                }
+            }
+        }
+
+        executionElapsedMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds;
+        hasCompleted = !stopRequested && !timeoutHit;
+        isRunning = false;
+    }
+}
+
+/* ---------- CCoinsSelectionSlidingWindow ---------- */
+
+/* ---------- CCoinsSelectionBranchAndBound ---------- */
+
+CCoinsSelectionBranchAndBound::CCoinsSelectionBranchAndBound(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                                             CAmount _targetAmount,
+                                                             CAmount _targetAmountPlusOffset,
+                                                             size_t _availableTotalSize,
+                                                             uint64_t _executionTimeoutMilliseconds)
+                                                             : CCoinsSelectionAlgorithmBase(CoinsSelectionAlgorithmType::BRANCH_AND_BOUND,
+                                                                                            _amountsAndSizesAndIds,
+                                                                                            _targetAmount,
+                                                                                            _targetAmountPlusOffset,
+                                                                                            _availableTotalSize,
+                                                                                            _executionTimeoutMilliseconds),
+                                                                                            cumulativeAmountsForward {PrepareCumulativeAmountsForward()}
+{
+}
+
+CCoinsSelectionBranchAndBound::~CCoinsSelectionBranchAndBound() {
+}
+
+std::vector<CAmount> CCoinsSelectionBranchAndBound::PrepareCumulativeAmountsForward()
+{
+    std::vector<CAmount> cumulativeAmountsForwardTemp(problemDimension + 1, 0);
+    cumulativeAmountsForwardTemp[problemDimension] = 0;
+    for (int index = problemDimension - 1; index >= 0; --index)
+    {
+        cumulativeAmountsForwardTemp[index] = cumulativeAmountsForwardTemp[index + 1] + amounts[index];
+    }
+    return cumulativeAmountsForwardTemp;
+}
+
+void CCoinsSelectionBranchAndBound::SolveRecursive(int currentIndex, size_t tempTotalSize, CAmount tempTotalAmount, unsigned int tempTotalSelection)
+{
+    #if COINS_SELECTION_ALGORITHM_PROFILING
+    ++recursions;
+    #endif
+    int nextIndex = currentIndex + 1;
+    // it has been empirically found that it is better to perform first exclusion and then inclusion this,
+    // together with the descending order of coins, is probably due to the fact in this way the algorithm
+    // arrives quickly at exploring tree branches with low amount coins (instead of dealing with included
+    // high amount coins that would hardly represent the optimal solution)
+    for (char value = 0; value <= 1; ++value)
+    {
+        // timeout handling
+        if (timeoutHit)
+        {
+            break;
+        }
+        if (value == 0 && currentIndex % CCoinsSelectionBranchAndBound::TIMEOUT_CHECK_PERIOD == 0 && // in order to avoid checking too frequently
+            executionTimeoutMilliseconds > 0 &&
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds > executionTimeoutMilliseconds)
+        {
+            timeoutHit = true;
+            break;
+        }
+
+        if (stopRequested)
+        {
+            break;
+        }
+        tempSelection[currentIndex] = value;
+        #if COINS_SELECTION_ALGORITHM_PROFILING
+        ++reachedNodes;
+        #endif
+        size_t tempTotalSizeNew = tempTotalSize + (value ? sizes[currentIndex] : 0);
+        if (tempTotalSizeNew <= availableTotalSize) // {backtracking}
+        {
+            CAmount tempTotalAmountNew = tempTotalAmount + (value ? amounts[currentIndex] : 0);
+            if (tempTotalAmountNew <= targetAmountPlusOffset) // {backtracking}
+            {
+                CAmount tempTotalAmountNewBiggestPossible = tempTotalAmountNew + cumulativeAmountsForward[nextIndex];
+                if (tempTotalAmountNewBiggestPossible >= targetAmount) // {backtracking}
+                {
+                    unsigned int tempTotalSelectionNew = tempTotalSelection + (value ? 1 : 0);
+                    unsigned int maxTotalSelectionForward = tempTotalSelectionNew + (maxIndex - currentIndex);
+                    if ((maxTotalSelectionForward > optimalTotalSelection) ||
+                        (maxTotalSelectionForward == optimalTotalSelection && tempTotalAmountNewBiggestPossible < optimalTotalAmount)) // {bounding}
+                    {
+                        if (tempTotalAmountNew < targetAmount) // no check "(currentIndex < maxIndex)" because already handled by boudning condition
+                        {                            
+                            SolveRecursive(nextIndex, tempTotalSizeNew, tempTotalAmountNew, tempTotalSelectionNew);
+                        }
+                        else // if admissible, then check if better and prune {pruning}
+                        {
+                            #if COINS_SELECTION_ALGORITHM_PROFILING
+                            if (currentIndex == maxIndex)
+                                ++reachedLeaves;
+                            #endif
+
+                            if ((tempTotalSelectionNew > optimalTotalSelection) ||
+                                (tempTotalSelectionNew == optimalTotalSelection && tempTotalAmountNew < optimalTotalAmount))
+                            {
+                                optimalTotalSize = tempTotalSizeNew;
+                                optimalTotalAmount = tempTotalAmountNew;
+                                optimalTotalSelection = tempTotalSelectionNew;
+                                // not necessarily at a leaf (hence only a partial copy is performed)
+                                for (int i = 0; i <= currentIndex; ++i)
+                                {
+                                    optimalSelection[i] = tempSelection[i];
+                                }
+                                for (int i = currentIndex + 1; i < problemDimension; ++i)
+                                {
+                                    optimalSelection[i] = 0;
+                                }
+                            }
+                            #if COINS_SELECTION_ALGORITHM_PROFILING
+                            else
+                            {
+                                avoidedRecursionsPruning += maxIndex - currentIndex;
+                            }
+                            #endif
+                        }
+                    }
+                    #if COINS_SELECTION_ALGORITHM_PROFILING
+                    else
+                    {
+                        avoidedRecursionsBounding += maxIndex - currentIndex;
+                    }
+                    #endif
+                }
+                #if COINS_SELECTION_ALGORITHM_PROFILING
+                else
+                {
+                    avoidedRecursionsBacktracking += maxIndex - currentIndex;
+                }
+                #endif
+            }
+            #if COINS_SELECTION_ALGORITHM_PROFILING
+            else
+            {
+                avoidedRecursionsBacktracking += maxIndex - currentIndex;
+            }
+            #endif
+        }
+        #if COINS_SELECTION_ALGORITHM_PROFILING
+        else
+        {
+            avoidedRecursionsBacktracking += maxIndex - currentIndex;
+        }
+        #endif
+    }
+}
+
+bool CCoinsSelectionBranchAndBound::Reset()
+{
+    bool resetActuallyDone = CCoinsSelectionAlgorithmBase::Reset();
+
+    if (resetActuallyDone)
+    {
+        #if COINS_SELECTION_ALGORITHM_PROFILING
+        recursions = 0;
+        reachedNodes = 0;
+        reachedLeaves = 0;
+        avoidedRecursionsBacktracking = 0;
+        avoidedRecursionsBounding = 0;
+        avoidedRecursionsPruning = 0;
+        #endif
+    }
+
+    return resetActuallyDone;
+}
+
+void CCoinsSelectionBranchAndBound::Solve()
+{
+    if (!isRunning)
+    {
+        Reset();
+
+        isRunning = true;
+        executionStartMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        SolveRecursive(0, 0, 0, 0);
+        executionElapsedMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds;
+        hasCompleted = !stopRequested && !timeoutHit;
+        isRunning = false;
+    }
+}
+
+/* ---------- CCoinsSelectionBranchAndBound ---------- */
+
+/* ---------- CCoinsSelectionForNotes ---------- */
+
+CCoinsSelectionForNotes::CCoinsSelectionForNotes(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                                 CAmount _targetAmount,
+                                                 CAmount _targetAmountPlusOffset,
+                                                 size_t _availableTotalSize,
+                                                 uint64_t _executionTimeoutMilliseconds,
+                                                 std::vector<CAmount> _joinsplitsOutputsAmounts)
+                                                 : CCoinsSelectionAlgorithmBase(CoinsSelectionAlgorithmType::FOR_NOTES,
+                                                                                _amountsAndSizesAndIds,
+                                                                                _targetAmount,
+                                                                                _targetAmountPlusOffset,
+                                                                                _availableTotalSize,
+                                                                                _executionTimeoutMilliseconds),
+                                                                                numberOfJoinsplitsOutputsAmounts {(unsigned int)_joinsplitsOutputsAmounts.size()},
+                                                                                joinsplitsOutputsAmounts(_joinsplitsOutputsAmounts)
+{
+}
+
+CCoinsSelectionForNotes::~CCoinsSelectionForNotes()
+{
+}
+
+bool CCoinsSelectionForNotes::Reset()
+{
+    bool resetActuallyDone = CCoinsSelectionAlgorithmBase::Reset();
+
+    if (resetActuallyDone)
+    {
+        #if COINS_SELECTION_ALGORITHM_PROFILING
+        iterations = 0;
+        #endif
+    }
+
+    return resetActuallyDone;
+}
+
+void CCoinsSelectionForNotes::Solve()
+{
+    if (!isRunning)
+    {
+        Reset();
+
+        isRunning = true;
+        executionStartMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        int windowBackIndex = maxIndex;
+        int windowFrontIndex = maxIndex;
+        bool admissibleFound = false;
+        bool bestAdmissibleFound = false; // "best" for this specific algorithm implementation
+        bool breakOuterLoop = false;
+
+        for (; !stopRequested && !breakOuterLoop && windowBackIndex >= 0; --windowBackIndex)
+        {
+            // quick reset before restarting with sliding window back index decreased by one position
+            std::fill(tempSelection.begin(), tempSelection.end(), 0);
+            size_t tempTotalSize = 0;
+            CAmount tempTotalAmount = 0;
+            unsigned int tempTotalSelection = 0;
+        
+            // joinsplits auxiliary variables
+            int joinsplitsOutputAmountIndex = 0;
+            bool isFirstJoinsplitInput = true;
+            CAmount joinsplitValue = 0;
+            CAmount changeFromPreviousJoinsplit = 0;
+
+            for (windowFrontIndex = windowBackIndex; !stopRequested && windowFrontIndex >= 0; --windowFrontIndex)   
+            {
+                // timeout handling
+                if (executionTimeoutMilliseconds > 0 &&
+                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds > executionTimeoutMilliseconds)
+                {
+                    breakOuterLoop = true;
+                    timeoutHit = true;
+                    break;
+                }
+
+                #if COINS_SELECTION_ALGORITHM_PROFILING
+                ++iterations;
+                #endif
+
+                // insert new note in selection
+                tempSelection[windowFrontIndex] = 1;
+                size_t tempTotalSizeIterationIncrease = isFirstJoinsplitInput ? sizes[windowFrontIndex] : 0;
+                tempTotalSize += tempTotalSizeIterationIncrease;
+                tempTotalAmount += amounts[windowFrontIndex];
+                tempTotalSelection += 1;
+
+                // update joinsplit auxiliary variables
+                if (isFirstJoinsplitInput && changeFromPreviousJoinsplit == 0)
+                {
+                    // first joinsplit input
+                    joinsplitValue = amounts[windowFrontIndex];
+                    isFirstJoinsplitInput = false;
+                }
+                else
+                {
+                    // first joinsplit input as previous joinsplit change
+                    if (isFirstJoinsplitInput && changeFromPreviousJoinsplit > 0)
+                    {
+                        joinsplitValue = changeFromPreviousJoinsplit;
+                    }
+                    //second joinsplit input
+                    joinsplitValue += amounts[windowFrontIndex];
+                    if (joinsplitsOutputAmountIndex < numberOfJoinsplitsOutputsAmounts)
+                    {
+                        if (joinsplitValue >= joinsplitsOutputsAmounts[joinsplitsOutputAmountIndex])
+                        {
+                            changeFromPreviousJoinsplit = joinsplitValue - joinsplitsOutputsAmounts[joinsplitsOutputAmountIndex];
+                            ++joinsplitsOutputAmountIndex;
+                        }
+                        else
+                        {
+                            joinsplitsOutputsAmounts[joinsplitsOutputAmountIndex] -= joinsplitValue;
+                            changeFromPreviousJoinsplit = 0;
+                        }
+                    }
+                    isFirstJoinsplitInput = true;
+                }
+
+                // check upper-limit constraints
+                if (tempTotalSize + (numberOfJoinsplitsOutputsAmounts - joinsplitsOutputAmountIndex) * sizes[0] > availableTotalSize || // first element size is used (but actually all sizes are equal)
+                    tempTotalAmount > targetAmountPlusOffset)
+                {
+                    // if admissible solution still not found, restart with sliding window back index increased by one position
+                    if (!admissibleFound)
+                    {
+                        break;
+                    }
+                    // if admissible solution already found, pop from front of the sliding window only the element just inserted
+                    else
+                    {
+                        tempSelection[windowFrontIndex] = 0;
+                        tempTotalSize -= tempTotalSizeIterationIncrease;
+                        tempTotalAmount -= amounts[windowFrontIndex];
+                        tempTotalSelection -= 1;
+                        bestAdmissibleFound = true;
+                    }                    
+                }
+
+                // check lower-limit constraint
+                if (tempTotalAmount >= targetAmount)
+                {
+                    admissibleFound = true;
+                    // if best admissible solution already found or reached array end, set optimal solution
+                    if (bestAdmissibleFound || windowFrontIndex == 0)
+                    {
+                        optimalTotalSize = tempTotalSize + (numberOfJoinsplitsOutputsAmounts - joinsplitsOutputAmountIndex) * sizes[0]; // first element size is used (but actually all sizes are equal)
+                        optimalTotalAmount = tempTotalAmount;
+                        optimalTotalSelection = tempTotalSelection;
+                        optimalSelection.assign(tempSelection.begin(), tempSelection.end());
+                        breakOuterLoop = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        executionElapsedMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - executionStartMilliseconds;
+        hasCompleted = !stopRequested && !timeoutHit;
+        isRunning = false;
+    }
+}
+
+/* ---------- CCoinsSelectionForNotes ---------- */

--- a/src/coinsselectionalgorithm.hpp
+++ b/src/coinsselectionalgorithm.hpp
@@ -1,0 +1,528 @@
+#ifndef _COINS_SELECTION_ALGORITHM_H
+#define _COINS_SELECTION_ALGORITHM_H
+
+
+#include <string>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include "amount.h"
+
+
+//! Flag for profiling/debugging mode
+#define COINS_SELECTION_ALGORITHM_PROFILING 0
+
+//! This represents the number of intermediate change levels inside the interval [targetAmount + 0, targetAmount + maxChange]
+/*!
+  Low value -> higher quantity of selected utxos and higher change, high value -> lower quantity of selected utxos and lower change
+*/
+constexpr int COINS_SELECTION_INTERMEDIATE_CHANGE_LEVELS = 9;
+
+
+//! Types of coins selection algorithm
+enum class CoinsSelectionAlgorithmType {
+    UNDEFINED = 0,
+    SLIDING_WINDOW = 1,
+    BRANCH_AND_BOUND = 2,
+    FOR_NOTES = 3
+};
+
+/* ---------- CCoinsSelectionAlgorithmBase ---------- */
+
+//! Abstract class for algorithm of coins selection
+/*!
+  This class provides common fields required by each implementation and utility methods
+*/
+class CCoinsSelectionAlgorithmBase
+{    
+protected:
+    //! The algorithm type
+    const CoinsSelectionAlgorithmType type;
+
+    // ---------- auxiliary
+    //! The temporary set of selected elements (1->selected, 0->unselected)
+    //! std::vector<char> is used over std::vector<bool> for favoring processing performance over memory optimization
+    std::vector<char> tempSelection;
+
+    //! Max index of elements (equal to "problemDimension - 1")
+    const unsigned int maxIndex;
+    // ---------- auxiliary
+
+    // ---------- profiling and control
+    //! Flag identifying if the solving routine is running
+    std::atomic<bool> isRunning = false;
+
+    //! Flag identifying if an async start of the solving routine has been requested
+    std::atomic<bool> asyncStartRequested = false;
+
+    //! Flag identifying if a stop of the solving routine has been requested
+    std::atomic<bool> stopRequested = false;
+
+    //! The thread associated to the solving routine
+    std::unique_ptr<std::thread> solvingThread = nullptr;
+
+    //! Flag identifying if the solving routine has completed
+    std::atomic<bool> hasCompleted = false;
+
+    //! Milliseconds the solving routine started at
+    uint64_t executionStartMilliseconds = 0;
+
+    //! Milliseconds elapsed completing the solving routine
+    uint64_t executionElapsedMilliseconds = 0;
+
+    //! Flag identifying if the solving routine has hit timeout
+    bool timeoutHit = false;
+    // ---------- profiling and control
+
+    // ---------- output variables
+    //! The optimal set of selected elements (1->selected, 0->unselected)
+    //! std::vector<char> is used over std::vector<bool> for favoring processing over optimization
+    std::vector<char> optimalSelection;
+
+    //! The total amount of optimal selection
+    CAmount optimalTotalAmount = 0;
+
+    //! The total size of optimal selection
+    size_t optimalTotalSize = 0;
+
+    //! The quantity of elements of optimal selection (this is the variable to be maximized)
+    unsigned int optimalTotalSelection = 0;
+    // ---------- output variables
+
+public:
+    // ---------- input variables
+    //! Number of elements
+    const unsigned int problemDimension;
+
+    //! The array of amounts
+    const std::vector<CAmount> amounts;
+
+    //! The array of sizes (in terms of bytes of the associated input)
+    const std::vector<size_t> sizes;
+
+    //! The array of ids
+    const std::vector<int> ids;
+
+    //! The target amount to satisfy (it is a lower-limit constraint)
+    const CAmount targetAmount;
+
+    //! The target amount plus a positive offset (it is an upper-limit constraint)
+    const CAmount targetAmountPlusOffset;
+
+    //! The available total size (in terms of bytes, it is an upper-limit constraint)
+    const size_t availableTotalSize;
+
+    //! Timeout for completing solving routine (in milliseconds)
+    const uint64_t executionTimeoutMilliseconds = 0;
+    // ---------- input variables
+
+private:
+    //! Method for preparing array of amounts sorting them with descending order (with respect to amounts)
+    /*!
+      \param amountsAndSizes vector of tuples of amounts and sizes and ids of the elements
+      \return the array of amounts in descending order
+    */
+    std::vector<CAmount> PrepareAmounts(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds);
+
+    //! Method for preparing array of sizes (expects descending order with respect to amounts)
+    /*!
+      \param amountsAndSizes vector of tuples of amounts and sizes and ids of the elements
+      \return the array of sizes
+    */
+    std::vector<size_t> PrepareSizes(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds);
+
+    //! Method for preparing array of ids (expects descending order with respect to amounts)
+    /*!
+      \param amountsAndSizes vector of tuples of amounts and sizes and ids of the elements
+      \return the array of ids
+    */
+    std::vector<int> PrepareIds(std::vector<std::tuple<CAmount, size_t, int>>& amountsAndSizesAndIds);
+
+protected:
+    //! Method for resetting internal variables (must be called before restarting the algorithm)
+    /*!
+      \return the flag representing if the reset was actually done
+    */
+    virtual bool Reset();
+
+public:
+    //! Constructor
+    /*!
+      \param _type algorithm type
+      \param _amountsAndSizesAndIds vector of tuples of amounts and sizes and ids of the elements
+      \param _targetAmount target amount to satisfy (it is a lower-limit constraint)
+      \param _targetAmountPlusOffset target amount plus a positive offset (it is an upper-limit constraint)
+      \param _availableTotalSize available total size (in terms of bytes, it is an upper-limit constraint)
+      \param _executionTimeoutMilliseconds timeout for completing solving routine (in milliseconds) (default to 0)
+    */
+    CCoinsSelectionAlgorithmBase(CoinsSelectionAlgorithmType _type,
+                                 std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                 CAmount _targetAmount,
+                                 CAmount _targetAmountPlusOffset,
+                                 size_t _availableTotalSize,
+                                 uint64_t _executionTimeoutMilliseconds = 0);
+
+    //! Deleted copy constructor
+    CCoinsSelectionAlgorithmBase(const CCoinsSelectionAlgorithmBase&) = delete;
+
+    //! Deleted move constructor (deletion not needed, but better to be explicit)
+    CCoinsSelectionAlgorithmBase(CCoinsSelectionAlgorithmBase&&) = delete;
+
+    //! Deleted assignment operator
+    CCoinsSelectionAlgorithmBase& operator=(const CCoinsSelectionAlgorithmBase&) = delete;
+
+    //! Deleted move operator (deletion not needed, but better to be explicit)
+    CCoinsSelectionAlgorithmBase& operator=(CCoinsSelectionAlgorithmBase&&) = delete;
+
+    //! Destructor
+    virtual ~CCoinsSelectionAlgorithmBase();
+
+    //! Method for asynchronously starting the solving routine
+    void StartSolvingAsync();
+
+    //! Abstract method for synchronously running the solving routine
+    virtual void Solve() = 0;
+
+    //! Method for synchronously stopping the solving routine
+    void StopSolving();
+
+    //! Method for providing a string representation of the algorithm input and output variables
+    /*!
+      \return a string representation of the algorithm input and output variables
+    */
+    std::string ToString();
+
+    //! Static method for selecting the best among two algorithms based on their output variables
+    /*!
+      \param left the algorithm for comparison (this is returned in case of full tie)
+      \param right the other algorithm for comparison
+      \param best the best algorithm
+    */
+    static void GetBestAlgorithmBySolution(std::unique_ptr<CCoinsSelectionAlgorithmBase> &left, std::unique_ptr<CCoinsSelectionAlgorithmBase> &right, std::unique_ptr<CCoinsSelectionAlgorithmBase> &best);
+
+    // ---------- getters
+    //! Method for getting the algorithm type
+    /*!
+      \return the algorithm type
+    */
+    CoinsSelectionAlgorithmType GetAlgorithmType() const;
+
+    //! Method for getting if the solving routine has completed
+    /*!
+      \return the flag representing if the solving routine has completed
+    */
+    bool GetHasCompleted() const;
+
+    //! Method for getting the milliseconds elapsed completing the solving routine
+    /*!
+      \return the milliseconds elapsed completing the solving routine
+    */
+    uint64_t GetExecutionElapsedMilliseconds() const;
+
+    //! Method for getting the optimal set of selected elements (true->selected, false->unselected)
+    /*!
+      \return the optimal set of selected elements
+    */
+    const std::vector<char>& GetOptimalSelection() const;
+
+    //! Method for getting the total amount of optimal selection
+    /*!
+      \return the total amount of optimal selection
+    */
+    CAmount GetOptimalTotalAmount() const;
+
+    //! Method for getting the total size of optimal selection (the underlying variable is the one to be maximized)
+    /*!
+      \return the total size of optimal selection
+    */
+    size_t GetOptimalTotalSize() const;
+
+    //! Method for getting the quantity of elements of optimal selection
+    /*!
+      \return the quantity of elements of optimal selection
+    */
+    unsigned int GetOptimalTotalSelection() const;
+    // ---------- getters
+};
+
+/* ---------- CCoinsSelectionAlgorithmBase ---------- */
+
+/* ---------- CCoinsSelectionSlidingWindow ---------- */
+
+//! "Sliding Window" implementation of algorithm of coins selection
+/*!
+  This class provides a specific implementation of the solving routine.
+  In this implementation coins are iteratively added to (or removed from) current selection set starting from lowest
+  amount coin and proceeding towards highest amount coin.
+  At each iteration the algorithm pushes in the next coin; if the target amount plus offset and available total size
+  constraints (upper-limit) are not met, the algorithm starts popping out the smallest coins until the two constraints
+  above are met; then the algorithm checks if the target amount constraint (lower-limit) is met; if it is not met, the
+  algorithm continues with next coin insertion, otherwise it marks the finding of an admissible solution and performs
+  additional insertions until one of the upper-limit constraints is broken (and thus removing the just inserted coin)
+  or the set of available coins is empty, eventually setting the best selection set.
+*/
+class CCoinsSelectionSlidingWindow : public CCoinsSelectionAlgorithmBase
+{
+protected:
+    // ---------- profiling
+    #if COINS_SELECTION_ALGORITHM_PROFILING
+    //! Counter for keeping track of the number of iterations the solving routine has performed
+    uint64_t iterations = 0;
+    #endif
+    // ---------- profiling
+
+protected:
+    //! Method for resetting internal variables (must be called before restarting the algorithm)
+    /*!
+      \return the flag representing if the reset was actually done
+    */
+    bool Reset() override;
+
+public:
+    //! Constructor
+    /*!
+      \param _amountsAndSizesAndIds vector of tuples of amounts and sizes and ids of the elements
+      \param _targetAmount target amount to satisfy (it is a lower-limit constraint)
+      \param _targetAmountPlusOffset target amount plus a positive offset (it is an upper-limit constraint)
+      \param _availableTotalSize available total size (in terms of bytes, it is an upper-limit constraint)
+      \param _executionTimeoutMilliseconds timeout for completing solving routine (in milliseconds) (default to 0)
+    */
+    CCoinsSelectionSlidingWindow(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                 CAmount _targetAmount,
+                                 CAmount _targetAmountPlusOffset,
+                                 size_t _availableTotalSize,
+                                 uint64_t _executionTimeoutMilliseconds = 0);
+
+    //! Deleted copy constructor
+    CCoinsSelectionSlidingWindow(const CCoinsSelectionSlidingWindow&) = delete;
+
+    //! Deleted move constructor (deletion not needed, but better to be explicit)
+    CCoinsSelectionSlidingWindow(CCoinsSelectionSlidingWindow&&) = delete;
+
+    //! Deleted assignment operator
+    CCoinsSelectionSlidingWindow& operator=(const CCoinsSelectionSlidingWindow&) = delete;
+
+    //! Deleted move operator (deletion not needed, but better to be explicit)
+    CCoinsSelectionSlidingWindow& operator=(CCoinsSelectionSlidingWindow&&) = delete;
+
+    //! Destructor
+    ~CCoinsSelectionSlidingWindow();
+
+    //! Method for synchronously running the solving routine with "Sliding Window" strategy
+    void Solve() override;
+};
+
+/* ---------- CCoinsSelectionSlidingWindow ---------- */
+
+/* ---------- CCoinsSelectionBranchAndBound ---------- */
+
+//! "Branch & Bound" implementation of algorithm of coins selection
+/*!
+  This class provides a specific implementation of the solving routine.
+  In this implementation, a binary tree is considered as the combination of excluding/including each coin.
+  This would lead to a number of combinations equal to 2^problemDimension with a brute force strategy.
+  The algorithm doesn't rely on simple brute force strategy, instead two additional aspects are taken into account for
+  speeding up the algorithm and avoiding exploring branches which would not give an improved solution (with respect to
+  the temporary optimal one): backtracking and bounding.
+  Starting with an "all coins unselected" setup, the algorithm recursively explores the tree (from biggest coin towards
+  smallest coin) opening two new branches, the first one excluding the current coin, the second one including the current
+  coin; when a leaf is reached, the output variables are checked to identify if an improved solution (with respect to
+  the temporary optimal one) is found and eventually marked as the new temporary optimal solution.
+  The tree actual exploration differs very significantly from the tree full exploration thanks to:
+  +] backtracking (1): given that at a certain recursion, including a new coin would automatically increase both the
+     temporary total amount as well as the temporary total size, if during the tree exploration the two upper-limit
+     constraints associated to target amount plus offset and to total size are broken then all the branches from the
+     current recursion on are cut; this is done in order to avoid reaching leaves that would certainly be not admissible
+     with respect to these two constraints,
+  +] backtracking (2): given that at a certain recursion, the highest total amount reachable is computed as the sum of
+     current total amount and of all the amounts of coins from the current recursion on, if during the tree exploration
+     this sum does not exceed the lower-limit associated to target amount then all the branches from the current recursion
+     on are cut; this is done in order to avoid reaching leaves that would certainly be not admissible with respect to this
+     constraint,
+  +] bounding: given that at a certain recursion, the highest total selection reachable is computed as the sum of current
+     total selection and of the quantity of coins from the current recursion on, if during tree exploration this sum does
+     not exceed the temporary optimal solution (ties are handled prioritizing low total amount) then all the branches from
+     the current recursion on are cut; this is done in order to avoid reaching leaves that would certainly not improve the
+     temporary optimal solution.
+*/
+class CCoinsSelectionBranchAndBound : public CCoinsSelectionAlgorithmBase
+{
+private:
+  //! The timeout check period (in order to avoid checking too frequently)  
+  static constexpr int TIMEOUT_CHECK_PERIOD = 10;
+
+protected:
+    // ---------- auxiliary
+    //! The array of cumulative amounts (considered summing amounts from index to end of amounts array)
+    const std::vector<CAmount> cumulativeAmountsForward;
+    // ---------- auxiliary
+
+    // ---------- profiling
+    #if COINS_SELECTION_ALGORITHM_PROFILING
+    //! Counter for keeping track of the number of recursions the solving routine has performed
+    uint64_t recursions = 0;
+
+    //! Counter for keeping track of the number of nodes reached by the solving routine
+    uint64_t reachedNodes = 0;
+
+    //! Counter for keeping track of the number of leaves reached by the solving routine
+    uint64_t reachedLeaves = 0;
+
+    //! Counter for keeping track of the number of recursions avoided leveraging backtracking feature
+    uint64_t avoidedRecursionsBacktracking = 0;
+
+    //! Counter for keeping track of the number of recursions avoided leveraging bounding feature
+    uint64_t avoidedRecursionsBounding = 0;
+
+    //! Counter for keeping track of the number of recursions avoided leveraging pruning feature
+    uint64_t avoidedRecursionsPruning = 0;
+    #endif
+    // ---------- profiling
+
+private:
+    //! Method for preparing array of cumulative amounts
+    /*!
+      \return the array of cumulative amounts
+    */
+    std::vector<CAmount> PrepareCumulativeAmountsForward();
+
+    //! Method for synchronously running the solving routine recursion with "Branch & Bound" strategy
+    /*!
+      \param currentIndex the current index the tree exploration is at
+      \param tempTotalSize the temporary total size of tree exploration
+      \param tempTotalAmount the temporary total amount of tree exploration
+      \param tempTotalSelection the temporary total selection of tree exploration
+    */
+
+    void SolveRecursive(int currentIndex, size_t tempTotalSize, CAmount tempTotalAmount, unsigned int tempTotalSelection);
+
+protected:
+    //! Method for resetting internal variables (must be called before restarting the algorithm)
+    /*!
+      \return the flag representing if the reset was actually done
+    */
+    bool Reset() override;
+
+public:
+    //! Constructor
+    /*!
+      \param _amountsAndSizesAndIds vector of tuples of amounts and sizes and ids of the elements
+      \param _targetAmount target amount to satisfy (it is a lower-limit constraint)
+      \param _targetAmountPlusOffset target amount plus a positive offset (it is an upper-limit constraint)
+      \param _availableTotalSize available total size (in terms of bytes, it is an upper-limit constraint)
+      \param _executionTimeoutMilliseconds timeout for completing solving routine (in milliseconds) (default to 0)
+    */
+    CCoinsSelectionBranchAndBound(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                                  CAmount _targetAmount,
+                                  CAmount _targetAmountPlusOffset,
+                                  size_t _availableTotalSize,
+                                  uint64_t _executionTimeoutMilliseconds = 0);
+
+    //! Deleted copy constructor
+    CCoinsSelectionBranchAndBound(const CCoinsSelectionBranchAndBound&) = delete;
+
+    //! Deleted move constructor (deletion not needed, but better to be explicit)
+    CCoinsSelectionBranchAndBound(CCoinsSelectionBranchAndBound&&) = delete;
+
+    //! Deleted assignment operator
+    CCoinsSelectionBranchAndBound& operator=(const CCoinsSelectionBranchAndBound&) = delete;
+
+    //! Deleted move operator (deletion not needed, but better to be explicit)
+    CCoinsSelectionBranchAndBound& operator=(CCoinsSelectionBranchAndBound&&) = delete;
+
+    //! Destructor
+    ~CCoinsSelectionBranchAndBound();
+
+    //! Method for synchronously running the solving routine with "Branch & Bound" strategy
+    void Solve() override;
+};
+
+/* ---------- CCoinsSelectionBranchAndBound ---------- */
+
+/* ---------- CCoinsSelectionForNotes ---------- */
+
+//! "For Notes" implementation of algorithm of coins selection
+/*!
+  The implementation details of this method are stricly connected to the implementation of AsyncRPCOperation_sendmany::main_impl() as for commit "d1104ef903147338692344069e30c666d8b78614"
+
+  This class provides a specific implementation of the solving routine.
+  A crucial consideration is that, unlike coins selection, the selection of a note doesn't give an independent contribution
+  to overall selection size; indeed, from an iteration point of view, each selection of a note actually adds size only if
+  it triggers the insertion of a new joinsplit; furthermore, from a global point of view, the overall selection of notes
+  may require a number of joinsplits that is lower than the number of joinsplits that is requested by the recipients, hence
+  the overall size has to be updated accordingly.
+  In this implementation notes are iteratively added to (or removed from) current selection set starting from lowest
+  amount note and proceeding towards highest amount note.
+  At each iteration the algorithm pushes in the next note and check if a new joinsplit has to be included, eventually
+  updating the overall selection size accordingly; if the target amount plus offset and available total size (eventually
+  increased by mandatory joinsplits to be included for satisfying outputs amounts) constraints (upper-limit) are not met,
+  the algorithm restarts with a new search excluding the very first note used within last search; then the algorithm checks
+  if the target amount constraint (lower-limit) is met; if it is not met, the algorithm continues with next note insertion,
+  otherwise it marks the finding of an admissible solution and performs additonal insertions until one of the upper-limit
+  constraints is broken (and thus removing the just inserted note) or the set of available notes is empty, eventually
+  setting the best selection set.
+*/
+class CCoinsSelectionForNotes : public CCoinsSelectionAlgorithmBase
+{
+protected:
+    // ---------- profiling
+    #if COINS_SELECTION_ALGORITHM_PROFILING
+    //! Counter for keeping track of the number of iterations the solving routine has performed
+    uint64_t iterations = 0;
+    #endif
+    // ---------- profiling
+
+    // ---------- input variables
+    //! Number of joinsplits outputs amounts
+    const unsigned int numberOfJoinsplitsOutputsAmounts;
+
+    //! Joinsplits outputs amounts
+    std::vector<CAmount> joinsplitsOutputsAmounts;
+    // ---------- input variables
+
+protected:
+    //! Method for resetting internal variables (must be called before restarting the algorithm)
+    /*!
+      \return the flag representing if the reset was actually done
+    */
+    bool Reset() override;
+
+public:
+    //! Constructor
+    /*!
+      \param _amountsAndSizesAndIds vector of tuples of amounts and sizes and ids of the elements
+      \param _targetAmount target amount to satisfy (it is a lower-limit constraint)
+      \param _targetAmountPlusOffset target amount plus a positive offset (it is an upper-limit constraint)
+      \param _availableTotalSize available total size (in terms of bytes, it is an upper-limit constraint)
+      \param _executionTimeoutMilliseconds timeout for completing solving routine (in milliseconds) (default to 0)
+      \param _joinsplitsOutputsAmount amounts of joinsplits outputs (order matters) (default to empty vector)
+    */
+    CCoinsSelectionForNotes(std::vector<std::tuple<CAmount, size_t, int>> _amountsAndSizesAndIds,
+                            CAmount _targetAmount,
+                            CAmount _targetAmountPlusOffset,
+                            size_t _availableTotalSize,
+                            uint64_t _executionTimeoutMilliseconds = 0,
+                            std::vector<CAmount> _joinsplitsOutputsAmounts = std::vector<CAmount>());
+
+    //! Deleted copyconstructor
+    CCoinsSelectionForNotes(const CCoinsSelectionForNotes&) = delete;
+
+    //! Deleted move constructor (deletion not needed, but better to be explicit)
+    CCoinsSelectionForNotes(CCoinsSelectionForNotes&&) = delete;
+
+    //! Deleted assignment operator
+    CCoinsSelectionForNotes& operator=(const CCoinsSelectionForNotes&) = delete;
+
+    //! Deleted move operator (deletion not needed, but better to be explicit)
+    CCoinsSelectionForNotes& operator=(CCoinsSelectionForNotes&&) = delete;
+
+    //! Destructor
+    ~CCoinsSelectionForNotes();
+
+    //! Method for synchronously running the solving routine with "Sliding Window" strategy
+    void Solve() override;
+};
+
+/* ---------- CCoinsSelectionForNotes ---------- */
+
+#endif // _COINS_SELECTION_ALGORITHM_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -450,6 +450,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
         " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
+    strUsage += HelpMessageOpt("-coinsselectiontimeout=<n>", strprintf(_("Set the timeout (in seconds) for coins selection optimal algorithm (default: %u)"), COINS_SELECTION_TIMEOUT));
 #endif
 
 #if ENABLE_ZMQ

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -399,4 +399,10 @@ struct CScCertificateView
     }
 };
 
+//! Struct for storing certificate subsections size info
+struct CCertificateSizeEstimation : CBaseTransactionSizeEstimation
+{
+    size_t certificateVariableFieldsSize = 0;
+};
+
 #endif // _CERTIFICATE_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1149,4 +1149,19 @@ struct CMutableTransaction : public CMutableTransactionBase
     bool add(const CFieldElement& acd);
 };
 
+//! Struct for storing transaction subsections size info
+struct CBaseTransactionSizeEstimation
+{
+    size_t overheadSize = 0;
+    size_t baseInputsSize = 0;
+    size_t baseOutputsNoChangeSize = 0;
+    size_t baseOutputChangeOnlySize = 0;
+};
+
+struct CTransactionSizeEstimation : CBaseTransactionSizeEstimation
+{
+    size_t joinsplitsSize = 0;
+    size_t sidechainOutputsSize = 0;
+};
+
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/sc/sidechainrpc.cpp
+++ b/src/sc/sidechainrpc.cpp
@@ -13,6 +13,8 @@
 #include <main.h>
 #include <init.h>
 
+constexpr int MAX_LOOP = 100;
+
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern CAmount AmountFromValue(const UniValue& value);
 extern CFeeRate minRelayTxFee;
@@ -871,7 +873,6 @@ ScRpcCmd::ScRpcCmd(
     CScript scriptPubKey = GetScriptForDestination(secret.GetPubKey().GetID());
     CTxOut out(CAmount(1), scriptPubKey);
     _dustThreshold = out.GetDustThreshold(minRelayTxFee);
-
 }
 
 void ScRpcCmd::init()
@@ -879,10 +880,10 @@ void ScRpcCmd::init()
     _totalInputAmount = 0;
 }
 
-void ScRpcCmd::addInputs()
+size_t ScRpcCmd::addInputs(size_t availableBytes)
 {
     std::vector<COutput> vAvailableCoins;
-    std::vector<SelectedUTXO> vInputUtxo;
+    std::vector<COutput> vAvailableCoinsFiltered;
 
     static const bool fOnlyConfirmed = false;
     static const bool fIncludeZeroValue = false;
@@ -890,6 +891,14 @@ void ScRpcCmd::addInputs()
     const bool fIncludeCommunityFund = ForkManager::getInstance().canSendCommunityFundsToTransparentAddress(chainActive.Height() + 1);
 
     pwalletMain->AvailableCoins(vAvailableCoins, fOnlyConfirmed, NULL, fIncludeZeroValue, fIncludeCoinBase, fIncludeCommunityFund);
+
+    CAmount targetAmount = _totalOutputAmount + _fee;
+    CAmount nValueRet = 0;
+    size_t baseInputsSize = 0;
+    std::vector<COutput> vCoinsRet;
+    COutput smallestCoin(NULL, 0, 0, false);
+    CAmount smallestValue = std::numeric_limits<CAmount>::max();
+    CAmount totalValue = 0;
 
     for (const auto& out: vAvailableCoins)
     {
@@ -912,82 +921,106 @@ void ScRpcCmd::addInputs()
             }
         }
 
-        CAmount nValue = out.tx->getTxBase()->GetVout()[out.pos].nValue;
-
-        SelectedUTXO utxo(out.tx->getTxBase()->GetHash(), out.pos, nValue);
-        vInputUtxo.push_back(utxo);
-    }
-
-    // sort in ascending order, so smaller utxos appear first
-    std::sort(vInputUtxo.begin(), vInputUtxo.end(), [](SelectedUTXO i, SelectedUTXO j) -> bool {
-        return ( std::get<2>(i) < std::get<2>(j));
-    });
-
-    CAmount targetAmount = _totalOutputAmount + _fee;
-
-    CAmount dustChange = -1;
-
-    std::vector<SelectedUTXO> vSelectedInputUTXO;
-
-    for (const SelectedUTXO & t : vInputUtxo)
-    {
-        _totalInputAmount += std::get<2>(t);
-        vSelectedInputUTXO.push_back(t);
-
-        LogPrint("sc", "---> added tx %s val: %12s, vout.n: %d\n",
-            std::get<0>(t).ToString(), FormatMoney(std::get<2>(t)), std::get<1>(t));
-
-        if (_totalInputAmount >= targetAmount)
+        if (targetAmount != 0)
         {
-            // Select another utxo if there is change less than the dust threshold.
-            dustChange = _totalInputAmount - targetAmount;
-            if (dustChange == 0 || dustChange >= _dustThreshold) {
-                break;
+            vAvailableCoinsFiltered.push_back(out);
+            totalValue += out.tx->getTxBase()->GetVout()[out.pos].nValue;
+        }
+        else
+        {
+            CAmount value = out.tx->getTxBase()->GetVout()[out.pos].nValue;
+            if (value < smallestValue && value >= _dustThreshold)
+            {
+                smallestCoin = out;
+                smallestValue = value;
             }
         }
     }
 
-    if (_totalInputAmount < targetAmount)
+    if (targetAmount != 0)
     {
-        std::string addrDetails;
-        if (_hasFromAddress)
-            addrDetails = strprintf(" for taddr[%s]", _fromMcAddress.ToString());
+        for (int loop = 0; loop < MAX_LOOP; ++loop) // loop provided for handling possible dust threshold
+        {
+            int conf = 0; // already filtered above
+            bool res = pwalletMain->SelectCoinsMinConf(targetAmount, conf, conf, vAvailableCoinsFiltered, vCoinsRet, nValueRet, baseInputsSize,
+                                                       availableBytes, _automaticFee); // auto fee -> use input net values, manual fee -> fee already explicitly included in target amount
 
-        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
-            strprintf("Insufficient transparent funds%s, have %s, need %s (minconf=%d)",
-            addrDetails, FormatMoney(_totalInputAmount), FormatMoney(targetAmount), _minConf));
+            std::string addrDetails;
+            if (_hasFromAddress)
+                addrDetails = strprintf(" for taddr[%s]", _fromMcAddress.ToString());
+
+            if (!res)
+            {
+                if (totalValue < targetAmount)
+                {
+                    throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
+                                       strprintf("Insufficient transparent funds%s, have %s, need %s (minconf=%d)",
+                                       addrDetails, FormatMoney(totalValue), FormatMoney(targetAmount), _minConf));
+                }
+                else
+                {
+                    throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
+                                       strprintf("Not selectable transparent funds%s, (probably due to prevented oversized tx/cert, available size %d), have %s, need %s (minconf=%d)",
+                                       addrDetails, availableBytes, FormatMoney(totalValue), FormatMoney(targetAmount), _minConf));
+                }
+            }
+            else
+            {
+                if (nValueRet != targetAmount && nValueRet - targetAmount < _dustThreshold)
+                {
+                    // in this case the selection has exceeded target value but the resulting change would be under dust threshold, so...
+
+                    if (totalValue < targetAmount + _dustThreshold)
+                    {
+                        // ...this means there are insufficient funds for avoiding creation of invalid change output
+                        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
+                                           strprintf("Insufficient transparent funds%s, have %s, need %s more to avoid creating invalid change output %s (dust threshold is %s)",
+                                           addrDetails, FormatMoney(totalValue), FormatMoney(_dustThreshold - (totalValue - targetAmount)), FormatMoney((totalValue - targetAmount)), FormatMoney(_dustThreshold)));
+                    }
+                    else
+                    {
+                        // ...another execution is done summing dust threshold to target value
+                        targetAmount += _dustThreshold;
+                        continue;
+                    }
+                }
+                _totalInputAmount = nValueRet;
+                break;
+            }
+        }
     }
-
-    // If there is transparent change, is it valid or is it dust?
-    if (dustChange < _dustThreshold && dustChange != 0) {
-        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
-            strprintf("Insufficient transparent funds, have %s, need %s more to avoid creating invalid change output %s (dust threshold is %s)",
-            FormatMoney(_totalInputAmount), FormatMoney(_dustThreshold - dustChange), FormatMoney(dustChange), FormatMoney(_dustThreshold)));
+    else
+    {
+        // this case allows to handle situation where no coins would be selected
+        // at least one input must be included (resulting in full change output) to avoid tx/cert rejection
+        vCoinsRet.push_back(smallestCoin);
+        _totalInputAmount = smallestValue;
     }
 
     // Check mempooltxinputlimit to avoid creating a transaction which the local mempool rejects
     size_t limit = (size_t)GetArg("-mempooltxinputlimit", 0);
     if (limit > 0)
     {
-        size_t n = vSelectedInputUTXO.size();
+        size_t n = vCoinsRet.size();
         if (n > limit) {
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Too many transparent inputs %zu > limit %zu", n, limit));
         }
     }
 
     // update the transaction with these inputs
-    for (const auto& t : vSelectedInputUTXO)
+    for (const auto& coin : vCoinsRet)
     {
-        uint256 txid = std::get<0>(t);
-        int vout = std::get<1>(t);
-
-        CTxIn in(COutPoint(txid, vout));
+        CTxIn in(coin.tx->getTxBase()->GetHash(),coin.pos);
         addInput(in);
     }
+
+    return baseInputsSize;
 }
 
-void ScRpcCmd::addChange()
+size_t ScRpcCmd::addChange(bool onlyComputeDummyChangeSize)
 {
+    size_t baseOutputChangeOnlySize = 0;
+
     // fee must start from 0 when automatically calculated, and then its updated. It might also be set explicitly to 0
     CAmount change = _totalInputAmount - ( _totalOutputAmount + _fee);
 
@@ -1022,16 +1055,22 @@ void ScRpcCmd::addChange()
 
         // Never create dust outputs; if we would, just add the dust to the fee.
         CTxOut newTxOut(change, scriptPubKey);
-        if (newTxOut.IsDust(::minRelayTxFee))
+        baseOutputChangeOnlySize = newTxOut.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+        if (!onlyComputeDummyChangeSize)
         {
-            LogPrint("sc", "%s():%d - adding dust change=%lld to fee\n", __func__, __LINE__, change);
-            _fee += change;
-        }
-        else
-        {
-            addOutput(CTxOut(change, scriptPubKey));
+            if (newTxOut.IsDust(::minRelayTxFee))
+            {
+                LogPrint("sc", "%s():%d - adding dust change=%lld to fee\n", __func__, __LINE__, change);
+                _fee += change;
+            }
+            else
+            {
+                addOutput(newTxOut);
+            }
         }
     }
+
+    return baseOutputChangeOnlySize;
 }
 
 ScRpcCmdCert::ScRpcCmdCert(
@@ -1047,13 +1086,51 @@ ScRpcCmdCert::ScRpcCmdCert(
 
 void ScRpcCmdCert::_execute()
 {
+    CCertificateSizeEstimation certificateSizeEstimation;
+
+    // initialize transaction and compute overhead size
     init();
-    addInputs();
-    addChange();
-    addBackwardTransfers();
-    addCustomFields();
     addScFees();
+    certificateSizeEstimation.overheadSize = _cert.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+
+    // compute size of dummy change output (when estimating certificate size, change output is always included)
+    certificateSizeEstimation.baseOutputChangeOnlySize = addChange(true);
+
+    // add crosschain outputs and store their sizes
+    certificateSizeEstimation.baseOutputsNoChangeSize = addBackwardTransfers();
+
+    // add custom fields and store their sizes
+    addCustomFields();
+    if (!_vCfe.empty())
+        certificateSizeEstimation.certificateVariableFieldsSize += GetSerializeSize(_vCfe, SER_NETWORK, PROTOCOL_VERSION);
+    if (!_vCmt.empty())
+        certificateSizeEstimation.certificateVariableFieldsSize += GetSerializeSize(_vCmt, SER_NETWORK, PROTOCOL_VERSION);
+
+    // add base inputs based on available size
+    certificateSizeEstimation.baseInputsSize = addInputs(MAX_CERT_SIZE - (certificateSizeEstimation.overheadSize +
+                                                                          certificateSizeEstimation.baseOutputChangeOnlySize +
+                                                                          certificateSizeEstimation.baseOutputsNoChangeSize +
+                                                                          certificateSizeEstimation.certificateVariableFieldsSize));
+
+    // add actual change base output
+    certificateSizeEstimation.baseOutputChangeOnlySize = addChange();
+
     sign();
+
+    // this quantity should match the sum of the members of struct transactionSize (apart maybe from change section)
+    unsigned int nBytes = ::GetSerializeSize(_cert, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("selectcoins", "Actual cert size: %d, estimated cert size: %d (%d+%d+%d+%d+%d)\n",
+             nBytes,
+             certificateSizeEstimation.overheadSize +
+             certificateSizeEstimation.baseOutputsNoChangeSize +
+             certificateSizeEstimation.baseOutputChangeOnlySize +
+             certificateSizeEstimation.certificateVariableFieldsSize +
+             certificateSizeEstimation.baseInputsSize,
+             certificateSizeEstimation.overheadSize,
+             certificateSizeEstimation.baseOutputsNoChangeSize,
+             certificateSizeEstimation.baseOutputChangeOnlySize,
+             certificateSizeEstimation.certificateVariableFieldsSize,
+             certificateSizeEstimation.baseInputsSize);
 }
 
 void ScRpcCmdCert::sign()
@@ -1116,7 +1193,7 @@ bool ScRpcCmd::checkFeeRate()
 
     unsigned int nSize = getSignedObjSize();
 
-    // there are 3 main user options handling the fee (plus an estimation algorithm currently broken):
+    // there are 3 main user options handling the fee (plus an estimation algorithm):
     // -------------------------------------------------------------------
     // minRelayTxFee: set via zen option "-minrelaytxfee" defaults to 100 sat per K
     //                Nodes, and expecially miners, consider txes under this thresholds the same as "free" transactions.
@@ -1206,15 +1283,20 @@ bool ScRpcCmd::send()
     return true;
 }
 
-void ScRpcCmdCert::addBackwardTransfers()
+size_t ScRpcCmdCert::addBackwardTransfers()
 {
+    size_t outputsTotalSize = 0;
+
     for (const auto& entry : _bwdParams)
     {
         CTxOut txout(entry._nAmount, entry._scriptPubKey);
         if (txout.IsDust(::minRelayTxFee))
             throw JSONRPCError(RPC_WALLET_ERROR, "backward transfer amount too small");
         _cert.addBwt(txout);
+        outputsTotalSize += txout.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
     }
+
+    return outputsTotalSize;
 }
 
 void ScRpcCmdCert::addCustomFields()
@@ -1298,19 +1380,47 @@ void ScRpcCmdTx::sign()
 
 void ScRpcCmdTx::_execute()
 {
+    CTransactionSizeEstimation transactionSizeEstimation;
+
+    // initialize transaction and compute overhead size
     init();
-    addInputs();
+    transactionSizeEstimation.overheadSize = _tx.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+
+    // compute size of dummy change output (when estimating transaction size, change output is always included)
+    transactionSizeEstimation.baseOutputChangeOnlySize = addChange(true);
+
+    // add crosschain outputs and store their sizes
+    transactionSizeEstimation.sidechainOutputsSize = addCcOutputs();
+
+    // add base inputs based on available size
+    transactionSizeEstimation.baseInputsSize = addInputs(MAX_TX_SIZE - (transactionSizeEstimation.overheadSize +
+                                                                        transactionSizeEstimation.baseOutputChangeOnlySize +
+                                                                        transactionSizeEstimation.sidechainOutputsSize));
+
+    // add actual change base output (estimation is not updated)
     addChange();
-    addCcOutputs();
+
     sign();
+
+    // this quantity should match the sum of the members of struct transactionSize (apart maybe from change section)
+    unsigned int nBytes = ::GetSerializeSize(_tx, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("selectcoins", "Actual tx size: %d, estimated tx size: %d (%d+%d+%d+%d)\n",
+             nBytes,
+             transactionSizeEstimation.overheadSize +
+             transactionSizeEstimation.baseOutputsNoChangeSize +
+             transactionSizeEstimation.baseOutputChangeOnlySize +
+             transactionSizeEstimation.baseInputsSize,
+             transactionSizeEstimation.overheadSize,
+             transactionSizeEstimation.baseOutputsNoChangeSize,
+             transactionSizeEstimation.baseOutputChangeOnlySize,
+             transactionSizeEstimation.baseInputsSize);
 }
 
 void ScRpcCmd::execute()
 {
-    // we need a safety counter for the case when we have a large number of very small inputs that gets added to
-    // the tx increasing its size and the fee needed
-    // An alternative might as well be letting it fail when we do not have utxo's anymore.
-    static const int MAX_LOOP = 100;
+    // theoretically coins selection algorithm should handle correctly the estimation of automatic fee for the
+    // transaction/certificate being created and sent but, in case some errors occurs due to roundings or signature
+    // size fluctuations, everything is wrapped in a loop that iteratively update new fee
 
     int safeCount = MAX_LOOP;
 
@@ -1346,8 +1456,10 @@ ScRpcCreationCmdTx::ScRpcCreationCmdTx(
     }
 } 
 
-void ScRpcCreationCmdTx::addCcOutputs()
+size_t ScRpcCreationCmdTx::addCcOutputs()
 {
+    size_t ccoutputsTotalSize = 0;
+
     if (_outParams.size() != 1)
     {
         // creation has just one output param
@@ -1356,6 +1468,9 @@ void ScRpcCreationCmdTx::addCcOutputs()
 
     CTxScCreationOut txccout(_outParams[0]._nAmount, _outParams[0]._toScAddress, _ftScFee, _mbtrScFee, _fixedParams);
     _tx.add(txccout);
+    ccoutputsTotalSize += txccout.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+
+    return ccoutputsTotalSize;
 }
 
 ScRpcSendCmdTx::ScRpcSendCmdTx(
@@ -1371,8 +1486,10 @@ ScRpcSendCmdTx::ScRpcSendCmdTx(
 } 
 
 
-void ScRpcSendCmdTx::addCcOutputs()
+size_t ScRpcSendCmdTx::addCcOutputs()
 {
+    size_t ccoutputsTotalSize = 0;
+
     if (_outParams.size() == 0)
     {
         // send cmd can not have empty output vector
@@ -1383,7 +1500,10 @@ void ScRpcSendCmdTx::addCcOutputs()
     {
         CTxForwardTransferOut txccout(entry._scid, entry._nAmount, entry._toScAddress, entry._mcReturnAddress);
         _tx.add(txccout);
+        ccoutputsTotalSize += txccout.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
     }
+
+    return ccoutputsTotalSize;
 }
 
 ScRpcRetrieveCmdTx::ScRpcRetrieveCmdTx(
@@ -1399,8 +1519,10 @@ ScRpcRetrieveCmdTx::ScRpcRetrieveCmdTx(
 } 
 
 
-void ScRpcRetrieveCmdTx::addCcOutputs()
+size_t ScRpcRetrieveCmdTx::addCcOutputs()
 {
+    size_t ccoutputsTotalSize = 0;
+
     if (_outParams.size() == 0)
     {
         // send cmd can not have empty output vector
@@ -1411,7 +1533,10 @@ void ScRpcRetrieveCmdTx::addCcOutputs()
     {
         CBwtRequestOut txccout(entry._scid, entry._pkh, entry._params);
         _tx.add(txccout);
+        ccoutputsTotalSize += txccout.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
     }
+
+    return ccoutputsTotalSize;
 }
 
 }  // end of namespace

--- a/src/sc/sidechainrpc.h
+++ b/src/sc/sidechainrpc.h
@@ -74,8 +74,8 @@ class ScRpcCmd
     // set null all data members that are filled during tx/cert construction  
     virtual void init();
 
-    void addInputs();
-    void addChange();
+    size_t addInputs(size_t availableBytes);
+    size_t addChange(bool onlyComputeDummyChangeSize = false);
     virtual void addOutput(const CTxOut& out) = 0;
     virtual void addInput(const CTxIn& out) = 0;
     virtual void sign() = 0;
@@ -109,7 +109,7 @@ class ScRpcCmdTx : public ScRpcCmd
     void addOutput(const CTxOut& out) override {_tx.addOut(out); }
     void addInput(const CTxIn& in) override    {_tx.vin.push_back(in); }
 
-    virtual void addCcOutputs() = 0;
+    virtual size_t addCcOutputs() = 0;
 
     void sign() override;
     void _execute() override;
@@ -139,7 +139,7 @@ class ScRpcCmdCert : public ScRpcCmd
     void _execute() override;
 
   private:
-    void addBackwardTransfers();
+    size_t addBackwardTransfers();
     void addCustomFields();
     void addScFees();
 
@@ -175,7 +175,7 @@ class ScRpcCmdCert : public ScRpcCmd
 class ScRpcCreationCmdTx : public ScRpcCmdTx
 {
   protected:
-    void addCcOutputs() override;
+    size_t addCcOutputs() override;
 
   public:
     struct sCrOutParams
@@ -208,7 +208,7 @@ class ScRpcCreationCmdTx : public ScRpcCmdTx
 class ScRpcSendCmdTx : public ScRpcCmdTx
 {
   protected:
-    void addCcOutputs() override;
+    size_t addCcOutputs() override;
 
   public:
     struct sFtOutParams
@@ -236,7 +236,7 @@ class ScRpcSendCmdTx : public ScRpcCmdTx
 class ScRpcRetrieveCmdTx : public ScRpcCmdTx
 {
   protected:
-    void addCcOutputs() override;
+    size_t addCcOutputs() override;
 
   public:
     struct sBtOutParams

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1038,8 +1038,8 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(mtx, taddr1, {}, std::move(recipients), 1) );
         operation->main();
         BOOST_CHECK(operation->isFailed());
-        std::string msg = operation->getErrorMessage();
-        BOOST_CHECK( msg.find("Insufficient funds, no UTXOs found") != string::npos);
+        int error = operation->getErrorCode();
+        BOOST_CHECK( error == RPCErrorCode::RPC_WALLET_INSUFFICIENT_FUNDS);
     }
 
     // minconf cannot be zero when sending from zaddr
@@ -1060,8 +1060,8 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(mtx, zaddr1, std::move(recipients), {}, 1) );
         operation->main();
         BOOST_CHECK(operation->isFailed());
-        std::string msg = operation->getErrorMessage();
-        BOOST_CHECK( msg.find("Insufficient funds, no unspent notes") != string::npos);
+        int error = operation->getErrorCode();
+        BOOST_CHECK( error == RPCErrorCode::RPC_WALLET_INSUFFICIENT_FUNDS);
     }
 
     // get_memo_from_hex_string())

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -96,10 +96,8 @@ private:
     
     CTransaction tx_;
    
-    void add_taddr_change_output_to_tx(CAmount amount, bool sendChangeToSource = false);
-    void add_taddr_outputs_to_tx();
-    bool find_unspent_notes();
-    bool find_utxos(bool fAcceptCoinbase);
+    size_t add_taddr_change_output_to_tx(CAmount amount, bool sendChangeToSource = false, bool onlyComputeDummyChangeSize = false);
+    size_t add_taddr_outputs_to_tx();
     std::array<unsigned char, ZC_MEMO_SIZE> get_memo_from_hex_string(const std::string& s);
     bool main_impl();
 
@@ -139,22 +137,14 @@ public:
     
     // Delegated methods
     
-    void add_taddr_change_output_to_tx(CAmount amount, bool sendCangeToSource = false) {
-        delegate->add_taddr_change_output_to_tx(amount, sendCangeToSource);
+    size_t add_taddr_change_output_to_tx(CAmount amount, bool sendChangeToSource = false, bool onlyComputeDummyChangeSize = false) {
+        return delegate->add_taddr_change_output_to_tx(amount, sendChangeToSource, onlyComputeDummyChangeSize);
     }
     
-    void add_taddr_outputs_to_tx() {
-        delegate->add_taddr_outputs_to_tx();
+    size_t add_taddr_outputs_to_tx() {
+        return delegate->add_taddr_outputs_to_tx();
     }
-    
-    bool find_unspent_notes() {
-        return delegate->find_unspent_notes();
-    }
-
-    bool find_utxos(bool fAcceptCoinbase) {
-        return delegate->find_utxos(fAcceptCoinbase);
-    }
-    
+       
     std::array<unsigned char, ZC_MEMO_SIZE> get_memo_from_hex_string(std::string s) {
         return delegate->get_memo_from_hex_string(s);
     }

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -15,17 +15,19 @@
 
 #include <boost/filesystem.hpp>
 
-using ::testing::Return;
-using ::testing::Eq;
 using ::testing::ByRef;
+using ::testing::Eq;
+using ::testing::Return;
 
 extern ZCJoinSplit* params;
 
-ACTION(ThrowLogicError) {
+ACTION(ThrowLogicError)
+{
     throw std::logic_error("Boom");
 }
 
-class MockWalletDB {
+class MockWalletDB
+{
 public:
     MOCK_METHOD0(TxnBegin, bool());
     MOCK_METHOD0(TxnCommit, bool());
@@ -41,36 +43,45 @@ public:
 };
 
 template void CWallet::SetBestChainINTERNAL<MockWalletDB>(
-        MockWalletDB& walletdb, const CBlockLocator& loc);
+    MockWalletDB& walletdb,
+    const CBlockLocator& loc);
 
-class TestWallet : public CWallet {
+class TestWallet : public CWallet
+{
 public:
     TestWallet() : CWallet(),
                    csWalletLock(cs_wallet, "cs_wallet", __FILE__, __LINE__) {}
 
-    bool EncryptKeys(CKeyingMaterial& vMasterKeyIn) {
+    bool EncryptKeys(CKeyingMaterial& vMasterKeyIn)
+    {
         return CCryptoKeyStore::EncryptKeys(vMasterKeyIn);
     }
 
-    bool Unlock(const CKeyingMaterial& vMasterKeyIn) {
+    bool Unlock(const CKeyingMaterial& vMasterKeyIn)
+    {
         return CCryptoKeyStore::Unlock(vMasterKeyIn);
     }
 
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
                                 const CBlock* pblock,
-                                ZCIncrementalMerkleTree& tree) {
+                                ZCIncrementalMerkleTree& tree)
+    {
         CWallet::IncrementNoteWitnesses(pindex, pblock, tree);
     }
-    void DecrementNoteWitnesses(const CBlockIndex* pindex) {
+    void DecrementNoteWitnesses(const CBlockIndex* pindex)
+    {
         CWallet::DecrementNoteWitnesses(pindex);
     }
-    void SetBestChain(MockWalletDB& walletdb, const CBlockLocator& loc) {
+    void SetBestChain(MockWalletDB& walletdb, const CBlockLocator& loc)
+    {
         CWallet::SetBestChainINTERNAL(walletdb, loc);
     }
-    bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx) {
+    bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx)
+    {
         return CWallet::UpdatedNoteData(wtxIn, wtx);
     }
-    void MarkAffectedTransactionsDirty(const CTransaction& tx) {
+    void MarkAffectedTransactionsDirty(const CTransaction& tx)
+    {
         CWallet::MarkAffectedTransactionsDirty(tx);
     }
 
@@ -78,21 +89,28 @@ private:
     CCriticalBlock csWalletLock;
 };
 
-CWalletTx GetValidReceive(const libzcash::SpendingKey& sk, CAmount value, bool randomInputs) {
+CWalletTx GetValidReceive(const libzcash::SpendingKey& sk, CAmount value, bool randomInputs)
+{
     return GetValidReceive(*params, sk, value, randomInputs);
 }
 
-CWalletTx GetInvalidCommitmentReceive(const libzcash::SpendingKey& sk, CAmount value, bool randomInputs, int32_t version = 2) {
+CWalletTx GetInvalidCommitmentReceive(const libzcash::SpendingKey& sk, CAmount value, bool randomInputs, int32_t version = 2)
+{
     return GetInvalidCommitmentReceive(*params, sk, value, randomInputs, version);
 }
 
 libzcash::Note GetNote(const libzcash::SpendingKey& sk,
-                       const CTransaction& tx, size_t js, size_t n) {
+                       const CTransaction& tx,
+                       size_t js,
+                       size_t n)
+{
     return GetNote(*params, sk, tx, js, n);
 }
 
 CWalletTx GetValidSpend(const libzcash::SpendingKey& sk,
-                        const libzcash::Note& note, CAmount value) {
+                        const libzcash::Note& note,
+                        CAmount value)
+{
     return GetValidSpend(*params, sk, note, value);
 }
 
@@ -100,14 +118,15 @@ JSOutPoint CreateValidBlock(TestWallet& wallet,
                             const libzcash::SpendingKey& sk,
                             const CBlockIndex& index,
                             CBlock& block,
-                            ZCIncrementalMerkleTree& tree) {
+                            ZCIncrementalMerkleTree& tree)
+{
     auto wtx = GetValidReceive(sk, 50, true);
     auto note = GetNote(sk, wtx.getWrappedTx(), 0, 1);
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
     wallet.AddToWallet(wtx, true, NULL);
@@ -141,8 +160,8 @@ TEST_F(WalletTest, note_data_serialisation) {
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     ZCIncrementalMerkleTree tree;
     nd.witnesses.push_front(tree.witness());
     noteData[jsoutpt] = nd;
@@ -159,7 +178,6 @@ TEST_F(WalletTest, note_data_serialisation) {
 
 
 TEST_F(WalletTest, find_unspent_notes) {
-
     SelectParams(CBaseChainParams::TESTNET);
     CWallet wallet;
     auto sk = libzcash::SpendingKey::random();
@@ -170,8 +188,8 @@ TEST_F(WalletTest, find_unspent_notes) {
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -193,7 +211,7 @@ TEST_F(WalletTest, find_unspent_notes) {
     block.vtx.push_back(wtx.getWrappedTx());
     block.hashMerkleRoot = block.BuildMerkleTree();
     auto blockHash = block.GetHash();
-    CBlockIndex fakeIndex {block};
+    CBlockIndex fakeIndex{block};
     mapBlockIndex.insert(std::make_pair(blockHash, &fakeIndex));
     chainActive.SetTip(&fakeIndex);
     EXPECT_TRUE(chainActive.Contains(&fakeIndex));
@@ -228,7 +246,7 @@ TEST_F(WalletTest, find_unspent_notes) {
     block2.hashMerkleRoot = block2.BuildMerkleTree();
     block2.hashPrevBlock = blockHash;
     auto blockHash2 = block2.GetHash();
-    CBlockIndex fakeIndex2 {block2};
+    CBlockIndex fakeIndex2{block2};
     mapBlockIndex.insert(std::make_pair(blockHash2, &fakeIndex2));
     fakeIndex2.nHeight = 1;
     chainActive.SetTip(&fakeIndex2);
@@ -265,8 +283,8 @@ TEST_F(WalletTest, find_unspent_notes) {
         auto nullifier = note.nullifier(sk);
 
         mapNoteData_t noteData;
-        JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+        CNoteData nd{sk.address(), nullifier};
         noteData[jsoutpt] = nd;
 
         wtx.SetNoteData(noteData);
@@ -283,7 +301,7 @@ TEST_F(WalletTest, find_unspent_notes) {
     block3.hashMerkleRoot = block3.BuildMerkleTree();
     block3.hashPrevBlock = blockHash2;
     auto blockHash3 = block3.GetHash();
-    CBlockIndex fakeIndex3 {block3};
+    CBlockIndex fakeIndex3{block3};
     mapBlockIndex.insert(std::make_pair(blockHash3, &fakeIndex3));
     fakeIndex3.nHeight = 2;
     chainActive.SetTip(&fakeIndex3);
@@ -304,11 +322,11 @@ TEST_F(WalletTest, find_unspent_notes) {
     // Increasing number of confirmations will exclude our new unspent note.
     wallet.GetFilteredNotes(entries, "", 2, false);
     EXPECT_EQ(1, entries.size());
-    entries.clear();    
+    entries.clear();
     // If we also ignore spent notes at thie depth, we won't find any notes.
     wallet.GetFilteredNotes(entries, "", 2, true);
     EXPECT_EQ(0, entries.size());
-    entries.clear(); 
+    entries.clear();
 
     // Tear down
     chainActive.SetTip(NULL);
@@ -317,6 +335,123 @@ TEST_F(WalletTest, find_unspent_notes) {
     mapBlockIndex.erase(blockHash3);
 }
 
+TEST_F(WalletTest, select_notes)
+{
+    uint256 apk, rho, r;
+    CNotePlaintextEntry note;
+    CWallet wallet;
+    CAmount nTargetValue = 0, nValueRet = 0;
+    std::vector<CAmount> joinsplitsOutputsAmounts;
+    size_t selectionTotalBytes = 0, availableBytes = 0;
+    std::vector<CNotePlaintextEntry> vecEntries, vNotesRet;
+    bool selectionResult = false;
+
+    // just one note of value 10
+    vecEntries.clear();
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 10, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    nTargetValue = 10;
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    EXPECT_EQ(selectionResult, true);
+    EXPECT_EQ(nValueRet, nTargetValue);
+    // the single note is to be selected
+    EXPECT_EQ(vNotesRet.size(), 1);
+    // but if not enough space is available for selection...
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         100, joinsplitsOutputsAmounts); // (100 bytes are for sure not enough for a joinsplit)
+    // ...then the selection cannot be performed
+    EXPECT_EQ(selectionResult, false);
+
+
+    // one note of value 10 and two notes of value 5
+    vecEntries.clear();
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 10, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 5, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    vecEntries.push_back(note);
+    nTargetValue = 10;
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    EXPECT_EQ(selectionResult, true);
+    EXPECT_EQ(nValueRet, nTargetValue);
+    // 2 smaller notes are to be selected (quantity maximization)
+    EXPECT_EQ(vNotesRet.size(), 2);
+
+
+    //many small notes with big target
+    vecEntries.clear();
+    for (int i = 0; i < 1000; ++i)
+    {
+        note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 1, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+        vecEntries.push_back(note);
+    }
+    nTargetValue = 1000;
+    joinsplitsOutputsAmounts.push_back(nTargetValue);
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    // the selection cannot be performed
+    EXPECT_EQ(selectionResult, false);
+    // but if the target value is decreased...
+    nTargetValue = 100;
+    joinsplitsOutputsAmounts[0] = nTargetValue;
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    // ...then the selection can be performed
+    EXPECT_EQ(selectionResult, true);
+    EXPECT_EQ(nValueRet, nTargetValue);
+    // 100 notes are to be selected
+    EXPECT_EQ(vNotesRet.size(), 100);
+
+
+    //one big note with many small targets
+    vecEntries.clear();
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 1000, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    nTargetValue = 1000;
+    joinsplitsOutputsAmounts.clear();
+    for (int i = 0; i < 1000; ++i)
+    {
+        joinsplitsOutputsAmounts.push_back(1);
+    }
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    // the selection cannot be performed
+    EXPECT_EQ(selectionResult, false);
+    // but if the number of targets is decreased...
+    nTargetValue = 10;
+    joinsplitsOutputsAmounts.clear();
+    for (int i = 0; i < 10; ++i)
+    {
+        joinsplitsOutputsAmounts.push_back(1);
+    }
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    // ...then the selection can be performed
+    EXPECT_EQ(selectionResult, true);
+    EXPECT_EQ(nValueRet, note.plaintext.value());
+    // the single note is to be selected
+    EXPECT_EQ(vNotesRet.size(), 1);
+
+
+    // some notes
+    vecEntries.clear();
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 2, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 3, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 5, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    note.plaintext = libzcash::NotePlaintext(libzcash::Note(apk, 7, rho, r), std::array<unsigned char, ZC_MEMO_SIZE>());
+    vecEntries.push_back(note);
+    nTargetValue = 11;
+    selectionResult = wallet.SelectNotes(nTargetValue, vecEntries, vNotesRet, nValueRet, selectionTotalBytes,
+                                         MAX_TX_SIZE, joinsplitsOutputsAmounts);
+    // a selection without an exact match can be performed
+    EXPECT_EQ(selectionResult, true);
+    EXPECT_GT(nValueRet, nTargetValue);
+}
 
 TEST_F(WalletTest, set_note_addrs_in_cwallettx) {
     auto sk = libzcash::SpendingKey::random();
@@ -326,8 +461,8 @@ TEST_F(WalletTest, set_note_addrs_in_cwallettx) {
     EXPECT_EQ(0, wtx.mapNoteData.size());
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -340,8 +475,8 @@ TEST_F(WalletTest, set_invalid_note_addrs_in_cwallettx) {
 
     mapNoteData_t noteData;
     auto sk = libzcash::SpendingKey::random();
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), uint256()};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), uint256()};
     noteData[jsoutpt] = nd;
 
     EXPECT_THROW(wtx.SetNoteData(noteData), std::logic_error);
@@ -362,10 +497,11 @@ TEST_F(WalletTest, CheckNoteCommitmentAgainstNotePlaintext) {
         *params, wtx.getWrappedTx().joinSplitPubKey);
 
     ASSERT_THROW(wallet.GetNoteNullifier(
-        wtx.getWrappedTx().GetVjoinsplit()[0],
-        address,
-        dec,
-        hSig, 1), libzcash::note_decryption_failed);
+                     wtx.getWrappedTx().GetVjoinsplit()[0],
+                     address,
+                     dec,
+                     hSig, 1),
+                 libzcash::note_decryption_failed);
 }
 
 TEST_F(WalletTest, GetNoteNullifier) {
@@ -418,16 +554,16 @@ TEST_F(WalletTest, FindMyNotes) {
     noteMap = wallet.FindMyNotes(wtx.getWrappedTx());
     EXPECT_EQ(2, noteMap.size());
 
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     EXPECT_EQ(1, noteMap.count(jsoutpt));
     EXPECT_EQ(nd, noteMap[jsoutpt]);
 }
 
 TEST_F(WalletTest, FindMyNotesInEncryptedWallet) {
     TestWallet wallet;
-    uint256 r {GetRandHash()};
-    CKeyingMaterial vMasterKey (r.begin(), r.end());
+    uint256 r{GetRandHash()};
+    CKeyingMaterial vMasterKey(r.begin(), r.end());
 
     auto sk = libzcash::SpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -441,8 +577,8 @@ TEST_F(WalletTest, FindMyNotesInEncryptedWallet) {
     auto noteMap = wallet.FindMyNotes(wtx.getWrappedTx());
     EXPECT_EQ(2, noteMap.size());
 
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     EXPECT_EQ(1, noteMap.count(jsoutpt));
     EXPECT_NE(nd, noteMap[jsoutpt]);
 
@@ -510,7 +646,7 @@ TEST_F(WalletTest, nullifier_is_spent) {
     block.vtx.push_back(wtx2.getWrappedTx());
     block.hashMerkleRoot = block.BuildMerkleTree();
     auto blockHash = block.GetHash();
-    CBlockIndex fakeIndex {block};
+    CBlockIndex fakeIndex{block};
     mapBlockIndex.insert(std::make_pair(blockHash, &fakeIndex));
     chainActive.SetTip(&fakeIndex);
     EXPECT_TRUE(chainActive.Contains(&fakeIndex));
@@ -536,8 +672,8 @@ TEST_F(WalletTest, navigate_from_nullifier_to_note) {
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -566,8 +702,8 @@ TEST_F(WalletTest, spent_note_is_from_me) {
     EXPECT_FALSE(wallet.IsFromMe(wtx2.getWrappedTx()));
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -592,10 +728,10 @@ TEST_F(WalletTest, cached_witnesses_empty_chain) {
     auto nullifier2 = note2.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 0};
-    JSOutPoint jsoutpt2 {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
-    CNoteData nd2 {sk.address(), nullifier2};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 0};
+    JSOutPoint jsoutpt2{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
+    CNoteData nd2{sk.address(), nullifier2};
     noteData[jsoutpt] = nd;
     noteData[jsoutpt2] = nd2;
     wtx.SetNoteData(noteData);
@@ -605,14 +741,14 @@ TEST_F(WalletTest, cached_witnesses_empty_chain) {
     uint256 anchor;
 
     wallet.GetNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    EXPECT_FALSE((bool)witnesses[0]);
+    EXPECT_FALSE((bool)witnesses[1]);
 
     wallet.AddToWallet(wtx, true, NULL);
     witnesses.clear();
     wallet.GetNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    EXPECT_FALSE((bool)witnesses[0]);
+    EXPECT_FALSE((bool)witnesses[1]);
 
     CBlock block;
     block.vtx.push_back(wtx.getWrappedTx());
@@ -621,8 +757,8 @@ TEST_F(WalletTest, cached_witnesses_empty_chain) {
     wallet.IncrementNoteWitnesses(&index, &block, tree);
     witnesses.clear();
     wallet.GetNoteWitnesses(notes, witnesses, anchor);
-    EXPECT_TRUE((bool) witnesses[0]);
-    EXPECT_TRUE((bool) witnesses[1]);
+    EXPECT_TRUE((bool)witnesses[0]);
+    EXPECT_TRUE((bool)witnesses[1]);
 
     // Until #1302 is implemented, this should triggger an assertion
     /*EXPECT_DEATH(wallet.DecrementNoteWitnesses(&index),
@@ -657,8 +793,8 @@ TEST_F(WalletTest, cached_witnesses_chain_tip) {
         auto nullifier = note.nullifier(sk);
 
         mapNoteData_t noteData;
-        JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+        CNoteData nd{sk.address(), nullifier};
         noteData[jsoutpt] = nd;
         wtx.SetNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
@@ -668,7 +804,7 @@ TEST_F(WalletTest, cached_witnesses_chain_tip) {
         uint256 anchor2;
 
         wallet.GetNoteWitnesses(notes, witnesses, anchor2);
-        EXPECT_FALSE((bool) witnesses[0]);
+        EXPECT_FALSE((bool)witnesses[0]);
 
         // Second block
         CBlock block2;
@@ -676,11 +812,11 @@ TEST_F(WalletTest, cached_witnesses_chain_tip) {
         block2.vtx.push_back(wtx.getWrappedTx());
         CBlockIndex index2(block2);
         index2.nHeight = 2;
-        ZCIncrementalMerkleTree tree2 {tree};
+        ZCIncrementalMerkleTree tree2{tree};
         wallet.IncrementNoteWitnesses(&index2, &block2, tree2);
         witnesses.clear();
         wallet.GetNoteWitnesses(notes, witnesses, anchor2);
-        EXPECT_TRUE((bool) witnesses[0]);
+        EXPECT_TRUE((bool)witnesses[0]);
         EXPECT_NE(anchor1, anchor2);
 
         // Decrementing should give us the previous anchor
@@ -688,7 +824,7 @@ TEST_F(WalletTest, cached_witnesses_chain_tip) {
         wallet.DecrementNoteWitnesses(&index2);
         witnesses.clear();
         wallet.GetNoteWitnesses(notes, witnesses, anchor3);
-        EXPECT_FALSE((bool) witnesses[0]);
+        EXPECT_FALSE((bool)witnesses[0]);
         // Should not equal first anchor because none of these notes had witnesses
         EXPECT_NE(anchor1, anchor3);
 
@@ -697,7 +833,7 @@ TEST_F(WalletTest, cached_witnesses_chain_tip) {
         wallet.IncrementNoteWitnesses(&index2, &block2, tree);
         witnesses.clear();
         wallet.GetNoteWitnesses(notes, witnesses, anchor4);
-        EXPECT_TRUE((bool) witnesses[0]);
+        EXPECT_TRUE((bool)witnesses[0]);
         EXPECT_EQ(anchor2, anchor4);
 
         // Incrementing with the same block again should not change the cache
@@ -746,8 +882,8 @@ TEST_F(WalletTest, CachedWitnessesDecrementFirst) {
         auto nullifier = note.nullifier(sk);
 
         mapNoteData_t noteData;
-        JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-        CNoteData nd {sk.address(), nullifier};
+        JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+        CNoteData nd{sk.address(), nullifier};
         noteData[jsoutpt] = nd;
         wtx.SetNoteData(noteData);
         wallet.AddToWallet(wtx, true, NULL);
@@ -757,7 +893,7 @@ TEST_F(WalletTest, CachedWitnessesDecrementFirst) {
         uint256 anchor3;
 
         wallet.GetNoteWitnesses(notes, witnesses, anchor3);
-        EXPECT_FALSE((bool) witnesses[0]);
+        EXPECT_FALSE((bool)witnesses[0]);
 
         // Decrementing (before the transaction has ever seen an increment)
         // should give us the previous anchor
@@ -765,7 +901,7 @@ TEST_F(WalletTest, CachedWitnessesDecrementFirst) {
         wallet.DecrementNoteWitnesses(&index2);
         witnesses.clear();
         wallet.GetNoteWitnesses(notes, witnesses, anchor4);
-        EXPECT_FALSE((bool) witnesses[0]);
+        EXPECT_FALSE((bool)witnesses[0]);
         // Should not equal second anchor because none of these notes had witnesses
         EXPECT_NE(anchor2, anchor4);
 
@@ -774,7 +910,7 @@ TEST_F(WalletTest, CachedWitnessesDecrementFirst) {
         wallet.IncrementNoteWitnesses(&index2, &block2, tree);
         witnesses.clear();
         wallet.GetNoteWitnesses(notes, witnesses, anchor5);
-        EXPECT_FALSE((bool) witnesses[0]);
+        EXPECT_FALSE((bool)witnesses[0]);
         EXPECT_EQ(anchor3, anchor5);
     }
 }
@@ -807,7 +943,7 @@ TEST_F(WalletTest, CachedWitnessesCleanIndex) {
         uint256 anchor;
         wallet.GetNoteWitnesses(notes, witnesses, anchor);
         for (size_t j = 0; j <= i; j++) {
-            EXPECT_TRUE((bool) witnesses[j]);
+            EXPECT_TRUE((bool)witnesses[j]);
         }
         anchors.push_back(anchor);
     }
@@ -815,13 +951,13 @@ TEST_F(WalletTest, CachedWitnessesCleanIndex) {
     // Now pretend we are reindexing: the chain is cleared, and each block is
     // used to increment witnesses again.
     for (size_t i = 0; i < numBlocks; i++) {
-        ZCIncrementalMerkleTree riPrevTree {riTree};
+        ZCIncrementalMerkleTree riPrevTree{riTree};
         wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), riTree);
         witnesses.clear();
         uint256 anchor;
         wallet.GetNoteWitnesses(notes, witnesses, anchor);
         for (size_t j = 0; j < numBlocks; j++) {
-            EXPECT_TRUE((bool) witnesses[j]);
+            EXPECT_TRUE((bool)witnesses[j]);
         }
         // Should equal final anchor because witness cache unaffected
         EXPECT_EQ(anchors.back(), anchor);
@@ -834,7 +970,7 @@ TEST_F(WalletTest, CachedWitnessesCleanIndex) {
                 uint256 anchor;
                 wallet.GetNoteWitnesses(notes, witnesses, anchor);
                 for (size_t j = 0; j < numBlocks; j++) {
-                    EXPECT_TRUE((bool) witnesses[j]);
+                    EXPECT_TRUE((bool)witnesses[j]);
                 }
                 // Should equal final anchor because witness cache unaffected
                 EXPECT_EQ(anchors.back(), anchor);
@@ -846,7 +982,7 @@ TEST_F(WalletTest, CachedWitnessesCleanIndex) {
                 uint256 anchor;
                 wallet.GetNoteWitnesses(notes, witnesses, anchor);
                 for (size_t j = 0; j < numBlocks; j++) {
-                    EXPECT_TRUE((bool) witnesses[j]);
+                    EXPECT_TRUE((bool)witnesses[j]);
                 }
                 // Should equal final anchor because witness cache unaffected
                 EXPECT_EQ(anchors.back(), anchor);
@@ -867,9 +1003,9 @@ TEST_F(WalletTest, ClearNoteWitnessCache) {
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 0};
-    JSOutPoint jsoutpt2 {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 0};
+    JSOutPoint jsoutpt2{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
@@ -887,8 +1023,8 @@ TEST_F(WalletTest, ClearNoteWitnessCache) {
 
     // Before clearing, we should have a witness for one note
     wallet.GetNoteWitnesses(notes, witnesses, anchor2);
-    EXPECT_TRUE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    EXPECT_TRUE((bool)witnesses[0]);
+    EXPECT_FALSE((bool)witnesses[1]);
     EXPECT_EQ(1, wallet.getMapWallet().at(hash)->mapNoteData[jsoutpt].witnessHeight);
     EXPECT_EQ(1, wallet.nWitnessCacheSize);
 
@@ -896,8 +1032,8 @@ TEST_F(WalletTest, ClearNoteWitnessCache) {
     wallet.ClearNoteWitnessCache();
     witnesses.clear();
     wallet.GetNoteWitnesses(notes, witnesses, anchor2);
-    EXPECT_FALSE((bool) witnesses[0]);
-    EXPECT_FALSE((bool) witnesses[1]);
+    EXPECT_FALSE((bool)witnesses[0]);
+    EXPECT_FALSE((bool)witnesses[1]);
     EXPECT_EQ(-1, wallet.getMapWallet().at(hash)->mapNoteData[jsoutpt].witnessHeight);
     EXPECT_EQ(0, wallet.nWitnessCacheSize);
 }
@@ -915,8 +1051,8 @@ TEST_F(WalletTest, WriteWitnessCache) {
     auto nullifier = note.nullifier(sk);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
@@ -935,8 +1071,8 @@ TEST_F(WalletTest, WriteWitnessCache) {
         .WillOnce(Return(false));
     EXPECT_CALL(walletdb, TxnAbort())
         .Times(1);
-    wallet.SetBestChain(walletdb, loc);             
-                                                    
+    wallet.SetBestChain(walletdb, loc);
+
     // WriteWalletTxBase throws
     EXPECT_CALL(walletdb, WriteWalletTxBase(wtx.getWrappedTx().GetHash(), Eq(ByRef(refWtx))))
         .WillOnce(ThrowLogicError());
@@ -991,8 +1127,8 @@ TEST_F(WalletTest, WriteWitnessCache) {
 
 TEST_F(WalletTest, UpdateNullifierNoteMap) {
     TestWallet wallet;
-    uint256 r {GetRandHash()};
-    CKeyingMaterial vMasterKey (r.begin(), r.end());
+    uint256 r{GetRandHash()};
+    CKeyingMaterial vMasterKey(r.begin(), r.end());
 
     auto sk = libzcash::SpendingKey::random();
     wallet.AddSpendingKey(sk);
@@ -1005,8 +1141,8 @@ TEST_F(WalletTest, UpdateNullifierNoteMap) {
 
     // Pretend that we called FindMyNotes while the wallet was locked
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd {sk.address()};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd{sk.address()};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
@@ -1040,8 +1176,8 @@ TEST_F(WalletTest, UpdatedNoteData) {
     // First pretend we added the tx to the wallet and
     // we don't have the key for the second note
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 0};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 0};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
     wtx.SetNoteData(noteData);
 
@@ -1053,8 +1189,8 @@ TEST_F(WalletTest, UpdatedNoteData) {
     // Now pretend we added the key for the second note, and
     // the tx was "added" to the wallet again to update it.
     // This happens via the 'z_importkey' RPC method.
-    JSOutPoint jsoutpt2 {wtx2.getWrappedTx().GetHash(), 0, 1};
-    CNoteData nd2 {sk.address(), nullifier2};
+    JSOutPoint jsoutpt2{wtx2.getWrappedTx().GetHash(), 0, 1};
+    CNoteData nd2{sk.address(), nullifier2};
     noteData[jsoutpt2] = nd2;
     wtx2.SetNoteData(noteData);
 
@@ -1084,8 +1220,8 @@ TEST_F(WalletTest, MarkAffectedTransactionsDirty) {
     auto wtx2 = GetValidSpend(sk, note, 5);
 
     mapNoteData_t noteData;
-    JSOutPoint jsoutpt {hash, 0, 1};
-    CNoteData nd {sk.address(), nullifier};
+    JSOutPoint jsoutpt{hash, 0, 1};
+    CNoteData nd{sk.address(), nullifier};
     noteData[jsoutpt] = nd;
 
     wtx.SetNoteData(noteData);
@@ -1122,9 +1258,9 @@ TEST_F(WalletTest, SetBestChainIgnoresTxsWithoutShieldedData) {
     // Generate a transparent transaction that is ours
     CMutableTransaction t;
     t.resizeOut(1);
-    t.getOut(0).nValue = 90*CENT;
+    t.getOut(0).nValue = 90 * CENT;
     t.getOut(0).scriptPubKey = scriptPubKey;
-    CWalletTx wtxTransparent {nullptr, t};
+    CWalletTx wtxTransparent{nullptr, t};
     wallet.AddToWallet(wtxTransparent, true, nullptr);
 
     // Generate a Sprout transaction that is ours
@@ -1138,9 +1274,9 @@ TEST_F(WalletTest, SetBestChainIgnoresTxsWithoutShieldedData) {
     auto wtxInput = GetValidReceive(sk2, 10, true);
     auto note = GetNote(sk2, wtxInput.getWrappedTx(), 0, 0);
     auto wtxTmp = GetValidSpend(sk2, note, 5);
-    CMutableTransaction mtx {wtxTmp.getWrappedTx()};
+    CMutableTransaction mtx{wtxTmp.getWrappedTx()};
     mtx.getOut(0).scriptPubKey = scriptPubKey;
-    CWalletTx wtxSproutTransparent {nullptr, mtx};
+    CWalletTx wtxSproutTransparent{nullptr, mtx};
     wallet.AddToWallet(wtxSproutTransparent, true, nullptr);
 
     EXPECT_CALL(walletdb, TxnBegin())
@@ -1148,7 +1284,8 @@ TEST_F(WalletTest, SetBestChainIgnoresTxsWithoutShieldedData) {
     EXPECT_CALL(walletdb, WriteWalletTxBase(wtxTransparent.getWrappedTx().GetHash(), Eq(ByRef(wtxTransparent))))
         .Times(0);
     EXPECT_CALL(walletdb, WriteWalletTxBase(wtxSprout.getWrappedTx().GetHash(), Eq(ByRef(wtxSprout))))
-        .Times(1).WillOnce(Return(true));
+        .Times(1)
+        .WillOnce(Return(true));
     EXPECT_CALL(walletdb, WriteWalletTxBase(wtxSproutTransparent.getWrappedTx().GetHash(), Eq(ByRef(wtxSproutTransparent))))
         .Times(0);
     EXPECT_CALL(walletdb, WriteWitnessCacheSize(0))
@@ -1169,8 +1306,8 @@ TEST_F(WalletTest, NoteLocking) {
     auto wtx = GetValidReceive(sk, 10, true);
     auto wtx2 = GetValidReceive(sk, 10, true);
 
-    JSOutPoint jsoutpt {wtx.getWrappedTx().GetHash(), 0, 0};
-    JSOutPoint jsoutpt2 {wtx2.getWrappedTx().GetHash(),0, 0};
+    JSOutPoint jsoutpt{wtx.getWrappedTx().GetHash(), 0, 0};
+    JSOutPoint jsoutpt2{wtx2.getWrappedTx().GetHash(), 0, 0};
 
     // Test selective locking
     wallet.LockNote(jsoutpt);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -719,7 +719,7 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
 
     // Create and send the transaction
     CReserveKey reservekey(pwalletMain);
-    CAmount nFeeRequired;
+    CAmount nFeeRequired = 0;
     std::string strError;
     vector<CRecipient> vecSend;
     vector<CRecipientScCreation> vecScSend;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -13,21 +13,9 @@
 
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
-
-// how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
-#define RUN_TESTS 100
-
-// some tests fail 1% of the time due to bad luck.
-// we repeat those tests this many times and only complain if all iterations of the test fail
-#define RANDOM_REPEATS 5
+#include "coinsselectionalgorithm.hpp"
 
 using namespace std;
-
-#if 0
-typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
-#else
-typedef set<pair<const CWalletTransactionBase*,unsigned int> > CoinSet;
-#endif
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, TestingSetup)
 
@@ -63,252 +51,192 @@ static void empty_wallet(void)
     vCoins.clear();
 }
 
-static bool equal_sets(CoinSet a, CoinSet b)
-{
-    pair<CoinSet::iterator, CoinSet::iterator> ret = mismatch(a.begin(), a.end(), b.begin());
-    return ret.first == a.end() && ret.second == b.end();
-}
-
 BOOST_AUTO_TEST_CASE(coin_selection_tests)
 {
-    CoinSet setCoinsRet, setCoinsRet2;
+    std::vector<COutput> vCoinsRet;
     CAmount nValueRet;
+    size_t totalInputsBytes;
 
     LOCK(wallet.cs_wallet);
 
-    // test multiple times to allow for differences in the shuffle order
-    for (int i = 0; i < RUN_TESTS; i++)
-    {
-        empty_wallet();
-
-        // with an empty wallet we can't even pay one cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-
-        add_coin(1*CENT, 4);        // add a new 1 cent coin
-
-        // with a new 1 cent coin, we still can't find a mature 1 cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-
-        // but we can find a new 1 cent
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
-
-        add_coin(2*CENT);           // add a mature 2 cent coin
-
-        // we can't make 3 cents of mature coins
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-
-        // we can make 3 cents of new  coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
-
-        add_coin(5*CENT);           // add a mature 5 cent coin,
-        add_coin(10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
-        add_coin(20*CENT);          // and a mature 20 cent coin
-
-        // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
-
-        // we can't make 38 cents only if we disallow new coins:
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-        // we can't even make 37 cents if we don't allow new coins even if they're from us
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 6, 6, vCoins, setCoinsRet, nValueRet));
-        // but we can make 37 cents if we accept new coins from ourself
-        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 37 * CENT);
-        // and we can make 38 cents if we accept all new coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 38 * CENT);
-
-        // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_GT(nValueRet, 34 * CENT);         // but should get more than 34 cents
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
-
-        // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
-
-        // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(nValueRet == 8 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
-
-        // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
-
-        // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
-        empty_wallet();
-
-        add_coin( 6*CENT);
-        add_coin( 7*CENT);
-        add_coin( 8*CENT);
-        add_coin(20*CENT);
-        add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
-
-        // check that we have 71 and not 72
-        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-
-        // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good at the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
-
-        add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
-
-        // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
-
-        add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
-
-        // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest coin wins
-
-        // now try making 11 cents.  we should get 5+6
-        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
-
-        // check that the smallest bigger coin is used
-        add_coin( 1*COIN);
-        add_coin( 2*COIN);
-        add_coin( 3*COIN);
-        add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
-        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
-
-        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 BTC in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
-
-        // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
-        empty_wallet();
-        add_coin(0.1*CENT);
-        add_coin(0.2*CENT);
-        add_coin(0.3*CENT);
-        add_coin(0.4*CENT);
-        add_coin(0.5*CENT);
-
-        // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 = 1.5 cents
-        // we'll get sub-cent change whatever happens, so can expect 1.0 exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
-
-        // but if we add a bigger coin, making it possible to avoid sub-cent change, things change:
-        add_coin(1111*CENT);
-
-        // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5 cents
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
-
-        // if we add more sub-cent coins:
-        add_coin(0.6*CENT);
-        add_coin(0.7*CENT);
-
-        // and try again to make 1.0 cents, we can still make 1.0 cents
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
-
-        // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
-        // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
-        empty_wallet();
-        for (int i = 0; i < 20; i++)
-            add_coin(50000 * COIN);
-
-        BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 10U); // in ten coins
-
-        // if there's not enough in the smaller coins to make at least 1 cent change (0.5+0.6+0.7 < 1.0+1.0),
-        // we need to try finding an exact subset anyway
-
-        // sometimes it will fail, and so we use the next biggest coin:
-        empty_wallet();
-        add_coin(0.5 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.7 * CENT);
-        add_coin(1111 * CENT);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1111 * CENT); // we get the bigger coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
-
-        // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
-        empty_wallet();
-        add_coin(0.4 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.8 * CENT);
-        add_coin(1111 * CENT);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);   // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two coins 0.4+0.6
-
-        // test avoiding sub-cent change
-        empty_wallet();
-        add_coin(0.0005 * COIN);
-        add_coin(0.01 * COIN);
-        add_coin(1 * COIN);
-
-        // trying to make 1.0001 from these three coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1.0001 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1.0105 * COIN);   // we should get all coins
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
-
-        // but if we try to make 0.999, we should take the bigger of the two small coins to avoid sub-cent change
-        BOOST_CHECK( wallet.SelectCoinsMinConf(0.999 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1.01 * COIN);   // we should get 1 + 0.01
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
-
-        // test randomness
-        {
-            empty_wallet();
-            for (int i2 = 0; i2 < 100; i2++)
-                add_coin(COIN);
-
-            // picking 50 from 100 coins doesn't depend on the shuffle,
-            // but does depend on randomness in the stochastic approximation code
-            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
-            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
-            BOOST_CHECK(!equal_sets(setCoinsRet, setCoinsRet2));
-
-            int fails = 0;
-            for (int i = 0; i < RANDOM_REPEATS; i++)
-            {
-                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
-                // run the test RANDOM_REPEATS times and only complain if all of them fail
-                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
-                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
-                if (equal_sets(setCoinsRet, setCoinsRet2))
-                    fails++;
-            }
-            BOOST_CHECK_NE(fails, RANDOM_REPEATS);
-
-            // add 75 cents in small change.  not enough to make 90 cents,
-            // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
-            // one of which should be picked at random
-            add_coin( 5*CENT); add_coin(10*CENT); add_coin(15*CENT); add_coin(20*CENT); add_coin(25*CENT);
-
-            fails = 0;
-            for (int i = 0; i < RANDOM_REPEATS; i++)
-            {
-                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
-                // run the test RANDOM_REPEATS times and only complain if all of them fail
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet , nValueRet));
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet2, nValueRet));
-                if (equal_sets(setCoinsRet, setCoinsRet2))
-                    fails++;
-            }
-            BOOST_CHECK_NE(fails, RANDOM_REPEATS);
-        }
-    }
     empty_wallet();
+    // with an empty wallet we can't even pay one cent
+    BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    add_coin(1*CENT, 4);        // add a new 1 cent coin
+    // with a new 1 cent coin, we still can't find a mature 1 cent
+    BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    // but we can find a new 1 cent
+    BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1);
+    add_coin(2*CENT);           // add a mature 2 cent coin
+    // we can't make 3 cents of mature coins
+    BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    // we can make 3 cents of new  coins
+    BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 2);
+    add_coin(5*CENT);           // add a mature 5 cent coin,
+    add_coin(10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
+    add_coin(20*CENT);          // and a mature 20 cent coin
+    // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
+    // we can't make 38 cents only if we disallow new coins:
+    BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 1, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    // we can't even make 37 cents if we don't allow new coins even if they're from us
+    BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 6, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    // but we can make 37 cents if we accept new coins from ourself
+    BOOST_CHECK( wallet.SelectCoinsMinConf(37 * CENT, 1, 6, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 37 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 4);
+    // and we can make 38 cents if we accept all new coins
+    BOOST_CHECK( wallet.SelectCoinsMinConf(38 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 38 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 5);
+    // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
+    BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_GT(nValueRet, 34 * CENT); // but should get more than 34 cents
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 3); // the best should be 20+10+5
+    // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
+    BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 2);
+    // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
+    BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK(nValueRet == 8 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 3);
+    // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
+    BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1);
+    // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
+    empty_wallet();
+    add_coin( 6*CENT);
+    add_coin( 7*CENT);
+    add_coin( 8*CENT);
+    add_coin(20*CENT);
+    add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
+    // check that we have 71 and not 72
+    BOOST_CHECK( wallet.SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 71 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 5);
+    BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good as the next biggest coin, 20
+    BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1);
+    add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
+    // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
+    BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 3);
+    add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
+    // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
+    BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 3 coins
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 3); // because in the event of a tie, the larger utxos set wins
+    // now try making 11 cents.  we should get 5+6
+    BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 2);
+    // check that the smallest bigger coin is used
+    add_coin( 1*COIN);
+    add_coin( 2*COIN);
+    add_coin( 3*COIN);
+    add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
+    BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1);
+    BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 BTC in 1 coin
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1);
+    // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
+    empty_wallet();
+    add_coin(0.1*CENT);
+    add_coin(0.2*CENT);
+    add_coin(0.3*CENT);
+    add_coin(0.4*CENT);
+    add_coin(0.5*CENT);
+    // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 = 1.5 cents
+    BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // in this case 1 cents
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 4);
+    // and if we add a bigger coin nothing changes:
+    add_coin(1111*CENT);
+    // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5 cents
+    BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we get 1.0 cents in four coins
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 4); // also 0.5 + 0.4 + 0.1 was a candidate, but excluded
+                                                                       // because in the event of a tie, the larger utxos set wins
+    // if we add more sub-cent coins:
+    add_coin(0.6*CENT);
+    add_coin(0.7*CENT);
+    // and try again to make 1.0 cents, again nothing changes
+    BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1.0 * CENT); // in this case 1.0 cents in four coins
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 4);
+    
+    // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
+    // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
+    empty_wallet();
+    for (int i = 0; i < 20; i++)
+        add_coin(50000 * COIN);
+    BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // in this case 500000 coins
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 10); // in eleven coins
+    // in case of sets of equal size we prioritize lower change
+    empty_wallet();
+    add_coin(0.5 * CENT);
+    add_coin(0.6 * CENT);
+    add_coin(0.7 * CENT);
+    add_coin(1111 * CENT);
+    BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1.1 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 2); // in two coins 0.5+0.6
+    // again prioritizing lower change
+    empty_wallet();
+    add_coin(0.4 * CENT);
+    add_coin(0.6 * CENT);
+    add_coin(0.8 * CENT);
+    add_coin(1111 * CENT);
+    BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 2); // in two coins 0.4+0.6
+    
+    empty_wallet();
+
+    // create many small coins and one big coin
+    for (int i = 0; i < 3000; i++)
+    {
+        add_coin(1*CENT);
+    }
+    add_coin(1000*CENT);
+    // target an amount greater than the big coin, it is expected it gets included because using only small coins would result in oversizing
+    BOOST_CHECK( wallet.SelectCoinsMinConf(3000 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, false));
+    BOOST_CHECK_EQUAL(nValueRet, 3000 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 1 + 2000); // the big one and many small
+
+    // setting useInputsNetValues to true leads to some counterintuitive outcomes at first glance
+    // but if we consider that net value of a coin is always very slightly less than its gross value everything makes sense
+    BOOST_CHECK( wallet.SelectCoinsMinConf(500 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, true));
+    BOOST_CHECK_GT(nValueRet, 500 * CENT);
+    BOOST_CHECK_GT(vCoinsRet.size(), 500); // few more than 500 coins are expected due to use of inputs net values
+
+    empty_wallet();
+    add_coin(0.1*CENT);
+    add_coin(0.1*CENT);
+    add_coin(0.2*CENT);
+    add_coin(0.2*CENT);
+    add_coin(0.3*CENT);
+    add_coin(0.3*CENT);
+    add_coin(0.4*CENT);
+    add_coin(0.4*CENT);
+    BOOST_CHECK( wallet.SelectCoinsMinConf(0.5 * CENT, 1, 1, vCoins, vCoinsRet, nValueRet, totalInputsBytes, MAX_TX_SIZE, true));
+    // surely we cannot get a set of coins with total net value exactly 0.5
+    // so we have to move to the first change level, in this case it is defined starting from sum of lower coins
+    // totalLower = 2.0 -> changeLevel = totalLower / 10 = 0.2, hence our second try at nTargetValue would be [5.5, 0.7 = 0.5 + 0.2]
+    // now a set of coins with total net value equals to 0.6-epsilon can be found, and the corresponding total gross value would be 0.6
+    BOOST_CHECK_EQUAL(nValueRet, 0.6 * CENT);
+    BOOST_CHECK_EQUAL(vCoinsRet.size(), 4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1283,7 +1283,26 @@ public:
                           int minDepth=1,
                           bool ignoreSpent=true,
                           bool ignoreUnspendable=true);
-    
+
+    //! Method for selecting notes based on value and size constraints
+    /*!
+      The implementation details of this method are stricly connected to the implementation of AsyncRPCOperation_sendmany::main_impl() as for commit "d1104ef903147338692344069e30c666d8b78614"
+      
+      Unlike coins selection methods (SelectCoins/SelectCoinsMinConf), this method does not provide a distinction between notes gross value and notes net value;
+      gross value is always considered as value.
+      \param nTargetValue the target value (as sum of notes values) to be satisfied (lower-limit), to be considered always as gross value
+      \param vNotes the set of notes on which the selection algorithms have to be executed
+      \param vNotesRet the set of notes returned selection algorithms
+      \param nValueRet the actual total value of notes returned (as sum of returned notes values), to be considered always as gross value
+      \param selectionTotalBytes the total bytes of selected notes
+      \param availableBytes available bytes (considered as an upper-limit on the sum of joinsplits sizes) for performing notes selection (default to MAX_TX_SIZE)
+      \param joinsplitsOutputsAmounts the vector of joinsplits outputs that need to be satisfied by the selected notes (default to empty vector)
+      \return a flag representing wether the selection actually found (true) an admissible set of notes or not (false)
+    */
+    bool SelectNotes(const CAmount& nTargetValue, std::vector<CNotePlaintextEntry> vNotes,
+                     std::vector<CNotePlaintextEntry>& vNotesRet, CAmount& nValueRet, size_t &selectionTotalBytes,
+                     size_t availableBytes = MAX_TX_SIZE, const std::vector<CAmount>& joinsplitsOutputsAmounts = std::vector<CAmount>()) const;
+
     /* Find unspent notes filtered by payment address, min depth and max depth */
     void GetUnspentFilteredNotes(std::vector<CUnspentNotePlaintextEntry>& outEntries,
                                  std::set<libzcash::PaymentAddress>& filterAddresses,


### PR DESCRIPTION
This pull request brings in improvements in the input (coins/notes) selection phase when wallet needs to create tx/cert, in particular:
- validation of transaction size constraint (previously absent); this allows to exclude inputs sets too big that would result in a discarded tx/cert (due to oversized limit); furthermore, for z-transactions, in case of impossibility to generate the transaction, an error is immediately signalled during the inputs selection phase instead of waiting for several joinsplits computation (as was previously done)
- new coins/notes selection criteria, aiming to maximize size of selection set*; at the same time change is kept at zero or at low level, through the use of increasing change bands
- improved automatic fee selection, granting that the minimum fee is paid (previously the operation was looped with iterative estimation, resulting in higher fee rates)


For reviewing this PR, the author suggests to check the changes with the following order:
1. `transaction.h`/`wallet.h`/`wallet.cpp` (focusing on transparent part):
- the new approach of estimating the non-input parts of tx/cert is shown, followed by the actual selection of inputs;
- the fundamentals structure for tx/cert estimation are introduced and major modifications targets methods `SelectCoins` and `SelectCoinsMinConf`, new method `SelectNotes` is provided (but it is better to check later)
2. `coinsselectionalgorithm.h`/`coinsselectionalgorithm.cpp`:
- the new solvers for coins selection algorithm are provided: fast and not optimal (`SlidingWindow`), slow and optimal (`B&B`); the new algorithm for notes selection is provided: `ForNotes` (but it is better to check later)
- check the integration of those new algorithms within `SelectCoinsMinConf` method
3. `sidechainrpc.h`/`sidechainrpc.cpp`:
- check the integration of the new algorithms within `addInputs` method
4. `asyncrpcoperation_sendmany.h`/`asyncrpcoperation_sendmany.cpp`/`wallet.h`/`wallet.cpp`/`coinsselectionalgorithm.h`/`coinsselectionalgorithm.cpp`:
- major modifications targets `main_impl` method
- check the integration of new method `SelectNotes` and new algorithm `ForNotes` within `main_impl` method
5. `oversized_tx_cert`:
- the creation of oversized tx/cert is tested; the majority of positive tests were failing with previous implementation (but it was a bad failure, because in many cases a solution could be found)
6. all the rest...(very minor sparse refactoring are included in this PR)


*this aspect is crucial in terms of community goal, since the growth of the global set of UTXOs is a critical issue for any UTXO-based model (in contrast with account-based model); hence the reduction of this set should be always encouraged and welcome.

_Initial discussion available on PR #495._