### PR TITLE
Fix for message header validity

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -245,6 +245,8 @@ public:
 
     int readHeader(const char *pch, unsigned int nBytes);
     int readData(const char *pch, unsigned int nBytes);
+
+    unsigned int ComputeMessageChecksum();
 };
 
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -163,7 +163,7 @@ public:
     CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn);
 
     std::string GetCommand() const;
-    bool IsValid(const MessageStartChars& messageStart) const;
+    bool HasValidCommand() const;
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
Fixed validation logic for command (rejected if null), moved header/message validation from `ProcessMessage` to `ReceiveMsgBytes`.
Partially inspired by https://github.com/bitcoin/bitcoin/pull/19107.