### PR TITLE
Added test options support for run_until_fails.py

### DIFF
--- a/qa/rpc-tests/run_until_fails.py
+++ b/qa/rpc-tests/run_until_fails.py
@@ -3,10 +3,11 @@
 # Please, note that only the output of the failing test is printed, the output of the succeeding tests is filtered out.
 #
 # Usage:
-# python run_until_fails.py <test_file>
+# python run_until_fails.py <test_file> [test options]
 #
 # Example usage:
 # python run_until_fails.py addressindex.py
+# python run_until_fails.py reindex.py --nocleanup
 
 import subprocess
 import sys
@@ -14,11 +15,12 @@ import sys
 from datetime import datetime
 from os import path
 
-if len(sys.argv) != 2:
-    print("Usage: run_until_fails.py test_name.py")
+if len(sys.argv) < 2:
+    print("Usage: run_until_fails.py test_name.py [test options]")
     sys.exit(1)
 
 test_file = sys.argv[1]
+test_command = sys.argv[1:]
 
 if not path.isfile(test_file):
     print(f"Test file does not exist: {test_file}")
@@ -31,7 +33,7 @@ counter = 0
 while not error_occurred:
     counter = counter + 1
     print(f"[{counter}] Running test: {test_file} - {datetime.now().strftime('%H:%M:%S')}")
-    command_call = subprocess.Popen(["python3", test_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    command_call = subprocess.Popen(["python3"]+test_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
     output, errors = command_call.communicate()
     error_occurred = command_call.returncode != 0
 


### PR DESCRIPTION
This PR improves the run_until_fails.py script by allowing to pass command line options to the script itself (for instance,  `--nocleanup`)