### PR TITLE
Update mempool_size_limit.py to fix issue with feerate

### DIFF
--- a/qa/rpc-tests/mempool_size_limit.py
+++ b/qa/rpc-tests/mempool_size_limit.py
@@ -38,6 +38,217 @@ MAX_FEE = Decimal("999999")
 NUM_CEASING_SIDECHAINS    = 2
 NUM_NONCEASING_SIDECHAINS = 2
 
+
+def write_to_file(filePath, feerate, hex):
+    file = open(filePath, "wb")
+    file.write(bytes(str(feerate) + '\n', encoding='utf8'))
+    file.write(bytes(hex, encoding='utf8'))
+    file.close()
+
+def load_from_file(rFile):
+    feerate = Decimal(rFile.readline().decode("utf-8"))
+    hex     = rFile.readline().decode("utf-8")
+    return {"feerate": feerate, "hex": hex}
+
+def load_from_storage(path):
+    res = []
+    certs = "certs" in path
+    for rf in os.listdir(path):
+        rFile = open(path + rf, "rb")
+        entry = load_from_file(rFile)
+        if (certs):
+            assert(rf.find("c_") == 0)
+            entry["quality"] = int(rf[2:])
+        res.append(entry)
+        rFile.close()
+    return res
+
+def satoshi_round(amount):
+    return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
+
+def create_tx_script():
+    script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
+    for i in range (512):
+        script_pubkey = script_pubkey + "01"
+
+    ## concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+    txouts = "80" # i.e. decimal 128
+    for k in range(128):
+        # add txout value
+        txouts += "b816000000000000"
+        # add length of script_pubkey
+        txouts += "fd0402"
+        # add script_pubkey
+        txouts += script_pubkey
+    return txouts
+
+def create_big_transactions(node, tmpdir, utxos, size):
+    txscript = create_tx_script()
+    addr = node.getnewaddress()
+    txs = []
+    tot_size = 0
+    i = 0
+    os.makedirs(tmpdir + "/txs")
+    while (tot_size < size):
+        t = utxos.pop()
+        inputs = []
+        inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+        outputs = {addr: satoshi_round(t['amount'])} # This will be overwritten anyway
+        rawtx = node.createrawtransaction(inputs, outputs)
+        out_num_pos = rawtx.find('ffffffff')
+        script_position = rawtx.find('76a914')
+        script_length = int(rawtx[script_position - 2 : script_position], 16) * 2
+
+        newtx = rawtx[0:out_num_pos + 8]
+        newtx = newtx + txscript
+        newtx = newtx + rawtx[script_position + script_length:]
+
+        signresult = node.signrawtransaction(newtx, None, None, "NONE")
+        tsize = len(signresult['hex']) // 2
+        tot_size += tsize
+        feerate = (t['amount'] - 128 * Decimal(0.00005816)) / tsize
+        write_to_file(tmpdir + "/txs/tx" + str(i), feerate, signresult["hex"])
+        txs.append({'feerate': feerate, 'hex': signresult["hex"]})
+        i += 1
+    print("Created big transaction for a total size: " + str(tot_size))
+    return txs
+
+def create_sc_certificates(nodes, mcTest, tmpdir, utxos, sidechain, scidx, epoch_number, quality, fee, size):
+    certs = []
+    tot_size = 0
+    raw_bwt_outs = []
+    os.makedirs(tmpdir + "/certs", exist_ok=True)
+    os.makedirs(tmpdir + f"/certs/{scidx}", exist_ok=True)
+    for i in range(128):
+        raw_bwt_outs.append({"address": nodes[1].getnewaddress(), "amount":Decimal("0.0001")})
+    i = 0
+    while (tot_size < size and len(utxos) > 0):
+        t = utxos.pop()
+        raw_inputs = [{'txid' : t['txid'], 'vout' : t['vout']}]
+        amt = t["amount"] - fee
+        raw_outs = {nodes[0].getnewaddress(): amt}
+
+        scid      = sidechain["id"]
+        epoch_len = sidechain["epoch_len"]
+        par_name  = sidechain["params"]
+        constant  = sidechain["constant"]
+        ref_height = nodes[0].getblockcount()
+        ceasing = True if epoch_len > 0 else False
+
+        scid_swapped = str(swap_bytes(scid))
+        _, epoch_cum_tree_hash, prev_cert_hash = get_epoch_data(scid, nodes[0], epoch_len, is_non_ceasing = not ceasing, reference_height = ref_height)
+
+        proof = mcTest.create_test_proof(par_name,
+                                         scid_swapped,
+                                         epoch_number,
+                                         quality,
+                                         MBTR_SC_FEE,
+                                         FT_SC_FEE,
+                                         epoch_cum_tree_hash,
+                                         prev_cert_hash,
+                                         constant = constant,
+                                         pks      = [raw_bwt_outs[i]["address"] for i in range(128)],
+                                         amounts  = [raw_bwt_outs[i]["amount"] for i in range(128)])
+
+        raw_params = {
+            "scid": scid,
+            "quality": quality,
+            "endEpochCumScTxCommTreeRoot": epoch_cum_tree_hash,
+            "scProof": proof,
+            "withdrawalEpochNumber": epoch_number
+        }
+
+        raw_cert    = nodes[0].createrawcertificate(raw_inputs, raw_outs, raw_bwt_outs, raw_params)
+        signed_cert = nodes[0].signrawtransaction(raw_cert)
+        csize = len(signed_cert['hex'])//2
+        feerate = fee / csize
+        tot_size += csize
+        write_to_file(tmpdir + f"/certs/{scidx}/c_{quality}", feerate, signed_cert["hex"])
+        certs.append({'quality': i, 'feerate': feerate, 'hex': signed_cert["hex"]})
+        quality += 1
+        print("Tot cert: " + str(tot_size))
+        i += 1
+        if (epoch_len == 0):
+            return certs
+
+    return certs
+
+def create_chained_transactions(node, tmpdir, utxos):
+    os.makedirs(tmpdir + "/ctxs")
+    addr = node.getnewaddress()
+    txs = []
+
+    low_fee = Decimal("0.0001")
+    high_fee = Decimal("10")
+    amt = Decimal("0")
+    while (amt < high_fee + low_fee):
+        t = utxos.pop()
+        amt = t['amount']
+
+    inputs = []
+    inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+    outputs = {}
+    send_value = t['amount'] - low_fee
+    outputs[addr] = satoshi_round(send_value)
+    rawtx = node.createrawtransaction(inputs, outputs)
+    signresult = node.signrawtransaction(rawtx, None, None, "NONE")
+    csize = len(signresult['hex']) // 2
+    feerate = low_fee / csize
+
+    write_to_file(tmpdir + "/ctxs/ctx0", feerate, signresult["hex"])
+    txs.append({'feerate': high_fee / csize, 'hex': signresult["hex"]})
+
+    ptx = node.decoderawtransaction(signresult["hex"])
+
+    assert(high_fee < t['amount'])
+    inputs = []
+    inputs.append({ "txid" : ptx['txid'], "vout" : 0})
+    outputs = {}
+    send_value = t['amount'] - low_fee - high_fee
+    outputs[node.getnewaddress()] = satoshi_round(send_value)
+    rawtx = node.createrawtransaction(inputs, outputs)
+    signresult = node.signrawtransaction(rawtx, [{"txid": ptx['txid'], "vout": 0, "scriptPubKey": ptx['vout'][0]['scriptPubKey']['hex']}], None, "NONE")
+    csize = len(signresult['hex']) // 2
+    feerate = high_fee / csize
+
+    write_to_file(tmpdir + "/ctxs/ctx1", feerate, signresult["hex"])
+    txs.append({'feerate': high_fee / csize, 'hex': signresult["hex"]})
+
+    return txs
+
+def create_sidechains(nodes, mcTest, num, ceasing):
+    res = []
+    # generate wCertVk and constant
+    for i in range(num):
+        newsc = {}
+        constant = generate_random_field_element_hex()
+        ep_len = EPOCH_LENGTH if ceasing else 0
+        par_name = PARAMS_NAME + ("c" if ceasing else "nc") + str(i)
+
+        vk = mcTest.generate_params(par_name, keyrot=True)
+
+        # generate sidechain
+        cmdInput = {
+            "version": 2,
+            "withdrawalEpochLength": ep_len,
+            "toaddress": "dada",
+            "amount": Decimal("15"),
+            "wCertVk": vk,
+            "constant": constant,
+        }
+
+        ret = nodes[0].sc_create(cmdInput)
+        creating_tx = ret['txid']
+        scid = ret['scid']
+        mark_logs("Node 0 created the SC {} via tx {}.".format(scid, creating_tx), nodes, DEBUG_MODE)
+        newsc["id"] = scid
+        newsc["params"] = par_name
+        newsc["constant"] = constant
+        newsc["epoch_len"] = ep_len
+        res.append(newsc)
+    return res
+
+
 class mempool_size_limit(BitcoinTestFramework):
     def import_data_to_data_dir(self):
         # importing datadir resource
