### PR TITLE
Fix for GUI when reindexing procedure is interrupted

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -670,7 +670,10 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
                 break; // No block files left to reindex
             FILE *file = OpenBlockFile(pos, true);
             assert(file); // This error is logged in OpenBlockFile
-            uiInterface.InitMessage(tfm::format(_("Reindexing block headers from files...") + "(blk%05i.dat)", pos.nFile));
+            if (chainActive.Tip() == NULL)
+                uiInterface.InitMessage(tfm::format(_("Reindexing block headers from files...") + "(blk%05i.dat)", pos.nFile));
+            else
+                uiInterface.InitMessageAfterLoading(tfm::format(_("Reindexing block headers from files...") + "(blk%05i.dat)", pos.nFile));
             LogPrintf("Reindexing block file blk%05i.dat, headers-only...\n", pos.nFile);
             LoadBlocksFromExternalFile(file, &pos, /*loadHeadersOnly*/true);
             ++pos.nFile;


### PR DESCRIPTION
This PR produces better GUI behavior in case of interrupted reindex/reindexfast procedure.

To reproduce:

1. make sure to have significant high blockchain (100+ blockXXX.dat files)
2. start zend with reindexfast parameter
3. interrupt reindexfast after blocks headers import, during raw blocks import (for example blk001.dat)
4. start zend without reindexfast parameter
5. reindexfast procedure resumes but without showing properly progress information (seems to be stucked at "Init message (node already loaded):")

Before fix (at step 4 above):
[before.webm](https://github.com/HorizenOfficial/zen/assets/113015853/5b795b5f-7d30-4df9-bb11-dfe30bd3f7ba)

After fix (at step 4 above):
[after.webm](https://github.com/HorizenOfficial/zen/assets/113015853/748d5225-0e84-410f-b67f-daad6905149b)
