### PR TITLE
Ap/join network sync improvement zend 616

### DIFF
--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -30,9 +30,9 @@ class AddressIndexTest(BitcoinTestFramework):
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug", "-addressindex", "-txindex", "-relaypriority=0"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-addressindex", "-txindex"]))
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 0, 3)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/blockdelay.py
+++ b/qa/rpc-tests/blockdelay.py
@@ -5,16 +5,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
-import traceback
-import os,sys
-import shutil
-from random import randint
-from decimal import Decimal
-import logging
+from test_framework.util import initialize_chain_clean, start_node, sync_blocks, connect_nodes_bi
 
 import time
 class blockdelay(BitcoinTestFramework):
@@ -27,9 +18,6 @@ class blockdelay(BitcoinTestFramework):
         #Join the (previously split) network halves together.
         assert self.is_network_split
         connect_nodes_bi(self.nodes, 0, 3)
-        connect_nodes_bi(self.nodes, 3, 0)
-        #sync_blocks(self.nodes[0:3],1,True)
-        #sync_mempools(self.nodes[1:3])
         self.sync_all()
         self.is_network_split = False
 
@@ -51,7 +39,6 @@ class blockdelay(BitcoinTestFramework):
             x.dbg_log(msg)
 
     def sync_longest_fork(self, wait=1, limit_loop=0):
-
         '''
            Wait until all the nodes have the same length for the longest fork.
         '''
@@ -99,8 +86,6 @@ class blockdelay(BitcoinTestFramework):
         except JSONRPCException as e:
             errorString = e.error['message']
             print(errorString)
-        '''
-        '''
 
         print("\n\nGenerating initial blockchain 104 blocks")
         blocks.extend(self.nodes[0].generate(101)) # block height 1
@@ -196,7 +181,6 @@ class blockdelay(BitcoinTestFramework):
 
         print("\n\nJoin network")
         self.mark_logs("Joining network")
-#        raw_input("press enter to join the netorks..")
         self.join_network()
         self.sync_longest_fork(1, 10)
 
@@ -267,8 +251,6 @@ class blockdelay(BitcoinTestFramework):
 #                                \
 #                                 +->[105h]...->[116h]
 
-#        raw_input("press enter to generate 64 malicious blocks..")
-
         print("\nGenerating 64 malicious blocks")
         self.mark_logs("Generating 64 malicious blocks")
         self.nodes[3].generate(64)
@@ -334,8 +316,6 @@ class blockdelay(BitcoinTestFramework):
 #                                \
 #                                 +->[105h]...->[116h]
 
-#        raw_input("press enter to generate 65 honest blocks..")
-
         print("\nGenerating 65 more honest blocks")
         self.mark_logs("Generating 65 more honest blocks")
         self.nodes[0].generate(65)
@@ -362,8 +342,6 @@ class blockdelay(BitcoinTestFramework):
             print("Node%d  ---" % i)
             self.dump_ordered_tips(self.nodes[i].getchaintips(True))
             print("---")
-
-#        raw_input("press enter to generate 1 more malicious blocks which will cause the attack to succeed..")
 
         print("\nTesting fork related data from getchaintips")
         print("\nTesting Node 0")
@@ -466,15 +444,12 @@ class blockdelay(BitcoinTestFramework):
         assert self.nodes[1].getbalance() == 0.0
         print("\nNode1 balance has been erased!:", self.nodes[1].getbalance())
 
-#        raw_input("press enter to connect a brand new node..")
-
         # Connect a fifth node from scratch and update
         s = "Connecting a new node"
         print(s)
         self.mark_logs(s)
         self.nodes.append(start_node(4, self.options.tmpdir))
         connect_nodes_bi(self.nodes, 4, 3)
-        connect_nodes_bi(self.nodes, 3, 4)
         sync_blocks(self.nodes, 1, True, 5)
 
         for i in range(0, 5):

--- a/qa/rpc-tests/blockdelay_2.py
+++ b/qa/rpc-tests/blockdelay_2.py
@@ -34,8 +34,8 @@ class blockdelay_2(BitcoinTestFramework):
 
     def split_network(self, id = 1):
         # Split the network of between adjanced nodes in linear topology ep. nodes 0-1 and 2-3.
-        disconnect_nodes(self.nodes[id], id + 1)
-        disconnect_nodes(self.nodes[id + 1], id)
+        disconnect_nodes(self.nodes, id, id + 1)
+        disconnect_nodes(self.nodes, id + 1, id)
 
     def dump_ordered_tips(self, tip_list):
         sorted_x = sorted(tip_list, key=lambda k: k['status'])

--- a/qa/rpc-tests/cbh_rpfix.py
+++ b/qa/rpc-tests/cbh_rpfix.py
@@ -39,12 +39,10 @@ class cbh_rpfix(BitcoinTestFramework):
 
         if not split:
             connect_nodes_bi(self.nodes, 1, 2)
-            connect_nodes_bi(self.nodes, 2, 1)
             sync_blocks(self.nodes[1:NUMB_OF_NODES])
             sync_mempools(self.nodes[1:NUMB_OF_NODES])
 
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 0)
         self.is_network_split = split
         self.sync_all()
 

--- a/qa/rpc-tests/checkblockatheight.py
+++ b/qa/rpc-tests/checkblockatheight.py
@@ -5,24 +5,14 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.script import OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_EQUAL, hash160, OP_CHECKSIG, OP_CHECKBLOCKATHEIGHT
+from test_framework.script import CScript, OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_CHECKSIG, OP_CHECKBLOCKATHEIGHT
 from test_framework.util import assert_equal, assert_greater_than, bytes_to_hex_str, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, disconnect_nodes
-from test_framework.script import CScript
+    start_nodes, stop_nodes, sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, \
+    hex_str_to_bytes, swap_bytes
 from test_framework.mininode import CTransaction, ToHex
-from test_framework.util import hex_str_to_bytes, swap_bytes
-import traceback
 from binascii import unhexlify
 from io import BytesIO
-import os,sys
-import shutil
 from decimal import Decimal
-import binascii
-import codecs
-import pprint
-
-import time
 
 NUMB_OF_NODES = 4
 
@@ -55,14 +45,11 @@ class checkblockatheight(BitcoinTestFramework):
         if not split:
             # 2 and 3 are joint only if split==false
             connect_nodes_bi(self.nodes, 2, 3)
-            connect_nodes_bi(self.nodes, 3, 2)
             sync_blocks(self.nodes[2:NUMB_OF_NODES])
             sync_mempools(self.nodes[2:NUMB_OF_NODES])
 
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 0)
         connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 1)
         self.is_network_split = split
         self.sync_all()
 