@@ -71,230 +282,15 @@ class mempool_size_limit(BitcoinTestFramework):
         sync_mempools(self.nodes[1:NUMB_OF_NODES])
         self.sync_all()
 
-    def satoshi_round(self, amount):
-        return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
-
-    def create_sc_certificates(self, scidx, epoch_number, quality, fee, size):
-        certs = []
-        tot_size = 0
-        raw_bwt_outs = []
-        os.makedirs(self.options.tmpdir + "/certs", exist_ok=True)
-        os.makedirs(self.options.tmpdir + f"/certs/{scidx}", exist_ok=True)
-        for i in range(128):
-            raw_bwt_outs.append({"address":self.nodes[1].getnewaddress(), "amount":Decimal("0.0001")})
-        i = 0
-        while (tot_size < size and len(self.utxos) > 0):
-            t = self.utxos.pop()
-            raw_inputs = [{'txid' : t['txid'], 'vout' : t['vout']}]
-            amt = t["amount"] - fee
-            raw_outs = {self.nodes[0].getnewaddress(): amt}
-
-            sc = self.sc[scidx]
-            scid = sc["id"]
-            epoch_len = sc["epoch_len"]
-            par_name = sc["params"]
-            constant = sc["constant"]
-            ref_height = self.nodes[0].getblockcount()
-            ceasing = True if epoch_len > 0 else False
-
-            scid_swapped = str(swap_bytes(scid))
-            _, epoch_cum_tree_hash, prev_cert_hash = get_epoch_data(scid, self.nodes[0], epoch_len, is_non_ceasing = not ceasing, reference_height = ref_height)
-
-            proof = self.mcTest.create_test_proof(par_name,
-                                             scid_swapped,
-                                             epoch_number,
-                                             quality,
-                                             MBTR_SC_FEE,
-                                             FT_SC_FEE,
-                                             epoch_cum_tree_hash,
-                                             prev_cert_hash,
-                                             constant = constant,
-                                             pks      = [raw_bwt_outs[i]["address"] for i in range(128)],
-                                             amounts  = [raw_bwt_outs[i]["amount"] for i in range(128)])
-
-            raw_params = {
-                "scid": scid,
-                "quality": quality,
-                "endEpochCumScTxCommTreeRoot": epoch_cum_tree_hash,
-                "scProof": proof,
-                "withdrawalEpochNumber": epoch_number
-            }
-
-            raw_cert    = self.nodes[0].createrawcertificate(raw_inputs, raw_outs, raw_bwt_outs, raw_params)
-            signed_cert = self.nodes[0].signrawtransaction(raw_cert)
-            certFile = open(self.options.tmpdir + f"/certs/{scidx}/c_{quality}", "wb")
-            certFile.write(bytes(str(fee) + '\n', encoding='utf8'))
-            certFile.write(bytes(signed_cert["hex"], encoding='utf8'))
-            certFile.close()
-            csize = len(signed_cert['hex'])//2
-            tot_size += csize
-            certs.append({'quality': i, 'feerate': fee / csize, 'hex': signed_cert["hex"]})
-            quality += 1
-            print("Tot cert: " + str(tot_size))
-            i += 1
-            if (epoch_len == 0):
-                return certs
-
-        return certs
-
-    def create_tx_script(self):
-        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
-        # So we have big transactions (and therefore can't fit very many into each block)
-        # create one script_pubkey
-        self.script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
-        for i in range (512):
-            self.script_pubkey = self.script_pubkey + "01"
-
-        #script_pubkey = script_pubkey + signature_imposter
-
-        ## concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
-        self.txouts = "80" # i.e. decimal 128
-        for k in range(128):
-            # add txout value
-            self.txouts = self.txouts + "b816000000000000"
-            # add length of script_pubkey
-            self.txouts = self.txouts + "fd0402"
-            # add script_pubkey
-            self.txouts = self.txouts + self.script_pubkey
-
-    def load_from_file(self, rFile):
-        fee = Decimal(rFile.readline().decode("utf-8"))
-        hex = rFile.readline().decode("utf-8")
-        return {"feerate": fee, "hex": hex}
-
-    def load_from_storage(self, path):
-        res = []
-        certs = "certs" in path
-        for rf in os.listdir(path):
-            rFile = open(path + rf, "rb")
-            entry = self.load_from_file(rFile)
-            if (certs):
-                assert(rf.find("c_") == 0)
-                entry["quality"] = int(rf[2:])
-            res.append(entry)
-            rFile.close()
-        return res
-
-
-    def create_chained_transactions(self):
-        os.makedirs(self.options.tmpdir + "/ctxs")
-        addr = self.nodes[0].getnewaddress()
-        txs = []
-
-        low_fee = Decimal("0.0001")
-        high_fee = Decimal("10")
-        amt = Decimal("0")
-        while (amt < high_fee + low_fee):
-            t = self.utxos.pop()
-            amt = t['amount']
-
-        inputs = []
-        inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-        outputs = {}
-        send_value = t['amount'] - low_fee
-        outputs[addr] = self.satoshi_round(send_value)
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signresult = self.nodes[0].signrawtransaction(rawtx, None, None, "NONE")
-        csize = len(signresult['hex']) // 2
-
-        txFile = open(self.options.tmpdir + "/ctxs/ctx0", "wb")
-        txFile.write(bytes(str((low_fee) / csize) + '\n', encoding='utf8'))
-        txFile.write(bytes(signresult["hex"], encoding='utf8'))
-        txFile.close()
-        txs.append({'feerate': high_fee / csize, 'hex': signresult["hex"]})
-
-        ptx = self.nodes[0].decoderawtransaction(signresult["hex"])
-
-        assert(high_fee < t['amount'])
-        inputs = []
-        inputs.append({ "txid" : ptx['txid'], "vout" : 0})
-        outputs = {}
-        send_value = t['amount'] - low_fee - high_fee
-        outputs[self.nodes[0].getnewaddress()] = self.satoshi_round(send_value)
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signresult = self.nodes[0].signrawtransaction(rawtx, [{"txid": ptx['txid'], "vout": 0, "scriptPubKey": ptx['vout'][0]['scriptPubKey']['hex']}], None, "NONE")
-        csize = len(signresult['hex']) // 2
-
-        txFile = open(self.options.tmpdir + "/ctxs/ctx1", "wb")
-        txFile.write(bytes(str(high_fee / csize) + '\n', encoding='utf8'))
-        txFile.write(bytes(signresult["hex"], encoding='utf8'))
-        txFile.close()
-        txs.append({'feerate': high_fee / csize, 'hex': signresult["hex"]})
-
-        return txs
-
-    def create_big_transactions(self, size):
-        self.create_tx_script()
-        addr = self.nodes[0].getnewaddress()
-        txs = []
-        tot_size = 0
-        i = 0
-        os.makedirs(self.options.tmpdir + "/txs")
-        while (tot_size < size):
-            t = self.utxos.pop()
-            inputs = []
-            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-            outputs = {addr: self.satoshi_round(t['amount'])} # This will be overwritten anyway
-            rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-            out_num_pos = rawtx.find('ffffffff')
-            script_position = rawtx.find('76a914')
-            script_length = int(rawtx[script_position - 2 : script_position], 16) * 2
-
-            newtx = rawtx[0:out_num_pos + 8]
-            newtx = newtx + self.txouts
-            newtx = newtx + rawtx[script_position + script_length:]
-
-            signresult = self.nodes[0].signrawtransaction(newtx, None, None, "NONE")
-            tsize = len(signresult['hex']) // 2
-            tot_size += tsize
-            txFile = open(self.options.tmpdir + "/txs/tx" + str(i), "wb")
-            txFile.write(bytes(str(t['amount'] / tsize) + '\n', encoding='utf8'))
-            txFile.write(bytes(signresult["hex"], encoding='utf8'))
-            txFile.close()
-            txs.append({'feerate': (t['amount'] - 128 * Decimal(0.00005816)) / tsize, 'hex': signresult["hex"]})
-            i += 1
-        print("Created big transaction for a total size: " + str(tot_size))
-        return txs
-
-    def create_sidechains(self, num, ceasing):
-        # generate wCertVk and constant
-        for i in range(num):
-            newsc = {}
-            constant = generate_random_field_element_hex()
-            ep_len = EPOCH_LENGTH if ceasing else 0
-            par_name = PARAMS_NAME + ("c" if ceasing else "nc") + str(i)
-
-            vk = self.mcTest.generate_params(par_name, keyrot=True)
-
-            # generate sidechain
-            cmdInput = {
-                "version": 2,
-                "withdrawalEpochLength": ep_len,
-                "toaddress": "dada",
-                "amount": Decimal("15"),
-                "wCertVk": vk,
-                "constant": constant,
-            }
-
-            ret = self.nodes[0].sc_create(cmdInput)
-            creating_tx = ret['txid']
-            scid = ret['scid']
-            mark_logs("Node 0 created the SC {} via tx {}.".format(scid, creating_tx), self.nodes, DEBUG_MODE)
-            newsc["id"] = scid
-            newsc["params"] = par_name
-            newsc["constant"] = constant
-            newsc["epoch_len"] = ep_len
-            self.sc.append(newsc)
-
     def setup_test(self):
         if USE_SNAPSHOT:
-            txs   = self.load_from_storage(self.options.tmpdir + "/txs/")
-            ctxs  = self.load_from_storage(self.options.tmpdir + "/ctxs/")
+            txs   = load_from_storage(self.options.tmpdir + "/txs/")
+            ctxs  = load_from_storage(self.options.tmpdir + "/ctxs/")
             certs = []
             for s in range(NUM_CEASING_SIDECHAINS):
-                certs.append(self.load_from_storage(self.options.tmpdir + f"/certs/{s}/"))
+                certs.append(load_from_storage(self.options.tmpdir + f"/certs/{s}/"))
             for s in range(NUM_NONCEASING_SIDECHAINS):
-                certs.append(self.load_from_storage(self.options.tmpdir + f"/certs/{s+NUM_CEASING_SIDECHAINS}/"))
+                certs.append(load_from_storage(self.options.tmpdir + f"/certs/{s+NUM_CEASING_SIDECHAINS}/"))
         else:
             mark_logs("Node 0 generates {} block".format(ForkHeights['NON_CEASING_SC']), self.nodes, DEBUG_MODE)
             self.nodes[0].generate(ForkHeights['NON_CEASING_SC'] + 800) # TODO: reduce to match the actual number of utxos needed
@@ -305,23 +301,23 @@ class mempool_size_limit(BitcoinTestFramework):
             small_amount    = Decimal("0.000001")
 
             ## Create sidechains
