### PR TITLE
Fix logging

### DIFF
--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -87,11 +87,11 @@ BOOST_AUTO_TEST_CASE(AlertNotifyFunction) {
 
     mapArgs["-alertnotify"] = std::string("echo 'Reporting the following alert: %s' >> ") + temp.string();
 
-    std::cout << "Resetting temporary alert notify file: " << temp.string() << std::endl;
+    BOOST_TEST_MESSAGE(std::string("Resetting temporary alert notify file: ") + temp.string());
     std::ofstream outF(temp.string(), std::ios::out);
     outF.close();
 
-    std::cout << "Reporting alerts to alert notify file through alertNotify() function" << std::endl;
+    BOOST_TEST_MESSAGE(std::string("Reporting alerts to alert notify file through alertNotify() function"));
     for (const auto& errorString : errs) {
         alertNotify(errorString, false);    // Using thread-safe version to preserve ordering
     }


### PR DESCRIPTION
Really really really minor stuff.

Before:
![before](https://github.com/HorizenOfficial/zen/assets/113015853/84093ea3-e4d7-4ec1-8037-76093f147be8)

After:
![after](https://github.com/HorizenOfficial/zen/assets/113015853/248a8a4b-08a9-49bf-bd95-3b0dfa739480)