@@ -70,7 +57,6 @@ class checkblockatheight(BitcoinTestFramework):
         #Join the (previously split) network pieces together: 0-1-2-3
         assert self.is_network_split
         connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 2)
         sync_blocks(self.nodes, 1, False, 5)
         self.is_network_split = False
 

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -48,10 +48,10 @@ class ForkNotifyTest(BitcoinTestFramework):
         # Node1 mines block.version=211 blocks
         self.nodes.append(start_node(1, self.options.tmpdir,
                                 ["-blockversion=%d" % UP_VERSION]))
-        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes, 1, 0)
 
         self.nodes.append(start_node(2, self.options.tmpdir, []))
-        connect_nodes(self.nodes[2], 1)
+        connect_nodes(self.nodes, 2, 1)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/getblocktemplate_blockmaxcomplexity.py
+++ b/qa/rpc-tests/getblocktemplate_blockmaxcomplexity.py
@@ -32,13 +32,13 @@ class GetBlockTemplateBlockMaxComplexityTest(BitcoinTestFramework):
         self.nodes.append(start_node(5, self.options.tmpdir, args5))
         self.nodes.append(start_node(6, self.options.tmpdir, args6))
         self.nodes.append(start_node(7, self.options.tmpdir, args7))
-        connect_nodes(self.nodes[1], 0)
-        connect_nodes(self.nodes[2], 0)
-        connect_nodes(self.nodes[3], 0)
-        connect_nodes(self.nodes[4], 0)
-        connect_nodes(self.nodes[5], 0)
-        connect_nodes(self.nodes[6], 0)
-        connect_nodes(self.nodes[7], 0)
+        connect_nodes(self.nodes, 1, 0)
+        connect_nodes(self.nodes, 2, 0)
+        connect_nodes(self.nodes, 3, 0)
+        connect_nodes(self.nodes, 4, 0)
+        connect_nodes(self.nodes, 5, 0)
+        connect_nodes(self.nodes, 6, 0)
+        connect_nodes(self.nodes, 7, 0)
         self.is_network_split = False
         self.sync_all
 

--- a/qa/rpc-tests/getblocktemplate_priority.py
+++ b/qa/rpc-tests/getblocktemplate_priority.py
@@ -31,9 +31,9 @@ class GetBlockTemplatePriorityTest(BitcoinTestFramework):
         self.nodes.append(start_node(2, self.options.tmpdir, args2))
         self.nodes.append(start_node(3, self.options.tmpdir, args3))
 
-        connect_nodes(self.nodes[1], 0)
-        connect_nodes(self.nodes[2], 0)
-        connect_nodes(self.nodes[3], 0)
+        connect_nodes(self.nodes, 1, 0)
+        connect_nodes(self.nodes, 2, 0)
+        connect_nodes(self.nodes, 3, 0)
 
         self.is_network_split = False
         self.sync_all

--- a/qa/rpc-tests/headers_01.py
+++ b/qa/rpc-tests/headers_01.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_02.py
+++ b/qa/rpc-tests/headers_02.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_02.py
+++ b/qa/rpc-tests/headers_02.py
@@ -88,9 +88,8 @@ class headers(BitcoinTestFramework):
         print("\n\nJoin network")
 #        raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
-        self.join_network_sync()
+        self.join_network()
 
-        time.sleep(2)
         print("\nNetwork joined") 
         self.mark_logs("Network joined")
 

--- a/qa/rpc-tests/headers_03.py
+++ b/qa/rpc-tests/headers_03.py
@@ -89,9 +89,8 @@ class headers(BitcoinTestFramework):
         print("\n\nJoin network")
 #        raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
-        self.join_network_sync()
+        self.join_network()
 
-        time.sleep(2)
         print("\nNetwork joined") 
         self.mark_logs("Network joined")
 

--- a/qa/rpc-tests/headers_03.py
+++ b/qa/rpc-tests/headers_03.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_04.py
+++ b/qa/rpc-tests/headers_04.py
@@ -104,9 +104,8 @@ class headers(BitcoinTestFramework):
         print("\n\nJoin network")
 #        raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
-        self.join_network_sync()
+        self.join_network()
 
-        time.sleep(2)
         print("\nNetwork joined\n") 
         self.mark_logs("Network joined")
 

--- a/qa/rpc-tests/headers_04.py
+++ b/qa/rpc-tests/headers_04.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_05.py
+++ b/qa/rpc-tests/headers_05.py
@@ -5,18 +5,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
-import traceback
-import os,sys
-import shutil
-from random import randint
-from decimal import Decimal
-import logging
-
+from test_framework.util import initialize_chain_clean, start_nodes, connect_nodes_bi
 import time
+
 class headers(BitcoinTestFramework):
 
     def setup_chain(self, split=False):
@@ -25,6 +16,13 @@ class headers(BitcoinTestFramework):
 
     def setup_nodes(self):
         self.nodes = start_nodes(3, self.options.tmpdir)
+
+    def join_network(self):
+        #Join the (previously split) network pieces together: 0-1-2
+        assert self.is_network_split
+        connect_nodes_bi(self.nodes, 2, 1)
+        self.sync_all()
+        self.is_network_split = False
 
     def dump_ordered_tips(self, tip_list):
         sorted_x = sorted(tip_list, key=lambda k: k['status'])
@@ -88,14 +86,10 @@ class headers(BitcoinTestFramework):
 #                       
 # Node(2): [0]->[1]->[2m]->..->..->[21m]
 
-#        raw_input("press enter to go on..")
-
         print("\n\nJoin network")
-        # raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
         self.join_network()
 
-        time.sleep(2)
         print("\nNetwork joined") 
         self.mark_logs("Network joined")
 
@@ -116,8 +110,6 @@ class headers(BitcoinTestFramework):
 #                 \     
 #                  +->[2h]->..->[8h]
 
-#        raw_input("press enter to go on..")
-
         print("Checking finality of block[", blA, "]")
         print("  Node0 has: %d" % self.nodes[0].getblockfinalityindex(blA))
         print("  Node1 has: %d" % self.nodes[1].getblockfinalityindex(blA))
@@ -127,8 +119,6 @@ class headers(BitcoinTestFramework):
         print("Checking finality of block[", blC, "]")
         print("  Node0 has: %d" % self.nodes[0].getblockfinalityindex(blC))
         print("  Node1 has: %d" % self.nodes[1].getblockfinalityindex(blC))
