### PR TITLE
[ZEND-665] More mempool size limit tests

### DIFF
--- a/contrib/ci-horizen/scripts/common/setup_environment.sh
+++ b/contrib/ci-horizen/scripts/common/setup_environment.sh
@@ -77,7 +77,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     NEED_B2_CREDS="true"
   fi
   if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]; then
-    export PIP3_INSTALL="${PIP3_INSTALL} pycryptodome pyzmq websocket-client requests"
+    export PIP3_INSTALL="${PIP3_INSTALL} pycryptodome pyzmq websocket-client requests b2sdk"
     export B2_DL_DECOMPRESS_FOLDER="${TRAVIS_BUILD_DIR}"
     # shellcheck disable=SC2001,SC2155
     export B2_DL_FILENAME="${TRAVIS_CPU_ARCH}-${TRAVIS_OS_NAME}-${TRAVIS_OSX_IMAGE}-${TRAVIS_BUILD_ID}-${TRAVIS_COMMIT}$(sed 's/ //g' <<< "${MAKEFLAGS:-}").tar.gz"

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -164,8 +164,8 @@ testScripts=(
   'p2p_ignore_spent_tx.py',215,455
   'shieldedpooldeprecation_rpc.py',558,1794
   'mempool_size_limit.py',121,203
-  'mempool_size_limit_more.py',50,65
-  # 'mempool_size_limit_even_more.py',90,120
+  'mempool_size_limit_more.py',103,160
+  'mempool_size_limit_even_more.py',87,210
   'mempool_hard_fork_cleaning.py',34,60
 );
 

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -164,6 +164,8 @@ testScripts=(
   'p2p_ignore_spent_tx.py',215,455
   'shieldedpooldeprecation_rpc.py',558,1794
   'mempool_size_limit.py',121,203
+  'mempool_size_limit_more.py',50,65
+  # 'mempool_size_limit_even_more.py',90,120
   'mempool_hard_fork_cleaning.py',34,60
 );
 

--- a/qa/rpc-tests/mempool_size_limit.py
+++ b/qa/rpc-tests/mempool_size_limit.py
@@ -216,13 +216,13 @@ def create_chained_transactions(node, tmpdir, utxos):
 
     return txs
 
-def create_sidechains(nodes, mcTest, num, ceasing):
+def create_sidechains(nodes, mcTest, num, ceasing, epoch_len = EPOCH_LENGTH, amount = Decimal("15")):
     res = []
     # generate wCertVk and constant
     for i in range(num):
         newsc = {}
         constant = generate_random_field_element_hex()
-        ep_len = EPOCH_LENGTH if ceasing else 0
+        ep_len = epoch_len if ceasing else 0
         par_name = PARAMS_NAME + ("c" if ceasing else "nc") + str(i)
 
         vk = mcTest.generate_params(par_name, keyrot=True)
@@ -232,7 +232,7 @@ def create_sidechains(nodes, mcTest, num, ceasing):
             "version": 2,
             "withdrawalEpochLength": ep_len,
             "toaddress": "dada",
-            "amount": Decimal("15"),
+            "amount": amount,
             "wCertVk": vk,
             "constant": constant,
         }