-            self.mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
-            self.sc = []
-            self.create_sidechains(NUM_CEASING_SIDECHAINS, ceasing = True)
-            self.create_sidechains(NUM_NONCEASING_SIDECHAINS, ceasing = False)
+            mcTest = CertTestUtils(self.options.tmpdir, self.options.srcdir)
+            sc = []
+            sc.extend(create_sidechains(self.nodes, mcTest, NUM_CEASING_SIDECHAINS, ceasing = True))
+            sc.extend(create_sidechains(self.nodes, mcTest, NUM_NONCEASING_SIDECHAINS, ceasing = False))
             self.nodes[0].generate(EPOCH_LENGTH) # goto end epoch
             self.sync_all()
 
             self.utxos = self.nodes[0].listunspent(0)
-            txs = self.create_big_transactions(NODE0_LIMIT_B + EPSILON)
-            ctxs = self.create_chained_transactions()
+            txs = create_big_transactions(self.nodes[0], self.options.tmpdir, self.utxos, NODE0_LIMIT_B + EPSILON)
+            ctxs = create_chained_transactions(self.nodes[0], self.options.tmpdir, self.utxos)
 
             certs = []
             for i in range(NUM_CEASING_SIDECHAINS):
-                certs.append(self.create_sc_certificates(i, 0, 0, CERT_FEE * (i+1), EPSILON + (NODE0_CERT_LIMIT_B * 2 / NUM_CEASING_SIDECHAINS)))
+                certs.append(create_sc_certificates(self.nodes, mcTest, self.options.tmpdir, self.utxos, sc[i], i, 0, 0, CERT_FEE * (i+1), EPSILON + (NODE0_CERT_LIMIT_B * 2 / NUM_CEASING_SIDECHAINS)))
 
             for i in range(NUM_NONCEASING_SIDECHAINS):
-                certs.append(self.create_sc_certificates(i+2, 0, 0, CERT_FEE, EPSILON)) # not possible to precompute non ceasing certificates
+                certs.append(create_sc_certificates(self.nodes, mcTest, self.options.tmpdir, self.utxos, sc[i+2], i+2, 0, 0, CERT_FEE, EPSILON)) # not possible to precompute non ceasing certificates
 
         return txs, ctxs, certs
 


### PR DESCRIPTION
This PR fixes a minor inconsistency in the fee vs. feerate values stored in snapshots created for testing mempool size limitations.
The snapshot is updated accordingly.

Also, few helper functions are moved out of the local class, so that they can be seamlessly used by other tests.