-
-#        raw_input("press enter to go on..")
 
         for j in range(1, 10):
             print("### block %d ---" % j)
@@ -153,22 +143,10 @@ class headers(BitcoinTestFramework):
                 print(errorString)
                 print("\n ===> Malicious attach succeeded after %d blocks!!\n\n" % j)
                 break
-#            for i in range(0, 3):
-#                print self.nodes[i].getchaintips()[0]
-#            raw_input("press enter to go on..")
-
-
-#        self.sync_all()
-        time.sleep(2)
 
         for i in range(0, 3):
             self.dump_ordered_tips(self.nodes[i].getchaintips())
             print("---")
-
-        time.sleep(1)
-
-#        raw_input("press enter to go on..")
-
 
 if __name__ == '__main__':
     headers().main()

--- a/qa/rpc-tests/headers_06.py
+++ b/qa/rpc-tests/headers_06.py
@@ -41,8 +41,8 @@ class headers(BitcoinTestFramework):
         self.sync_all()
 
     def split_network_2(self):
-        disconnect_nodes(self.nodes[1], 3)
-        disconnect_nodes(self.nodes[3], 1)
+        disconnect_nodes(self.nodes, 1, 3)
+        disconnect_nodes(self.nodes, 3, 1)
 
     def join_network_2(self):
         connect_nodes_bi(self.nodes, 1, 3)

--- a/qa/rpc-tests/headers_06.py
+++ b/qa/rpc-tests/headers_06.py
@@ -41,18 +41,11 @@ class headers(BitcoinTestFramework):
         self.sync_all()
 
     def split_network_2(self):
-#        assert not self.is_network_split
         disconnect_nodes(self.nodes[1], 3)
         disconnect_nodes(self.nodes[3], 1)
-#        self.is_network_split = True
 
     def join_network_2(self):
-#        assert self.is_network_split
         connect_nodes_bi(self.nodes, 1, 3)
-        connect_nodes_bi(self.nodes, 3, 1)
-        time.sleep(2)
-#        self.sync_all()
-#        self.is_network_split = False
 
     def mark_logs(self, msg):
         self.nodes[0].dbg_log(msg)

--- a/qa/rpc-tests/headers_07.py
+++ b/qa/rpc-tests/headers_07.py
@@ -5,19 +5,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
-import traceback
-import os,sys
-import shutil
-from random import randint
-from decimal import Decimal
-import logging
-import operator
-
+from test_framework.util import initialize_chain_clean, start_nodes, stop_nodes, \
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, disconnect_nodes
 import time
+
 class headers(BitcoinTestFramework):
 
     def setup_chain(self, split=False):
@@ -44,17 +35,11 @@ class headers(BitcoinTestFramework):
         self.sync_all()
 
     def split_network_2(self):
-#        assert not self.is_network_split
         disconnect_nodes(self.nodes[1], 3)
         disconnect_nodes(self.nodes[3], 1)
-        self.is_network_split = True
 
     def join_network_2(self):
-#        assert self.is_network_split
-        connect_nodes_bi(self.nodes, 3, 1)
         connect_nodes_bi(self.nodes, 1, 3)
-        time.sleep(2)
-#        self.sync_all()
         self.is_network_split = False
 
     def mark_logs(self, msg):
@@ -106,14 +91,8 @@ class headers(BitcoinTestFramework):
 # Node(3): [0]->[1]
 
         print("\n\nSplit nodes (1)----x   x---(3)")
-#        self.split_network_2()
-#-------------------------------------------------
-        disconnect_nodes(self.nodes[1], 3)
-        disconnect_nodes(self.nodes[3], 1)
-#        connect_nodes_bi(self.nodes, 1, 2)
-#        connect_nodes_bi(self.nodes, 0, 1)
-#-------------------------------------------------
-        time.sleep(2)
+        self.split_network_2()
+
         print("The network is split")
         self.mark_logs("The network is split 2")
 
@@ -137,15 +116,7 @@ class headers(BitcoinTestFramework):
 # Node(3): [0]->[1]
 
         print("\n\nSplit nodes (1)----x   x---(2)")
-#        self.split_network()
-#-------------------------------------------------
-        stop_nodes(self.nodes)
-        wait_bitcoinds()
-        self.setup_nodes()
-        connect_nodes_bi(self.nodes, 0, 1)
-#-------------------------------------------------
-        self.is_network_split = True
-        time.sleep(2)
+        self.split_network(1)
 
         print("The network is split")
         self.mark_logs("The network is split")
@@ -189,15 +160,8 @@ class headers(BitcoinTestFramework):
         print("\n\nJoin nodes (1)--(2)")
         # raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
-#        self.join_network()
-#-------------------------------------------------
-        stop_nodes(self.nodes)
-        wait_bitcoinds()
-        self.setup_nodes()
-        connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
 #-------------------------------------------------
-        time.sleep(10)
 
         print("\nNetwork joined") 
         self.mark_logs("Network joined")
@@ -241,13 +205,7 @@ class headers(BitcoinTestFramework):
 
         print("\n\nJoin nodes (1)--(3)")
         self.mark_logs("Joining network 2")
-#        self.join_network_2()
-#-------------------------------------------------
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 1, 3)
-#-------------------------------------------------
-        time.sleep(10)
+        self.join_network_2()
 
         print("\nNetwork joined") 
         self.mark_logs("Network joined 2")

--- a/qa/rpc-tests/headers_07.py
+++ b/qa/rpc-tests/headers_07.py
@@ -5,8 +5,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import initialize_chain_clean, start_nodes, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, disconnect_nodes
+from test_framework.util import initialize_chain_clean, start_nodes, \
+    sync_blocks, sync_mempools, connect_nodes_bi, disconnect_nodes
 import time
 
 class headers(BitcoinTestFramework):
@@ -35,8 +35,8 @@ class headers(BitcoinTestFramework):
         self.sync_all()
 
     def split_network_2(self):
-        disconnect_nodes(self.nodes[1], 3)
-        disconnect_nodes(self.nodes[3], 1)
+        disconnect_nodes(self.nodes, 1, 3)
+        disconnect_nodes(self.nodes, 3, 1)
 
     def join_network_2(self):
         connect_nodes_bi(self.nodes, 1, 3)

--- a/qa/rpc-tests/headers_08.py
+++ b/qa/rpc-tests/headers_08.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_09.py
+++ b/qa/rpc-tests/headers_09.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision
 import traceback
 import os,sys
 import shutil