--- a/qa/rpc-tests/mempool_size_limit_even_more.py
+++ b/qa/rpc-tests/mempool_size_limit_even_more.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ForkHeights
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import initialize_chain_clean, start_nodes, connect_nodes_bi, mark_logs,\
+    get_epoch_data, swap_bytes, assert_greater_than, colorize as cc
+from mempool_size_limit import load_from_storage, create_big_transactions, create_sidechains, \
+    write_to_file
+from test_framework.mc_test.mc_test import *
+import os
+import zipfile
+from decimal import Decimal
+
+DEBUG_MODE = 1
+NUMB_OF_NODES = 1
+EPOCH_LENGTH = 100
+
+class feeAmounts():
+    HIGHEST = Decimal('0.0001')
+    HIGH    = Decimal('0.00005')
+    MEDIUM  = Decimal('0.00001')
+    LOW     = Decimal('0.000005')
+    LOWEST  = Decimal('0.000001')
+    NULL    = Decimal('0')
+
+FT_SC_FEE      = feeAmounts.NULL
+MBTR_SC_FEE    = feeAmounts.NULL
+CERT_FEE       = Decimal('0.00015')
+
+NODE0_LIMIT_B = 4000000
+NODE1_LIMIT_B = 4000000
+
+NODE0_CERT_LIMIT_B = NODE0_LIMIT_B / 2
+NODE1_CERT_LIMIT_B = NODE1_LIMIT_B / 2
+
+EPSILON = 100000
+MAX_FEE = Decimal("999999")
+
+NUM_CEASING_SIDECHAINS    = 750
+
+PARAMS_NAME = "sc"
+USE_SNAPSHOT = True
+
+"""
+This test is a follow up of mempool_size_limit.py and mempool_size_limit_more.py, and uses a new snapshot data.
+Snapshot creation takes slightly more than an hour, and the resulting archive will be about 2.5 GBytes in size.
+
+Test MAX_SIZE for certificates
+    Clear the mempool
+    Add certificates up to the max size, all related to different sidechains (no duplications), fee_rate = F_medium [OK]
+        Add one more certificate exceeding the max size, fee_rate = F_low [REJECT]
+        Add one more certificate exceeding the max size, fee_rate = F_high [ACCEPT, one certificate gets evicted]
+    Add transactions up to MAX_SIZE / 2, fee_rate = F_highest [ACCEPT, certificates get evicted]
+        Add one more transaction, fee_rate = F_highest [REJECTED]
+"""
+
+class mempool_size_limit_even_more(BitcoinTestFramework):
+
+    def import_data_to_data_dir(self):
+        # importing datadir resource
+        # Tests checkpoint creation (during startup rescan) and usage, checks everything ok with old wallet
+        # resource_file = os.sep.join([os.path.dirname(__file__), 'resources', 'mempool_size_limit_more', 'test_setup_.zip'])
+        resource_file = os.sep.join(['/', 'temporary', 'absolute', 'path', 'to', 'snapshot.zip'])
+        with zipfile.ZipFile(resource_file, 'r') as zip_ref:
+            zip_ref.extractall(self.options.tmpdir)
+
+    def setup_chain(self, split=False):
+        if (USE_SNAPSHOT):
+            self.import_data_to_data_dir()
+            os.remove(self.options.tmpdir+'/node0/regtest/debug.log') # make sure that we have only logs from this test
+            os.remove(self.options.tmpdir+'/node1/regtest/debug.log')
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args =
+            [
+                ['-debug=cert', '-debug=mempool', '-maxorphantx=10000', f'-maxmempool={NODE0_LIMIT_B / 1000000}', '-minconf=0', '-allownonstandardtx'],
+            ])
+
+        self.is_network_split = False
+        self.sync_all()
+
+    def create_sc_certificates(self, mcTest, sidechain, scidx, epoch_number, quality, fee, size, raw_bwt_outs = None):
+        os.makedirs(self.options.tmpdir + "/certs", exist_ok=True)
+        os.makedirs(self.options.tmpdir + f"/certs/{scidx}", exist_ok=True)
+        if raw_bwt_outs is None:
+            raw_bwt_outs = []
+            for _ in range(128):
+                raw_bwt_outs.append({"address":self.nodes[0].getnewaddress(), "amount":Decimal("0.0001")})
+        i = 0
+        if (self.tot_sc_cert_size < size and len(self.utxos) > 0):
+            t = self.utxos.pop()
+            raw_inputs = [{'txid' : t['txid'], 'vout' : t['vout']}]
+            amt = t["amount"] - fee
+            raw_outs = {self.nodes[0].getnewaddress(): amt}
+
+            scid = sidechain["id"]
+            epoch_len = sidechain["epoch_len"]
+            par_name = sidechain["params"]
+            constant = sidechain["constant"]
+            ref_height = self.nodes[0].getblockcount()
+            ceasing = True if epoch_len > 0 else False
+
+            scid_swapped = str(swap_bytes(scid))
+            _, epoch_cum_tree_hash, prev_cert_hash = get_epoch_data(scid, self.nodes[0], epoch_len, is_non_ceasing = not ceasing, reference_height = ref_height)
+
+            proof = mcTest.create_test_proof(par_name,
+                                             scid_swapped,
+                                             epoch_number,
+                                             quality,
+                                             MBTR_SC_FEE,
+                                             FT_SC_FEE,
+                                             epoch_cum_tree_hash,
+                                             prev_cert_hash,
+                                             constant = constant,
+                                             pks      = [raw_bwt_outs[i]["address"] for i in range(128)],
+                                             amounts  = [raw_bwt_outs[i]["amount"] for i in range(128)])
+
+            raw_params = {
+                "scid": scid,
+                "quality": quality,
+                "endEpochCumScTxCommTreeRoot": epoch_cum_tree_hash,
+                "scProof": proof,
+                "withdrawalEpochNumber": epoch_number
+            }
+
+            raw_cert    = self.nodes[0].createrawcertificate(raw_inputs, raw_outs, raw_bwt_outs, raw_params)
+            signed_cert = self.nodes[0].signrawtransaction(raw_cert)
+            csize = len(signed_cert['hex']) // 2
+            feerate = fee / csize
+            self.tot_sc_cert_size += csize
+            write_to_file(self.options.tmpdir + f"/certs/{scidx}/c_{quality}", feerate, signed_cert["hex"])
+            cert = {'quality': quality, 'feerate': feerate, 'hex': signed_cert["hex"]}
+            print("Size of total cert produced: " + str(self.tot_sc_cert_size))
+
+            return cert
+        return None
+    
+    def create_certificate(self, scidx, epoch_number, quality, fee, raw_bwt_outs = None):
+        if raw_bwt_outs is None:
+            raw_bwt_outs = []
+            for _ in range(128):
+                raw_bwt_outs.append({"address":self.nodes[0].getnewaddress(), "amount":Decimal("0.0001")})
+
+        utxos = self.nodes[0].listunspent(0)
+        t = utxos.pop()
+        raw_inputs = [{'txid' : t['txid'], 'vout' : t['vout']}]
+        amt = t["amount"] - fee
+        raw_outs = {self.nodes[0].getnewaddress(): amt}
+
+        sc = self.nodes[0].getscinfo("*")['items'][scidx]
+        scid = sc["scid"]
+        epoch_len = sc["withdrawalEpochLength"]
+        ceasing = True if epoch_len > 0 else False
+        par_name = par_name = PARAMS_NAME + ("c" if ceasing else "nc") + str(scidx)
+        constant = sc["constant"]
+        ref_height = self.nodes[0].getblockcount()
+
+        scid_swapped = str(swap_bytes(scid))
+        _, epoch_cum_tree_hash, prev_cert_hash = get_epoch_data(scid, self.nodes[0], epoch_len, is_non_ceasing = not ceasing, reference_height = ref_height)
+
+        proof = self.mcTest.create_test_proof(par_name,
+                                            scid_swapped,
+                                            epoch_number,
+                                            quality,
+                                            MBTR_SC_FEE,
+                                            FT_SC_FEE,
+                                            epoch_cum_tree_hash,
+                                            prev_cert_hash,
+                                            constant = constant,
+                                            pks      = [raw_bwt_outs[i]["address"] for i in range(128)],
+                                            amounts  = [raw_bwt_outs[i]["amount"] for i in range(128)])
+
+        raw_params = {
+            "scid": scid,
+            "quality": quality,
+            "endEpochCumScTxCommTreeRoot": epoch_cum_tree_hash,
+            "scProof": proof,
+            "withdrawalEpochNumber": epoch_number
+        }
+        raw_cert    = self.nodes[0].createrawcertificate(raw_inputs, raw_outs, raw_bwt_outs, raw_params)
+        signed_cert = self.nodes[0].signrawtransaction(raw_cert)
+        csize = len(signed_cert['hex'])//2
+        cert = {'quality': quality, 'feerate': fee / csize, 'hex': signed_cert["hex"]}
+
+        return cert, t
+
+
+    def setup_test(self):
+        if USE_SNAPSHOT:
+            txs   = load_from_storage(self.options.tmpdir + "/txs/")
+            certs = []
+            for s in range(NUM_CEASING_SIDECHAINS):
+                certs.append(load_from_storage(self.options.tmpdir + f"/certs/{s}/"))
+
+        else:
+            mark_logs("Node 0 generates {} block".format(ForkHeights['NON_CEASING_SC']), self.nodes, DEBUG_MODE)
+            self.nodes[0].generate(ForkHeights['NON_CEASING_SC'] + 800)
+            self.sync_all()
+
+            # Create sidechains. Enjoy the wait.
+            mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+            sc = []
+            sc.extend(create_sidechains(self.nodes, mcTest, NUM_CEASING_SIDECHAINS, ceasing = True,
+                                        epoch_len = EPOCH_LENGTH, amount = Decimal('3')))
+            self.nodes[0].generate(EPOCH_LENGTH)
+            self.sync_all()
+
+            self.utxos = self.nodes[0].listunspent(0)
+            txs = create_big_transactions(self.nodes[0], self.options.tmpdir, self.utxos, NODE0_LIMIT_B + EPSILON)
+
+            # Create certificates, one per sc
+            certs = list()
+            self.tot_sc_cert_size = 0
+            raw_bwt_outs = []
+            for _ in range(128):
+                raw_bwt_outs.append({"address":self.nodes[0].getnewaddress(), "amount":Decimal("0.0001")})
+            for i in range(NUM_CEASING_SIDECHAINS):
+                cert = self.create_sc_certificates(mcTest, sc[i], i, 0, 0, feeAmounts.MEDIUM, EPSILON + NODE0_LIMIT_B, raw_bwt_outs)
+                if cert is not None:
+                    certs.append(cert)
+
+        return txs, certs
+
+
+    def run_test(self):
+        mark_logs("Loading or generating the snapshot...", self.nodes, DEBUG_MODE, color = 'e')
+        txs, certs = self.setup_test()
+
+        txs.sort(key=lambda x: x['feerate'])
+        if USE_SNAPSHOT:
+            certs = [x[0] for x in certs if len(x) > 0] # purge empty elements
+
+        mark_logs("Filling the entire mempool with certificates having fee = 0.00001 => feerate = F_medium ~ 1.4974e-9", self.nodes, DEBUG_MODE, color = 'c')
+        cert_sent_size, usage, last_cert_size = 0, 0, 0
+        initial_cert_n = len(certs)
+        maxfeerate, minfeerate = 0, MAX_FEE
+        while (cert_sent_size < NODE0_LIMIT_B and usage < NODE0_LIMIT_B - last_cert_size):
+            assert(len(certs) > 0)
+            c = certs.pop(0)
+            try:
+                self.nodes[0].sendrawtransaction(c['hex'])
+            except JSONRPCException as e:
+                errorString = e.error['message']
+                print("Send certificate failed with reason {}".format(errorString))
+                assert(False)
+            last_cert_size = len(c['hex']) // 2
+            cert_sent_size += last_cert_size
+            usage = int(self.nodes[0].getmempoolinfo()['bytes'])
+            minfeerate, maxfeerate = min(minfeerate, c['feerate']), max(maxfeerate, c['feerate'])
+        mark_logs(cc('g', "certificates sent to mempool: ") + f"{initial_cert_n - len(certs)}", self.nodes, DEBUG_MODE)
+        mark_logs(cc('g', "certificates left: ") + f"{len(certs)}", self.nodes, DEBUG_MODE)
+        mark_logs(cc('g', "certificates -- minfeerate: ") + f"{minfeerate:.8E}" + cc('g', " - maxfeerate: ") + f"{maxfeerate:.8E}", self.nodes, DEBUG_MODE)
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        cert_partition = int(mempoolstatus['bytes-for-cert'])
+        print()
+
+
+        mark_logs("Adding one more certificate with feerate = F_medium exceeding the max size will fail", self.nodes, DEBUG_MODE, color = 'c')
+        c = certs.pop(0)
+        try:
+            mark_logs(cc('e', "Cert fees: ") + f"{c['feerate']:.8E}", self.nodes, DEBUG_MODE)
+            self.nodes[0].sendrawtransaction(c['hex'])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print(cc('y', f"Send certificate failed with reason {errorString}"))
+        print()
+
+
+        mark_logs("Adding one more certificate with feerate = F_high ~ 7.4884e-9 exceeding the max size will be ok and one F_medium cert gets evicted", self.nodes, DEBUG_MODE, color = 'c')
+        raw_bwt_outs = []
+        for _ in range(128):
+            raw_bwt_outs.append({"address":self.nodes[0].getnewaddress(), "amount":Decimal("0.0001")})
+        self.mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+        cert, tx_used_as_input = self.create_certificate(NUM_CEASING_SIDECHAINS - 1, 0, 0, feeAmounts.HIGH, raw_bwt_outs)
+        try:
+            mark_logs(cc('e', "Cert fees: ") + f"{cert['feerate']:.8E}", self.nodes, DEBUG_MODE)
+            self.nodes[0].sendrawtransaction(cert['hex'])
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print("Send certificate failed with reason {}".format(errorString))
+            assert(False)
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        print()
+
+
+        mark_logs("Add transactions with feerate = F_highest up to MAX_SIZE/2: certificates get evicted", self.nodes, DEBUG_MODE, color = 'c')
+        tx_sent_size, usage, last_tx_size = 0, 0, 0
+        mintxfeerate, maxtxfeerate = MAX_FEE, 0
+        usage = int(self.nodes[0].getmempoolinfo()['bytes-for-cert'])
+        while (usage > NODE0_LIMIT_B // 2):
+            assert(len(txs) > 0)
+            tx = txs.pop()
+            tx_hex = tx['hex']
+            feerate = tx['feerate']
+            temp_tx = self.nodes[0].decoderawtransaction(tx_hex)        # Prevent double spending error by ignoring
+            if temp_tx['vin'][0]['txid'] == tx_used_as_input['txid']:   # this tx if its input has already been used as
+                continue                                                # input for the certificate we sent previously
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            last_tx_size = len(tx_hex) // 2
+            tx_sent_size += last_tx_size
+            mintxfeerate, maxtxfeerate = min(mintxfeerate, feerate), max(maxtxfeerate, feerate)
+            usage = int(self.nodes[0].getmempoolinfo()['bytes-for-cert'])
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "transactions -- minfeerate: ") + f"{mintxfeerate:1.8f}" + cc('g', " - maxfeerate: ") + f"{maxtxfeerate:1.8f}", self.nodes, DEBUG_MODE)
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        # Assert that certificates got evicted
+        assert_greater_than(cert_partition, int(mempoolstatus['bytes-for-cert']))
+        print()
+
+
+        mark_logs("Add another transactions with feerate = F_highest > 0.0001 will fail", self.nodes, DEBUG_MODE, color = 'c')
+        tx = txs.pop()
+        tx_hex = tx['hex']
+        try:
+            mark_logs(cc('e', "Tx fees: ") + f"{tx['feerate']:1.8f}", self.nodes, DEBUG_MODE)
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print(cc('y', errorString))
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+
+
+if __name__ == '__main__':
+    mempool_size_limit_even_more().main()