--- a/qa/rpc-tests/headers_09.py
+++ b/qa/rpc-tests/headers_09.py
@@ -30,7 +30,6 @@ class headers(BitcoinTestFramework):
         #Join the (previously split) network pieces together: 0-1-2
         assert self.is_network_split
         connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 1)
         self.sync_all()
         self.is_network_split = False
 

--- a/qa/rpc-tests/headers_10.py
+++ b/qa/rpc-tests/headers_10.py
@@ -79,10 +79,7 @@ class headers(BitcoinTestFramework):
 #                       
 # Node(2): [0]->[1]->[2m]
 
-#        raw_input("press enter to go on..")
-
         print("\n\nJoin network")
-#        raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
         self.join_network()
 
@@ -145,9 +142,6 @@ class headers(BitcoinTestFramework):
 # Node(2): [0]->[1]->[2m]  **Active**
 #                 \     
 #                  +->[2h]    
-
-#        raw_input("press enter to go on..")
-        time.sleep(10)
 
 if __name__ == '__main__':
     headers().main()

--- a/qa/rpc-tests/headers_10.py
+++ b/qa/rpc-tests/headers_10.py
@@ -4,19 +4,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, start_node, connect_nodes, stop_node, stop_nodes, \
-    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, p2p_port, check_json_precision, \
-    disconnect_nodes
-import traceback
-import os,sys
-import shutil
-from random import randint
-from decimal import Decimal
-import logging
-
+from test_framework.util import initialize_chain_clean, start_nodes, sync_blocks
 import time
+
 class headers(BitcoinTestFramework):
 
     def setup_chain(self, split=False):
@@ -94,9 +84,8 @@ class headers(BitcoinTestFramework):
         print("\n\nJoin network")
 #        raw_input("press enter to join the netorks..")
         self.mark_logs("Joining network")
-        self.join_network_sync()
+        self.join_network()
 
-#        time.sleep(10)
         sync_blocks(self.nodes, 1, True, 15)
 
         for i in range(0, 3):

--- a/qa/rpc-tests/mempool_coinbase_spends.py
+++ b/qa/rpc-tests/mempool_coinbase_spends.py
@@ -9,7 +9,7 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, start_node, connect_nodes
+from test_framework.util import assert_equal, start_node
 
 
 # Create one-input, one-output, no-fee transaction:
@@ -54,6 +54,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spend_102_id = self.nodes[0].sendrawtransaction(spend_102_raw)
         spend_103_id = self.nodes[0].sendrawtransaction(spend_103_raw)
         self.nodes[0].generate(1)
+        self.sync_all()
 
         # Create 102_1 and 103_1:
         spend_102_1_raw = self.create_tx(spend_102_id, node1_address, 11)
@@ -63,11 +64,11 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spend_103_1_id = self.nodes[0].sendrawtransaction(spend_103_1_raw)
         [spend_103_1_id] # hush pyflakes
         self.nodes[0].generate(1)
+        self.sync_all()
 
         # ... now put spend_101 and spend_102_1 in memory pools:
         spend_101_id = self.nodes[0].sendrawtransaction(spend_101_raw)
         spend_102_1_id = self.nodes[0].sendrawtransaction(spend_102_1_raw)
-
         self.sync_all()
 
         assert_equal(set(self.nodes[0].getrawmempool()), set([ spend_101_id, spend_102_1_id ]))

--- a/qa/rpc-tests/mempool_double_spend.py
+++ b/qa/rpc-tests/mempool_double_spend.py
@@ -9,10 +9,8 @@
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, connect_nodes, \
-    sync_blocks, gather_inputs, start_nodes, sync_mempools, \
-    connect_nodes_bi, initialize_chain_clean, mark_logs, \
-    disconnect_nodes
+from test_framework.util import assert_equal, start_nodes, sync_mempools, \
+    connect_nodes_bi, initialize_chain_clean, mark_logs
 from decimal import Decimal
 
 DEBUG_MODE = 1
@@ -30,21 +28,12 @@ class TxnMallTest(BitcoinTestFramework):
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args= [['-blockprioritysize=0',
             '-debug=py', '-debug=sc', '-debug=mempool', '-debug=net', '-debug=cert', '-debug=zendoo_mc_cryptolib',
             '-scproofqueuesize=0', '-logtimemicros=1', '-sccoinsmaturity=%d' % SC_COINS_MAT]] * NUMB_OF_NODES )
-
-        if not split:
-            self.join_network()
-        else:
-            self.split_network()
-        
-        self.sync_all()
-
-    def join_network(self):
         for idx in range(NUMB_OF_NODES - 1):
             connect_nodes_bi(self.nodes, idx, idx+1)
         self.is_network_split = False
+        self.sync_all()
 
     def run_test(self):
-
         node0_address = self.nodes[0].getnewaddress()
         iterations = 100
 
@@ -154,7 +143,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         mark_logs(("Join the network and sync; all the nodes should remove the pending transactions from mempool"
                    "(conflicting with the transaction that has just been mined)"), self.nodes, DEBUG_MODE)
-        self.join_network()
+        self.join_network(DOUBLE_SPEND_NODE_INDEX - 1)
         self.sync_all()
 
         mark_logs("Check that the mempool of every node is empty", self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/mempool_tx_input_limit.py
+++ b/qa/rpc-tests/mempool_tx_input_limit.py
@@ -19,7 +19,7 @@ class MempoolTxInputLimitTest(BitcoinTestFramework):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.nodes.append(start_node(1, self.options.tmpdir, args))
-        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes, 1, 0)
         self.is_network_split = False
         self.sync_all
 

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -38,9 +38,9 @@ class MerkleBlockTest(BitcoinTestFramework):
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-txindex"]))
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 0, 3)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -12,7 +12,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_raises, \
     initialize_chain_clean, start_node, connect_nodes, \
     assert_true, assert_false, mark_logs, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import *

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -8,7 +8,7 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, connect_nodes_bi, p2p_port,connect_nodes
+from test_framework.util import assert_equal, p2p_port,connect_nodes
 
 import time
 
@@ -55,7 +55,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         for node in self.nodes[0].getpeerinfo():
             assert(node['addr'] != url.hostname+":"+str(p2p_port(1)))
 
-        connect_nodes_bi(self.nodes,0,1) #reconnect the node
+        connect_nodes(self.nodes, 0, 1) #reconnect the node
         found = False
         for node in self.nodes[0].getpeerinfo():
             if node['addr'] == url.hostname+":"+str(p2p_port(1)):
@@ -88,4 +88,4 @@ class NodeHandlingTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NodeHandlingTest ().main ()
+    NodeHandlingTest().main()

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -76,7 +76,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         start_time = time.time()
         connections_count = 0
         while time.time() - start_time < total_duration:
-            connect_nodes(self.nodes[0], 0)
+            connect_nodes(self.nodes, 0, 0)
             connections_count += 1
             time.sleep(0.1)
             for node in self.nodes[0].getpeerinfo():

--- a/qa/rpc-tests/prioritisetransaction.py
+++ b/qa/rpc-tests/prioritisetransaction.py
@@ -23,7 +23,7 @@ class PrioritiseTransactionTest (BitcoinTestFramework):
         # Start nodes with tiny block size of 11kb
         self.nodes.append(start_node(0, self.options.tmpdir, [f"-blockprioritysize={self.blockprioritysize}", "-blockmaxsize=11000", "-maxorphantx=1000", "-relaypriority=true", "-printpriority=1"]))
         self.nodes.append(start_node(1, self.options.tmpdir, [f"-blockprioritysize={self.blockprioritysize}", "-blockmaxsize=11000", "-maxorphantx=1000", "-relaypriority=true", "-printpriority=1"]))
-        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes, 1, 0)
         self.is_network_split=False
         self.sync_all()
 

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -74,9 +74,9 @@ class PruneTest(BitcoinTestFramework):
         # Determine default relay fee
         self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
 
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[2], 0)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 1, 2)
+        connect_nodes(self.nodes, 2, 0)
         sync_blocks(self.nodes[0:3])
 
     def create_big_chain(self):
@@ -136,8 +136,8 @@ class PruneTest(BitcoinTestFramework):
                 self.mine_full_block(self.nodes[0],self.address[0])
 
             # Create connections in the order so both nodes can see the reorg at the same time
-            connect_nodes(self.nodes[1], 0)
-            connect_nodes(self.nodes[2], 0)
+            connect_nodes(self.nodes, 1, 0)
+            connect_nodes(self.nodes, 2, 0)
             sync_blocks(self.nodes[0:3])
 
         print("Usage can be over target because of high stale rate:", calc_usage(self.prunedir))
@@ -177,8 +177,8 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[1].generate(300)
 
         print("Reconnect nodes")
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[2], 1)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 2, 1)
         sync_blocks(self.nodes[0:3])
 
         print("Verify height on node 2:",self.nodes[2].getblockcount())

--- a/qa/rpc-tests/sbh_rpc_cmds.py
+++ b/qa/rpc-tests/sbh_rpc_cmds.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import ForkHeights
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_true, initialize_chain_clean, \
     mark_logs, start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, \
-    get_epoch_data, disconnect_nodes, wait_and_assert_operationid_status, \
+    get_epoch_data, wait_and_assert_operationid_status, \
     swap_bytes
 from test_framework.mc_test.mc_test import *
 import os

--- a/qa/rpc-tests/sc_cert_addrmempool.py
+++ b/qa/rpc-tests/sc_cert_addrmempool.py
@@ -52,10 +52,10 @@ class AddresMempool(BitcoinTestFramework):
 
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args)
 
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[3], 0)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 1, 2)
+        connect_nodes(self.nodes, 2, 3)
+        connect_nodes(self.nodes, 3, 0)
         self.is_network_split=False
         self.sync_all()
 

--- a/qa/rpc-tests/sc_cert_ceasing_split.py
+++ b/qa/rpc-tests/sc_cert_ceasing_split.py
@@ -12,7 +12,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import *

--- a/qa/rpc-tests/sc_cert_memcleanup_split.py
+++ b/qa/rpc-tests/sc_cert_memcleanup_split.py
@@ -12,7 +12,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import *
 

--- a/qa/rpc-tests/sc_cert_nonceasing.py
+++ b/qa/rpc-tests/sc_cert_nonceasing.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_framework import ForkHeights
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_nodes, sync_blocks, sync_mempools, disconnect_nodes, connect_nodes_bi, mark_logs,\
+    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
     get_epoch_data, wait_bitcoinds, stop_nodes, \
     swap_bytes
 from test_framework.mc_test.mc_test import *

--- a/qa/rpc-tests/sc_csw_actcertdata.py
+++ b/qa/rpc-tests/sc_csw_actcertdata.py
@@ -8,7 +8,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import *

--- a/qa/rpc-tests/sc_csw_actcertdata_null.py
+++ b/qa/rpc-tests/sc_csw_actcertdata_null.py
@@ -8,7 +8,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 

--- a/qa/rpc-tests/sc_csw_balance_exceeding.py
+++ b/qa/rpc-tests/sc_csw_balance_exceeding.py
@@ -12,7 +12,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import CertTestUtils, CSWTestUtils, generate_random_field_element_hex
 

--- a/qa/rpc-tests/sc_csw_eviction_from_mempool.py
+++ b/qa/rpc-tests/sc_csw_eviction_from_mempool.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_true, assert_false, initialize_chain_clean, \
     stop_nodes, wait_bitcoinds, \
-    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, disconnect_nodes, mark_logs, \
+    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs, \
     dump_sc_info_record, swap_bytes, advance_epoch
 from test_framework.mc_test.mc_test import CertTestUtils, CSWTestUtils, generate_random_field_element_hex
 import os

--- a/qa/rpc-tests/sc_csw_fundrawtransaction.py
+++ b/qa/rpc-tests/sc_csw_fundrawtransaction.py
@@ -8,7 +8,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import *

--- a/qa/rpc-tests/sc_csw_memcleanup_split.py
+++ b/qa/rpc-tests/sc_csw_memcleanup_split.py
@@ -14,7 +14,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, get_epoch_data, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 
 from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import CertTestUtils, CSWTestUtils, generate_random_field_element_hex

--- a/qa/rpc-tests/sc_csw_nullifier.py
+++ b/qa/rpc-tests/sc_csw_nullifier.py
@@ -12,7 +12,7 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, assert_true, assert_false, mark_logs, \
     wait_bitcoinds, stop_nodes, sync_mempools, sync_blocks, \
-    disconnect_nodes, advance_epoch, swap_bytes
+    advance_epoch, swap_bytes
 from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.mc_test.mc_test import *
 

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees.py
@@ -478,7 +478,6 @@ class SCFtAndMbtrFeesTest(BitcoinTestFramework):
 
         mark_logs("Reconnecting nodes 0 and 1", self.nodes, DEBUG_MODE)
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 0)
         self.is_network_split = False
         sync_blocks(self.nodes[:])
 

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees.py
@@ -390,8 +390,8 @@ class SCFtAndMbtrFeesTest(BitcoinTestFramework):
         self.sync_all()
 
         mark_logs("Disconnecting nodes", self.nodes, DEBUG_MODE)