--- a/qa/rpc-tests/mempool_size_limit_even_more.py
+++ b/qa/rpc-tests/mempool_size_limit_even_more.py
@@ -6,8 +6,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_framework import ForkHeights
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import initialize_chain_clean, start_nodes, connect_nodes_bi, mark_logs,\
-    get_epoch_data, swap_bytes, assert_greater_than, colorize as cc
+from test_framework.util import initialize_chain_clean, start_nodes, mark_logs,\
+    get_epoch_data, swap_bytes, assert_greater_than, download_snapshot, colorize as cc
 from mempool_size_limit import load_from_storage, create_big_transactions, create_sidechains, \
     write_to_file
 from test_framework.mc_test.mc_test import *
@@ -63,8 +63,8 @@ class mempool_size_limit_even_more(BitcoinTestFramework):
     def import_data_to_data_dir(self):
         # importing datadir resource
         # Tests checkpoint creation (during startup rescan) and usage, checks everything ok with old wallet
-        # resource_file = os.sep.join([os.path.dirname(__file__), 'resources', 'mempool_size_limit_more', 'test_setup_.zip'])
-        resource_file = os.sep.join(['/', 'temporary', 'absolute', 'path', 'to', 'snapshot.zip'])
+        snapshot_filename = 'mempool_size_limit_even_more_snapshot.zip'
+        resource_file = download_snapshot(snapshot_filename, self.options.tmpdir)
         with zipfile.ZipFile(resource_file, 'r') as zip_ref:
             zip_ref.extractall(self.options.tmpdir)
 