-        disconnect_nodes(self.nodes[1], 0)
-        disconnect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes, 1, 0)
+        disconnect_nodes(self.nodes, 0, 1)
         self.is_network_split = True
 
         quality = 1

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees_update.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_greater_than, initialize_chain_clean, \
     start_nodes, stop_nodes, wait_bitcoinds, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
-    get_epoch_data, swap_bytes, disconnect_nodes ##, colorize as cc
+    get_epoch_data, swap_bytes ##, colorize as cc
 from test_framework.test_framework import ForkHeights
 from test_framework.mc_test.mc_test import CertTestUtils, generate_random_field_element_hex
 from decimal import Decimal

--- a/qa/rpc-tests/sc_fwd_maturity.py
+++ b/qa/rpc-tests/sc_fwd_maturity.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_true, assert_false, assert_equal, initialize_chain_clean, \
     mark_logs, start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, \
-    disconnect_nodes, dump_sc_info, dump_sc_info_record
+    dump_sc_info, dump_sc_info_record
 from test_framework.mc_test.mc_test import *
 import os
 from decimal import Decimal

--- a/qa/rpc-tests/sc_invalidate.py
+++ b/qa/rpc-tests/sc_invalidate.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_true, assert_equal, initialize_chain_clean, \
     start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, \
-    dump_ordered_tips, mark_logs, disconnect_nodes
+    dump_ordered_tips, mark_logs
 from test_framework.mc_test.mc_test import *
 import os
 from decimal import Decimal

--- a/qa/rpc-tests/sc_quality_nodes.py
+++ b/qa/rpc-tests/sc_quality_nodes.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import ForkHeights, MINER_REWARD_POST_H200
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs,\
-    get_epoch_data, disconnect_nodes, assert_false, assert_true, swap_bytes
+    get_epoch_data, assert_false, assert_true, swap_bytes
 from test_framework.mc_test.mc_test import *
 import os
 from decimal import Decimal

--- a/qa/rpc-tests/sc_stale_ft_and_mbtr.py
+++ b/qa/rpc-tests/sc_stale_ft_and_mbtr.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_true, assert_false, initialize_chain_clean, \
     stop_nodes, wait_bitcoinds, \
-    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, disconnect_nodes, mark_logs, \
+    start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, mark_logs, \
     dump_sc_info_record, get_epoch_data, swap_bytes, advance_epoch
 from test_framework.mc_test.mc_test import CertTestUtils, generate_random_field_element_hex
 import os

--- a/qa/rpc-tests/shieldedpooldeprecation_rpc.py
+++ b/qa/rpc-tests/shieldedpooldeprecation_rpc.py
@@ -23,7 +23,7 @@ class ShieldedPoolDeprecationTest (BitcoinTestFramework):
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(2, self.options.tmpdir, [['-debug=zrpcunsafe', '-experimentalfeatures', '-zmergetoaddress']] * 2)
-        connect_nodes(self.nodes[0],1)
+        connect_nodes(self.nodes, 0, 1)
         self.is_network_split=False
         self.sync_all()
 

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -184,15 +184,15 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir,
                                      ["-blockprioritysize=1500", "-blockmaxsize=18000",
                                       "-maxorphantx=1000", "-relaypriority=0", "-debug=estimatefee"]))
-        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes, 1, 0)
 
         # Node2 is a stingy miner, that
         # produces too small blocks (room for only 70 or so transactions)
         node2args = ["-blockprioritysize=0", "-blockmaxsize=12000", "-maxorphantx=1000", "-relaypriority=0"]
 
         self.nodes.append(start_node(2, self.options.tmpdir, node2args))
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[2], 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 2, 1)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -28,9 +28,9 @@ class SpentIndexTest(BitcoinTestFramework):
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug", "-spentindex"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-spentindex", "-txindex"]))
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 0, 3)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/subsidyhalving.py
+++ b/qa/rpc-tests/subsidyhalving.py
@@ -46,9 +46,9 @@ class subsidyhalving(BitcoinTestFramework):
                 ['-logtimemicros', '-debug=py', '-debug=net', '-subsidyhalvinginterval=101']
             ])
 
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[2], 0)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 1, 2)
+        connect_nodes(self.nodes, 2, 0)
         sync_blocks(self.nodes, 1, False, 5)
         sync_mempools(self.nodes[0:NUMB_OF_NODES])
         self.is_network_split = split

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -73,8 +73,8 @@ class BitcoinTestFramework(object):
     def split_network(self, id = 1):
         # Split the network of between adjanced nodes in linear topology ep. nodes 0-1 and 2-3.
         assert not self.is_network_split
-        disconnect_nodes(self.nodes[id], id + 1)
-        disconnect_nodes(self.nodes[id + 1], id)
+        disconnect_nodes(self.nodes, id, id + 1)
+        disconnect_nodes(self.nodes, id + 1, id)
         self.is_network_split = True
 
     def sync_all(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -541,8 +541,10 @@ def wait_and_assert_operationid_status(node, myopid, in_status='success', in_err
     else:
         return txid # otherwise return the txid
 
-def disconnect_nodes(from_connection, node_num):
-    ip_port = "127.0.0.1:" + str(p2p_port(node_num))
+# Disconnect nodes a and b; disconnection is explicitly issued on node a
+def disconnect_nodes(nodes, a, b):
+    from_connection = nodes[a]
+    ip_port = "127.0.0.1:" + str(p2p_port(b))
     from_connection.disconnectnode(ip_port)
     # poll until version handshake complete to avoid race conditions
     # with transaction relaying

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -27,9 +27,9 @@ class TimestampIndexTest(BitcoinTestFramework):
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-timestampindex"]))
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 0, 3)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/tlsprotocols.py
+++ b/qa/rpc-tests/tlsprotocols.py
@@ -29,7 +29,6 @@ class tlsproto(BitcoinTestFramework):
             ])
 
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 1, 0)
 
         self.is_network_split = split
         self.sync_all()

--- a/qa/rpc-tests/txindex.py
+++ b/qa/rpc-tests/txindex.py
@@ -29,9 +29,9 @@ class TxIndexTest(BitcoinTestFramework):
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug", "-txindex"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-txindex"]))
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 2)
+        connect_nodes(self.nodes, 0, 3)
 
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -92,7 +92,7 @@ class TxnMallTest(BitcoinTestFramework):
         self.nodes[2].generate(1)
 
         # Reconnect the split network, and sync chain:
-        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes, 1, 2)
         self.nodes[2].generate(1)  # Mine another block to make sure we sync
         sync_blocks(self.nodes)
 

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -81,10 +81,10 @@ class WalletBackupTest(BitcoinTestFramework):
            ['-debug=zrpc', "-keypool=100", ed2],
            []]
         self.nodes = start_nodes(4, self.options.tmpdir, extra_args)
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[2], 0)
+        connect_nodes(self.nodes, 0, 3)
+        connect_nodes(self.nodes, 1, 3)
+        connect_nodes(self.nodes, 2, 3)
+        connect_nodes(self.nodes, 2, 0)
         self.is_network_split=False
         self.sync_all()
 
@@ -121,10 +121,10 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[1] = start_node(1, self.options.tmpdir, ['-debug=zrpc', ed1])
         self.nodes[2] = start_node(2, self.options.tmpdir, ['-debug=zrpc', ed2])
 
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[2], 0)
+        connect_nodes(self.nodes, 0, 3)
+        connect_nodes(self.nodes, 1, 3)
+        connect_nodes(self.nodes, 2, 3)
+        connect_nodes(self.nodes, 2, 0)
 
     def stop_three(self):
         stop_node(self.nodes[0], 0)

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -20,7 +20,7 @@ class JoinSplitTest(BitcoinTestFramework):
         self.is_network_split = False
         self.nodes.append(start_node(0, self.options.tmpdir))
         self.nodes.append(start_node(1, self.options.tmpdir))
-        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes, 0, 1)
 
     def run_test(self):
 
@@ -75,7 +75,7 @@ class JoinSplitTest(BitcoinTestFramework):
             if (round == crossing_fork_round):
                 # advance chain on node1 (so that shielded pool deprecation hard fork is active)
                 self.nodes[1].generate(fork_crossing_margin)
-                connect_nodes(self.nodes[0], 1)
+                connect_nodes(self.nodes, 0, 1)
                 sync_blocks(self.nodes)
                 # make sure now deprecated tx is in node0 mempool but not in node1 mempool
                 assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -57,7 +57,7 @@ class JoinSplitTest(BitcoinTestFramework):
 
             # disconnect the nodes so that the chains are not synced
             if (round == crossing_fork_round):
-                disconnect_nodes(self.nodes[0], 1)
+                disconnect_nodes(self.nodes, 0, 1)
 
             try:
                 self.nodes[0].sendrawtransaction(protect_tx["hex"])

--- a/qa/rpc-tests/zcjoinsplitdoublespend.py
+++ b/qa/rpc-tests/zcjoinsplitdoublespend.py
@@ -156,7 +156,7 @@ class JoinSplitTest(BitcoinTestFramework):
 
         # Connect the two nodes
 
-        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes, 1, 2)
         sync_blocks(self.nodes)
 
         # AB and CD should all be impossible to spend for each node.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -636,7 +636,9 @@ void CNode::copyStats(CNodeStats &stats)
     X(fInbound);
     X(nStartingHeight);
     X(nSendBytes);
+    X(mapSendBytesPerMsgType);
     X(nRecvBytes);
+    X(mapRecvBytesPerMsgType);
     X(fWhitelisted);
     X(m_addr_rate_limited);
     X(m_addr_processed);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -526,7 +526,7 @@ void CNode::PushVersion()
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), id);
     else
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
-    PushMessage("version", PROTOCOL_VERSION, connman->GetLocalServices(), nTime, addrYou, addrMe,
+    PushMessage(NetMsgType::VERSION, PROTOCOL_VERSION, connman->GetLocalServices(), nTime, addrYou, addrMe,
                 nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()), nBestHeight, true);
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -192,6 +192,8 @@ public:
     int nStartingHeight;
     uint64_t nSendBytes;
     uint64_t nRecvBytes;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> mapSendBytesPerMsgType;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> mapRecvBytesPerMsgType;
     bool fWhitelisted;
     double dPingTime;
     double dPingWait;

--- a/src/net.h
+++ b/src/net.h
@@ -362,6 +362,9 @@ public:
     ~CNode();
 
 private:
+    // messageType : {numberOfMessages, totalAmountOfBytes}
+    std::map<std::string, std::pair<uint64_t, uint64_t>> mapSendBytesPerMsgType;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> mapRecvBytesPerMsgType;
 
     CNode(const CNode&);
     void operator=(const CNode&);
@@ -457,7 +460,7 @@ public:
     void AbortMessage() UNLOCK_FUNCTION(cs_vSend);
 
     // TODO: Document the precondition of this function.  Is cs_vSend locked?
-    void EndMessage() UNLOCK_FUNCTION(cs_vSend);
+    void EndMessage(const char* pszCommand) UNLOCK_FUNCTION(cs_vSend);
 
     void PushVersion();
 
@@ -467,7 +470,7 @@ public:
         try
         {
             BeginMessage(pszCommand);
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -489,7 +492,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -505,7 +508,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -521,7 +524,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -537,7 +540,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -553,7 +556,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -569,7 +572,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -585,7 +588,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -601,7 +604,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -617,7 +620,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8 << a9;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -652,6 +655,24 @@ public:
     static void GetBanned(std::map<CSubNet, int64_t> &banmap);
 
     void copyStats(CNodeStats &stats);
+    void AccountForSentBytes(const std::string& msg_type, size_t sent_bytes)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
+    {
+        std::pair<uint64_t, uint64_t>& messageType = mapSendBytesPerMsgType[msg_type];
+        messageType.first  += 1;            // number of messages
+        messageType.second += sent_bytes;   // amount of data for message type
+    }
+
+    void AccountForRecvBytes(const std::string& msg_type, size_t recv_bytes)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
+    {
+        auto msgTypeInMap = mapRecvBytesPerMsgType.find(msg_type);
+        if (msgTypeInMap == mapRecvBytesPerMsgType.end())
+            msgTypeInMap = mapRecvBytesPerMsgType.find(NetMsgType::OTHER);
+        assert(msgTypeInMap != mapRecvBytesPerMsgType.end());
+        msgTypeInMap->second.first  += 1;           // number of messages
+        msgTypeInMap->second.second += recv_bytes;  // amount of data for message type
+    }
 
     // returns the value of the tlsfallbacknontls and tlsvalidate flags set at zend startup (see init.cpp)
     static bool GetTlsFallbackNonTls();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -72,6 +72,56 @@ bool CMessageHeader::IsValid(const MessageStartChars& pchMessageStartIn) const
     return true;
 }
 
+namespace NetMsgType {
+const char *VERSION="version";
+const char *VERACK="verack";
+const char *ADDR="addr";
+const char *INV="inv";
+const char *GETDATA="getdata";
+const char *MERKLEBLOCK="merkleblock";
+const char *GETBLOCKS="getblocks";
+const char *GETHEADERS="getheaders";
+const char *TX="tx";
+const char *HEADERS="headers";
+const char *BLOCK="block";
+const char *GETADDR="getaddr";
+const char *MEMPOOL="mempool";
+const char *PING="ping";
+const char *PONG="pong";
+const char *FILTERLOAD="filterload";
+const char *FILTERADD="filteradd";
+const char *FILTERCLEAR="filterclear";
+const char *REJECT="reject";
+const char *NOTFOUND="notfound";
+const char *OTHER="*other*";
+} // namespace NetMsgType
+
+const std::string allNetMessageTypes[] = {
+    NetMsgType::VERSION,
+    NetMsgType::VERACK,
+    NetMsgType::ADDR,
+    NetMsgType::INV,
+    NetMsgType::GETDATA,
+    NetMsgType::MERKLEBLOCK,
+    NetMsgType::GETBLOCKS,
+    NetMsgType::GETHEADERS,
+    NetMsgType::TX,
+    NetMsgType::HEADERS,
+    NetMsgType::BLOCK,
+    NetMsgType::GETADDR,
+    NetMsgType::MEMPOOL,
+    NetMsgType::PING,
+    NetMsgType::PONG,
+    NetMsgType::FILTERLOAD,
+    NetMsgType::FILTERADD,
+    NetMsgType::FILTERCLEAR,
+    NetMsgType::REJECT,
+    NetMsgType::NOTFOUND,
+    NetMsgType::OTHER,
+};
+
+const size_t allNetMessageTypesSize = sizeof(allNetMessageTypes) / sizeof(std::string);
+
 CAddress::CAddress() : CService()
 {
     Init();

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,6 +18,134 @@
 #include <stdint.h>
 #include <string>
 
+/**
+ * Zend protocol message types. When adding new message types, don't forget
+ * to update allNetMessageTypes in protocol.cpp.
+ */
+namespace NetMsgType {
+
+/**
+ * The version message provides information about the transmitting node to the
+ * receiving node at the beginning of a connection.
+ */
+extern const char* VERSION;
+/**
+ * The verack message acknowledges a previously-received version message,
+ * informing the connecting node that it can begin to send other messages.
+ */
+extern const char* VERACK;
+/**
+ * The addr (IP address) message relays connection information for peers on the
+ * network.
+ */
+extern const char* ADDR;
+/**
+ * The inv message (inventory message) transmits one or more inventories of
+ * objects known to the transmitting peer.
+ */
+extern const char* INV;
+/**
+ * The getdata message requests one or more data objects from another node.
+ */
+extern const char* GETDATA;
+/**
+ * The merkleblock message is a reply to a getdata message which requested a
+ * block using the inventory type MSG_MERKLEBLOCK.
+ * @since protocol version 70001 as described by BIP37.
+ */
+extern const char* MERKLEBLOCK;
+/**
+ * The getblocks message requests an inv message that provides block header
+ * hashes starting from a particular point in the block chain.
+ */
+extern const char* GETBLOCKS;
+/**
+ * The getheaders message requests a headers message that provides block
+ * headers starting from a particular point in the block chain.
+ */
+extern const char* GETHEADERS;
+/**
+ * The tx message transmits a single transaction.
+ */
+extern const char* TX;
+/**
+ * The headers message sends one or more block headers to a node which
+ * previously requested certain headers with a getheaders message.
+ * @since protocol version 31800.
+ */
+extern const char* HEADERS;
+/**
+ * The block message transmits a single serialized block.
+ */
+extern const char* BLOCK;
+/**
+ * The getaddr message requests an addr message from the receiving node,
+ * preferably one with lots of IP addresses of other receiving nodes.
+ */
+extern const char* GETADDR;
+/**
+ * The mempool message requests the TXIDs of transactions that the receiving
+ * node has verified as valid but which have not yet appeared in a block.
+ * @since protocol version 60002 as described by BIP35.
+ *   Only available with service bit NODE_BLOOM, see also BIP111.
+ */
+extern const char* MEMPOOL;
+/**
+ * The ping message is sent periodically to help confirm that the receiving
+ * peer is still connected.
+ */
+extern const char* PING;
+/**
+ * The pong message replies to a ping message, proving to the pinging node that
+ * the ponging node is still alive.
+ * @since protocol version 60001 as described by BIP31.
+ */
+extern const char* PONG;
+/**
+ * The filterload message tells the receiving peer to filter all relayed
+ * transactions and requested merkle blocks through the provided filter.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ */
+extern const char* FILTERLOAD;
+/**
+ * The filteradd message tells the receiving peer to add a single element to a
+ * previously-set bloom filter, such as a new public key.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ */
+extern const char* FILTERADD;
+/**
+ * The filterclear message tells the receiving peer to remove a previously-set
+ * bloom filter.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ */
+extern const char* FILTERCLEAR;
+/**
+ * The notfound message is a reply to a getdata message which requested an
+ * object the receiving node does not have available for relay.
+ */
+extern const char* NOTFOUND;
+/**
+ * The reject message is a reply that is sent to peer when, for diverse 
+ * reasons, we are rejecting its message.
+ */
+extern const char* REJECT;
+/**
+ * This is not a real category, but it is used by the AccountForSent/RecvBytes
+ * functions for counting bytes that do not fall in any of the previous
+ * categories.
+ */
+extern const char* OTHER;
+}; // namespace NetMsgType
+
+extern const std::string allNetMessageTypes[];
+extern const size_t allNetMessageTypesSize;
+
 #define MESSAGE_START_SIZE 4
 
 /** Message header.


### PR DESCRIPTION
This PR changes the logic behind the connection of two zend nodes in the test framework. In particular, we introduced a check that explicitly waits for the two nodes to exchange their respective `verack` messages before continuing with the test. This prevents racing conditions such as requesting data to a node before the connection takes place.

For this purpose, we enriched the `getpeerinfo()` RPC command with two new fields: `bytessent_per_msg` and `bytesrecv_per_msg`, two dictionaries which collect the amount of sent and received data, divided by message category.

This PR also modifies a few tests that were sporadically failing because of that racing condition.

Finally, we fixed `mempool_coinbase_spends` test which lacked proper synchronization between the two nodes.