--- a/qa/rpc-tests/mempool_size_limit_more.py
+++ b/qa/rpc-tests/mempool_size_limit_more.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_nodes, sync_blocks,connect_nodes_bi, mark_logs, \
+    colorize as cc
+from mempool_size_limit import load_from_storage, satoshi_round, create_tx_script
+from test_framework.mc_test.mc_test import *
+import os
+import zipfile
+from decimal import Decimal
+
+DEBUG_MODE = 1
+NUMB_OF_NODES = 1
+
+CERT_FEE       = Decimal('0.00015')
+
+NODE0_LIMIT_B = 5000000
+NODE1_LIMIT_B = 4000000
+
+NODE0_CERT_LIMIT_B = NODE0_LIMIT_B / 2
+
+MAX_FEE = Decimal("999999")
+
+NUM_CEASING_SIDECHAINS    = 2
+NUM_NONCEASING_SIDECHAINS = 2
+
+"""
+This test is a follow up of mempool_size_limit.py and uses the same snapshot data
+Please use that test to recreate the snapshot from scratch, as this file does not include
+all the helper functions to that purpose.
+
+Test replacement of transactions when certificate partition is full:
+    - Clear the mempool
+    - Add certificates up to MAX_SIZE / 2 (50%), fee_rate = F_low
+    - Add transactions up to MAX_SIZE / 2 (50%), fee_rate = F_high
+    - Add a new transaction, fee_rate = F_medium [REJECT]
+    - Add a new transaction, fee_rate = F_highest [OK, one transaction gets evicted]
+
+--------------
+feerates ratings: F_high and F_medium a evaluated at realtime, given the feerates of txs array
+
+F_highest ---   0.00020
+           |
+           |     \                      |- maxtxfeerate
+F_high    ---    | --> midpoint between |             ~ 0.000165
+           |     /                      |- mintxfeerate
+           |
+           |     \                      |- mintxfeerate
+F_medium  ---    | --> midpoint between |             ~ 0.000081
+           |     /                      |- F_low
+           |
+F_low     ---   ~2.245E-8
+
+If creating the snapshot from scratch, verify that the evaluated values for F_high and F_medium
+falls in these intervals!
+
+"""
+
+class mempool_size_limit_more(BitcoinTestFramework):
+    def import_data_to_data_dir(self):
+        # importing datadir resource
+        # Tests checkpoint creation (during startup rescan) and usage, checks everything ok with old wallet
+        resource_file = os.sep.join([os.path.dirname(__file__), 'resources', 'mempool_size_limit', 'test_setup_.zip'])
+        with zipfile.ZipFile(resource_file, 'r') as zip_ref:
+            zip_ref.extractall(self.options.tmpdir)
+
+    def setup_chain(self, split=False):
+        self.import_data_to_data_dir()
+        os.remove(self.options.tmpdir+'/node0/regtest/debug.log') # make sure that we have only logs from this test
+        os.remove(self.options.tmpdir+'/node1/regtest/debug.log')
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args =
+            [
+                ['-debug=cert', '-debug=mempool', '-maxorphantx=10000', f'-maxmempool={NODE0_LIMIT_B / 1000000}', '-minconf=0', '-allownonstandardtx', '-maxtipage=3153600000'],
+            ])
+
+        sync_blocks(self.nodes)
+
+    def create_a_big_transaction(self, utxos):
+        txscript = create_tx_script()
+        addr = self.nodes[0].getnewaddress()
+        t = utxos.pop()
+        inputs = [{ "txid" : t["txid"], "vout" : t["vout"]}]
+        outputs = {addr: satoshi_round(t['amount'])} # This will be overwritten anyway
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        out_num_pos = rawtx.find('ffffffff')
+        script_position = rawtx.find('76a914')
+        script_length = int(rawtx[script_position - 2 : script_position], 16) * 2
+
+        newtx = rawtx[0:out_num_pos + 8]
+        newtx = newtx + txscript
+        newtx = newtx + rawtx[script_position + script_length:]
+
+        signresult = self.nodes[0].signrawtransaction(newtx, None, None, "NONE")
+        tsize = len(signresult['hex']) // 2
+        feerate = (t['amount'] - 128 * Decimal(0.00005816)) / tsize
+        txs = {'feerate': feerate, 'hex': signresult["hex"]} 
+        return txs
+
+    def setup_test(self):
+        txs   = load_from_storage(self.options.tmpdir + "/txs/")
+        ctxs  = load_from_storage(self.options.tmpdir + "/ctxs/")
+        certs = []
+        for s in range(NUM_CEASING_SIDECHAINS):
+            certs.append(load_from_storage(self.options.tmpdir + f"/certs/{s}/"))
+        for s in range(NUM_NONCEASING_SIDECHAINS):
+            certs.append(load_from_storage(self.options.tmpdir + f"/certs/{s+NUM_CEASING_SIDECHAINS}/"))
+
+        return txs, ctxs, certs
+
+
+    def run_test(self):
+        mark_logs("Loading snapshot...", self.nodes, DEBUG_MODE, color = 'e')
+        txs, _, certs = self.setup_test() # We only need txs and certs
+
+        txs.sort(key=lambda x: x['feerate'])
+        for c in certs:
+            c.sort(key=lambda x: x['quality'])
+
+        mark_logs("Start from a clean mempool on node 0", self.nodes, DEBUG_MODE, color = 'e')
+        self.nodes[0].clearmempool()
+
+        mark_logs("Filling cert partition with certificates with fee = 0.00015 => feerate = F_low (~2.2465E-8)", self.nodes, DEBUG_MODE, color = 'c')
+        mark_logs("Trying to be conservative and not overcome cert partition limit ", self.nodes, DEBUG_MODE, color = 'c')
+        cert_fees = []
+        cert_sent_size, last_cert_size = 0, 0
+        maxfeerate, minfeerate = 0, MAX_FEE
+        while (cert_sent_size < NODE0_CERT_LIMIT_B - last_cert_size):
+            assert(len(certs[0]) > 0)
+            c = certs[0].pop(0)
+            cert_hex = self.nodes[0].sendrawtransaction(c['hex'])
+            last_cert_size = len(c['hex']) // 2
+            cert_fees.append(c['feerate'])
+            cert_sent_size += last_cert_size
+            minfeerate = min(minfeerate, c['feerate'])
+            maxfeerate = max(maxfeerate, c['feerate'])
+
+        mark_logs(cc('g', "certificates -- minfeerate: ") + f"{minfeerate:.8E}" + cc('g', " - maxfeerate: ") + f"{maxfeerate:.8E}", self.nodes, DEBUG_MODE)
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        certPartitionStatus = int(mempoolstatus['bytes-for-cert'])
+        print()
+
+
+        mark_logs("Filling tx partition with transactions having feerate > 0.00015 (F_high)", self.nodes, DEBUG_MODE, color = 'c')
+        mark_logs("Trying to be conservative and not overcome tx partition limit ", self.nodes, DEBUG_MODE, color = 'c')
+        self.utxos = self.nodes[0].listunspent()
+        tx_sent = 0
+        last_tx_size = 0
+        mintxfeerate, maxtxfeerate = MAX_FEE, 0
+        discarded_txs = 0
+        while True:
+            if len(txs) > 0:
+                tx = txs.pop(0)
+            else:
+                assert(len(self.utxos) > 0)
+                tx = self.create_a_big_transaction(self.utxos)
+            if tx['feerate'] <= Decimal('0.00015'):
+                discarded_txs += 1
+                continue
+            tx_hex = tx['hex']
+            feerate = tx['feerate']
+            tx_size = len(tx_hex)//2
+            usage = self.nodes[0].getmempoolinfo()
+            if int(usage['bytes-for-tx']) + tx_size > NODE0_LIMIT_B // 2 or int(usage['bytes']) + tx_size > NODE0_LIMIT_B:
+                break
+            self.nodes[0].sendrawtransaction(tx_hex, True)
+            mintxfeerate, maxtxfeerate = min(mintxfeerate, feerate), max(maxtxfeerate, feerate)
+            tx_sent += last_tx_size
+
+        mark_logs(cc('g', "Rejected transactions (fee too low for this test): ") + f"{discarded_txs}", self.nodes, DEBUG_MODE)
+        mark_logs(cc('g', "transactions -- mintxfeerate: ") + f"{mintxfeerate:1.8f}" + cc('g', " - maxtxfeerate: ") + f"{maxtxfeerate:1.8f}", self.nodes, DEBUG_MODE)
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        # Assert that we did not evict any certificate
+        assert_equal(mempoolstatus['bytes-for-cert'], certPartitionStatus)
+        print()
+
+
+        # We choose a feerate that still classify as high: the midpoint between the lower and higher tx fee of the previous step
+        selected_high_feerate = mintxfeerate + (maxtxfeerate - mintxfeerate) / 2
+        mark_logs(f"Filling tx partition with tiny transactions having feerate {selected_high_feerate:1.8f} (F_high)", self.nodes, DEBUG_MODE, color = 'c')
+        mark_logs("It's ok to fill tx partition over its limit, we only do not want to evict certificates", self.nodes, DEBUG_MODE, color = 'c')
+        last_tx_size = 0
+        usage = self.nodes[0].getmempoolinfo()
+        addr = self.nodes[0].getnewaddress()
+        utxos = self.nodes[0].listunspent()
+        while(int(usage['bytes']) < NODE0_LIMIT_B - last_tx_size):
+            t = utxos.pop(0)
+            inputs = [{"txid" : t["txid"], "vout" : t["vout"]}]
+
+            outputs = {addr: t["amount"]}                                           #
+            rawtx = self.nodes[0].createrawtransaction(inputs, outputs)             # Initial
+            signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")  # estimation
+            tx_size = len(signedtx['hex']) // 2                                     #
+
+            outputs = {addr: t["amount"] - Decimal(selected_high_feerate * tx_size)}
+            rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+            signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")
+            try:
+                self.nodes[0].sendrawtransaction(signedtx['hex'], True)
+            except JSONRPCException as e:
+                errorString = e.error['message']
+                print(errorString)
+                assert(False)
+            new_usage = self.nodes[0].getmempoolinfo()
+            last_tx_size = int(new_usage['bytes-for-tx']) - int(usage['bytes-for-tx'])
+            usage = new_usage
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        # Assert that we did not evict any certificate
+        assert_equal(mempoolstatus['bytes-for-cert'], certPartitionStatus)
+        print()
+
+
+        selected_medium_feerate = float(maxfeerate) + (float(mintxfeerate) - float(maxfeerate)) / 2
+        mark_logs(f"Sending a medium feerate transaction (F_medium = {selected_medium_feerate:1.8f}) will result in a error", self.nodes, DEBUG_MODE, color = 'c')
+        t = utxos.pop(0)
+        inputs = [{"txid" : t["txid"], "vout" : t["vout"]}]
+
+        outputs = {addr: t["amount"]}                                           #
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)             # Initial
+        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")  # estimation
+        tx_size = len(signedtx['hex']) // 2                                     #
+
+        outputs = {addr: t["amount"] - Decimal(str(selected_medium_feerate * tx_size))}
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")
+        try:
+            self.nodes[0].sendrawtransaction(signedtx['hex'], True)
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print(cc('y', errorString))
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        # Assert that we did not evict any certificate
+        assert_equal(mempoolstatus['bytes-for-cert'], certPartitionStatus)
+        print()
+
+
+        mark_logs("Sending a highest feerate transaction (F_higest = 0.0002) will result in the eviction of a low fee transaction", self.nodes, DEBUG_MODE, color = 'c')
+        t = utxos.pop(0)
+        inputs = [{"txid" : t["txid"], "vout" : t["vout"]}]
+
+        outputs = {addr: t["amount"]}                                           #
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)             # Initial
+        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")  # estimation
+        tx_size = len(signedtx['hex']) // 2                                     #
+
+        outputs = {addr: t["amount"] - Decimal(str(0.0002 * tx_size))}
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")
+        try:
+            self.nodes[0].sendrawtransaction(signedtx['hex'], True)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            print(errorString)
+            assert(False)
+        mempoolstatus = self.nodes[0].getmempoolinfo()
+        mark_logs(cc('g', "Current mempool state: bytes: ") + f"{mempoolstatus['bytes']}" +
+                  cc('g', " - bytes-for-tx: ") + f"{mempoolstatus['bytes-for-tx']}" +
+                  cc('g', " - bytes-for-cert: ") + f"{mempoolstatus['bytes-for-cert']}", self.nodes, DEBUG_MODE)
+        # Assert that we did not evict any certificate
+        assert_equal(mempoolstatus['bytes-for-cert'], certPartitionStatus)
+
+if __name__ == '__main__':
+    mempool_size_limit_more().main()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -22,6 +22,7 @@ import subprocess
 import time
 import re
 import codecs
+from b2sdk.v2 import *
 from test_framework.authproxy import AuthServiceProxy, JSONRPCException
 
 COIN = 100000000 # 1 zec in zatoshis
@@ -766,3 +767,21 @@ def get_field_element_with_padding(field_element, sidechain_version):
         return field_element.ljust(FIELD_ELEMENT_STRING_SIZE, "0")
     else:
         assert(False)
+
+def download_snapshot(snapshot_filename, temporary_dir):
+    print(colorize('e', "Downloading snapshot"), snapshot_filename, colorize('e', "from Blaze..."), end='', flush=True)
+    info = InMemoryAccountInfo()
+    b2_api = B2Api(info)
+    application_key_id = os.environ['MCB_B2_APPLICATION_KEY_ID']
+    application_key    = os.environ['MCB_B2_APPLICATION_KEY']
+    bucket_name        = os.environ['MCB_B2_BUCKET_NAME']
+    b2_api.authorize_account("production", application_key_id, application_key)
+
+    local_filename = temporary_dir + os.sep + snapshot_filename
+    bucket = b2_api.get_bucket_by_name(bucket_name)
+    downloaded_file = bucket.download_file_by_name(snapshot_filename)
+    downloaded_file.save_to(local_filename)
+    print(colorize('g', " Done!"))
+
+    # returns the complete path to the saved filename, to be used with import_data_to_data_dir()
+    return local_filename

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1577,7 +1577,9 @@ MempoolReturnValue AcceptTxToMemoryPool(CTxMemPool& pool, CValidationState &stat
 
     if (!pool.checkIncomingTxConflicts(tx))
     {
-        LogPrintf("%s():%d: tx[%s] has conflicts in mempool\n", __func__, __LINE__, tx.GetHash().ToString());
+        state.Invalid(error("%s():%d: tx[%s] has conflicts in mempool\n",
+            __func__, __LINE__, tx.GetHash().ToString()),
+            CValidationState::Code::HAS_CONFLICTS, "bad-txns-has-conflict-in-mempool");
         return MempoolReturnValue::INVALID;
     }
 


### PR DESCRIPTION
This PR adds two new Python scripts for testing the mempool size limit functionality.
They build two slightly more complex scenarios than those in the mempool_size_limit.py script for evaluating borderline cases.