### PR TITLE
[ZEND-569] Remove boost threads from networking system

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ BITCOIN_CORE_H = \
   support/events.h \
   support/pagelocker.h \
   sync.h \
+  threadinterrupt.h \
   threadsafety.h \
   timedata.h \
   timestampindex.h \
@@ -415,6 +416,7 @@ libbitcoin_util_a_SOURCES = \
   rpc/protocol.cpp \
   support/cleanse.cpp \
   sync.cpp \
+  threadinterrupt.cpp \
   uint256.cpp \
   util.cpp \
   utilmoneystr.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1983,7 +1983,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     connOptions.nSendBufferMaxSize = fromKBtoBfactor * static_cast<unsigned int>(GetArgWithinLimits("-maxsendbuffer", DEFAULT_MAX_SEND_BUFFER, bufferMinMax));
     connOptions.nReceiveFloodSize = fromKBtoBfactor * static_cast<unsigned int>(GetArgWithinLimits("-maxreceivebuffer", DEFAULT_MAX_RECEIVE_BUFFER, bufferMinMax));
     
-    connman->StartNode(threadGroup, scheduler, connOptions);
+    connman->StartNode(scheduler, connOptions);
 
     // Monitor the chain, and alert if we get blocks much quicker or slower than expected
     int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -201,7 +201,6 @@ void Shutdown()
     GenerateBitcoins(false, 0);
  #endif
 #endif
-    connman->StopNode();
     StopTorControl();
     UnregisterNodeSignals(GetNodeSignals());
 
@@ -267,7 +266,6 @@ void Shutdown()
     pzcashParams = NULL;
     globalVerifyHandle.reset();
     ECC_Stop();
-    connman->NetCleanup();
     connman.reset();
     LogPrintf("%s: done\n", __func__);
 }

--- a/src/main.h
+++ b/src/main.h
@@ -291,14 +291,14 @@ void ProcessTxBaseAcceptToMemoryPool(const CTransactionBase& txBase, CNode* pfro
 /** Process protocol message of type "tx" */
 void ProcessTxBaseMsg(const CTransactionBase& txBase, CNode* pfrom);
 /** Process protocol messages received from a given node */
-bool ProcessMessages(CNode* pfrom);
+bool ProcessMessages(CNode* pfrom, const std::atomic<bool>& interruptMsgProc);
 /**
  * Send queued protocol messages to be sent to a give node.
  *
  * @param[in]   pto             The node which we are sending messages to.
  * @param[in]   fSendTrickle    When true send the trickled data, otherwise trickle the data until true.
  */
-bool SendMessages(CNode* pto, bool fSendTrickle);
+bool SendMessages(CNode* pto, bool fSendTrickle, const std::atomic<bool>& interruptMsgProc);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -784,8 +784,10 @@ CConnman::~CConnman()
 {
     try
     {
+        LogPrintf("CConnman destruction");
         StopNode();
         Stop();
+        LogPrintf("CConnman destruction - done");
     }
     catch (...)
     {
@@ -797,7 +799,7 @@ CConnman::~CConnman()
 // In Bitcoin this is called CConnman::Interrupt()
 bool CConnman::StopNode()
 {
-    LogPrintf("StopNode()\n");
+    LogPrintf("CConnman: StopNode()\n");
 
     flagInterruptMsgProc = true;
 
@@ -823,7 +825,7 @@ void CConnman::NetCleanup()
 {
     // Close sockets
     BOOST_FOREACH(CNode* pnode, vNodes)
-    pnode->CloseSocketDisconnect();
+        pnode->CloseSocketDisconnect();
     BOOST_FOREACH(ListenSocket& hListenSocket, vhListenSocket)
         if (hListenSocket.socket != INVALID_SOCKET)
             if (!CloseSocket(hListenSocket.socket))

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -17,6 +17,7 @@
 #include "ui_interface.h"
 #include "crypto/common.h"
 #include "zen/utiltls.h"
+#include "zen/tlsmanager.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -24,13 +25,9 @@
 #include <fcntl.h>
 #endif
 
-#include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
-
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#include <zen/tlsmanager.cpp>
 
 // Dump addresses to peers.dat every 15 minutes (900s)
 #define DUMP_ADDRESSES_INTERVAL 900
@@ -2015,7 +2012,7 @@ void static Discover()
 
 
 
-void CConnman::StartNode(boost::thread_group& threadGroup, CScheduler& scheduler, const Options& connOptions)
+void CConnman::StartNode(CScheduler& scheduler, const Options& connOptions)
 {
     Init(connOptions);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -806,7 +806,8 @@ bool CConnman::StopNode()
     condMsgProc.notify_all();
 
     interruptNet();
-    // InterruptSocks5(true);
+    InterruptSocks5(true);
+    InterruptLookup(true);
 
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
@@ -2086,7 +2087,8 @@ void CConnman::StartNode(CScheduler& scheduler, const Options& connOptions)
     // Start threads
     //
 
-    // InterruptSocks5(false);
+    InterruptSocks5(false);
+    InterruptLookup(false);
     interruptNet.reset();
     flagInterruptMsgProc = false;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -58,9 +58,6 @@
     #error "ERROR: Your OpenSSL version does not support TLS v1.2"
 #endif
 
-// TEMPORARY! This should be removed as soon as we get rid of boost:thread
-extern std::unique_ptr<CConnman> connman;
-
 //
 // Global state variables
 //
@@ -773,7 +770,18 @@ CConnman::CConnman() {
 
 void CConnman::Stop()
 {
-    // StopThreads();
+    if (threadMessageHandler.joinable())
+        threadMessageHandler.join();
+    if (threadOpenConnections.joinable())
+        threadOpenConnections.join();
+    if (threadOpenAddedConnections.joinable())
+        threadOpenAddedConnections.join();
+    if (threadDNSAddressSeed.joinable())
+        threadDNSAddressSeed.join();
+    if (threadSocketHandler.joinable())
+        threadSocketHandler.join();
+    if (threadNonTLSPoolsCleaner.joinable())
+        threadNonTLSPoolsCleaner.join();
     NetCleanup();
 };
 
@@ -790,13 +798,8 @@ CConnman::~CConnman()
     }
 }
 
-// Temporary!
-// This shouldn't be neeed after boost::thread refactoring
-void DumpAddresses();
 
-
-// In Bitcoin this is called CConnman::Interrupt() and it also features
-// calls to condMsgProc.notify_all(), interruptNet() and InterruptSocks5()
+// In Bitcoin this is called CConnman::Interrupt()
 bool CConnman::StopNode()
 {
     LogPrintf("StopNode()\n");
@@ -1016,7 +1019,6 @@ public:
     }
 };
 
-//// To be moved to CConnman
 bool CConnman::AttemptToEvictConnection(bool fPreferNewConnection) {
     std::vector<CNodeRef> vEvictionCandidates;
     {
@@ -1247,12 +1249,12 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 }
 
 #if defined(USE_TLS)
-void ThreadNonTLSPoolsCleaner()
+void CConnman::ThreadNonTLSPoolsCleaner()
 {
     while (true)
     {
-        tlsmanager.cleanNonTLSPool(connman->vNonTLSNodesInbound,  connman->cs_vNonTLSNodesInbound);
-        tlsmanager.cleanNonTLSPool(connman->vNonTLSNodesOutbound, connman->cs_vNonTLSNodesOutbound);
+        tlsmanager.cleanNonTLSPool(vNonTLSNodesInbound,  cs_vNonTLSNodesInbound);
+        tlsmanager.cleanNonTLSPool(vNonTLSNodesOutbound, cs_vNonTLSNodesOutbound);
         MilliSleep(DEFAULT_CONNECT_TIMEOUT);  // sleep and sleep_for are interruption points, which will throw boost::thread_interrupted
     }
 }
@@ -1260,7 +1262,7 @@ void ThreadNonTLSPoolsCleaner()
 #endif // USE_TLS 
 
 
-void ThreadSocketHandler()
+void CConnman::ThreadSocketHandler()
 {
     unsigned int nPrevNodeCount = 0;
     while (true)
@@ -1269,16 +1271,16 @@ void ThreadSocketHandler()
         // Disconnect nodes
         //
         {
-            LOCK(connman->cs_vNodes);
+            LOCK(cs_vNodes);
             // Disconnect unused nodes
-            vector<CNode*> vNodesCopy = connman->vNodes;
+            vector<CNode*> vNodesCopy = vNodes;
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
             {
                 if (pnode->fDisconnect ||
                     (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 && pnode->ssSend.empty()))
                 {
                     // remove from vNodes
-                    connman->vNodes.erase(remove(connman->vNodes.begin(), connman->vNodes.end(), pnode), connman->vNodes.end());
+                    vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());
 
                     // release outbound grant (if any)
                     pnode->grantOutbound.Release();
@@ -1289,13 +1291,13 @@ void ThreadSocketHandler()
                     // hold in disconnected pool until all refs are released
                     if (pnode->fNetworkNode || pnode->fInbound)
                         pnode->Release();
-                    connman->vNodesDisconnected.push_back(pnode);
+                    vNodesDisconnected.push_back(pnode);
                 }
             }
         }
         {
             // Delete disconnected nodes
-            list<CNode*> vNodesDisconnectedCopy = connman->vNodesDisconnected;
+            list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
             BOOST_FOREACH(CNode* pnode, vNodesDisconnectedCopy)
             {
                 // Destroy the object only after other threads have stopped using it
@@ -1309,14 +1311,14 @@ void ThreadSocketHandler()
                     }
                     if (fDelete)
                     {
-                        connman->vNodesDisconnected.remove(pnode);
+                        vNodesDisconnected.remove(pnode);
                         delete pnode;
                     }
                 }
             }
         }
-        if(connman->vNodes.size() != nPrevNodeCount) {
-            nPrevNodeCount = connman->vNodes.size();
+        if(vNodes.size() != nPrevNodeCount) {
+            nPrevNodeCount = vNodes.size();
             uiInterface.NotifyNumConnectionsChanged(nPrevNodeCount);
         }
 
@@ -1336,15 +1338,15 @@ void ThreadSocketHandler()
         SOCKET hSocketMax = 0;
         bool have_fds = false;
 
-        BOOST_FOREACH(const ListenSocket& hListenSocket, connman->vhListenSocket) {
+        BOOST_FOREACH(const ListenSocket& hListenSocket, vhListenSocket) {
             FD_SET(hListenSocket.socket, &fdsetRecv);
             hSocketMax = max(hSocketMax, hListenSocket.socket);
             have_fds = true;
         }
 
         {
-            LOCK(connman->cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, connman->vNodes)
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes)
             {
                 LOCK(pnode->cs_hSocket);
                 
@@ -1382,7 +1384,7 @@ void ThreadSocketHandler()
                     TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
                     if (lockRecv && (
                         pnode->vRecvMsg.empty() || !pnode->vRecvMsg.front().complete() ||
-                        pnode->GetTotalRecvSize() <= connman->GetReceiveFloodSize()))
+                        pnode->GetTotalRecvSize() <= GetReceiveFloodSize()))
                         FD_SET(pnode->hSocket, &fdsetRecv);
                 }
             }
@@ -1409,11 +1411,11 @@ void ThreadSocketHandler()
         //
         // Accept new connections
         //
-        BOOST_FOREACH(const ListenSocket& hListenSocket, connman->vhListenSocket)
+        BOOST_FOREACH(const ListenSocket& hListenSocket, vhListenSocket)
         {
             if (hListenSocket.socket != INVALID_SOCKET && FD_ISSET(hListenSocket.socket, &fdsetRecv))
             {
-                connman->AcceptConnection(hListenSocket);
+                AcceptConnection(hListenSocket);
             }
         }
 
@@ -1422,8 +1424,8 @@ void ThreadSocketHandler()
         //
         vector<CNode*> vNodesCopy;
         {
-            LOCK(connman->cs_vNodes);
-            vNodesCopy = connman->vNodes;
+            LOCK(cs_vNodes);
+            vNodesCopy = vNodes;
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->AddRef();
         }
@@ -1464,7 +1466,7 @@ void ThreadSocketHandler()
             }
         }
         {
-            LOCK(connman->cs_vNodes);
+            LOCK(cs_vNodes);
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
@@ -1472,15 +1474,15 @@ void ThreadSocketHandler()
 }
 
 
-void ThreadDNSAddressSeed()
+void CConnman::ThreadDNSAddressSeed()
 {
     // goal: only query DNS seeds if address need is acute
     if ((addrman.size() > 0) &&
         (!GetBoolArg("-forcednsseed", false))) {
         MilliSleep(11 * 1000);
 
-        LOCK(connman->cs_vNodes);
-        if (connman->vNodes.size() >= 2) {
+        LOCK(cs_vNodes);
+        if (vNodes.size() >= 2) {
             LogPrintf("P2P peers available. Skipped DNS seeding.\n");
             return;
         }
@@ -1497,7 +1499,7 @@ void ThreadDNSAddressSeed()
     for(const CDNSSeedData &seed : vSeeds)
     {
         if (HaveNameProxy()) {
-            connman->AddOneShot(seed.host);
+            AddOneShot(seed.host);
             continue;
         } 
     
@@ -1525,7 +1527,7 @@ void ThreadDNSAddressSeed()
 
 
 /// To be moved to CConnman after boost::thread refactoring
-void DumpAddresses()
+void CConnman::DumpAddresses()
 {
     int64_t nStart = GetTimeMillis();
 
@@ -1554,18 +1556,18 @@ void CConnman::ProcessOneShot()
     }
 }
 
-void ThreadOpenConnections()
+void CConnman::ThreadOpenConnections()
 {
     // Connect to specific addresses
     if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
     {
         for (int64_t nLoop = 0;; nLoop++)
         {
-            connman->ProcessOneShot();
+            ProcessOneShot();
             BOOST_FOREACH(const std::string& strAddr, mapMultiArgs["-connect"])
             {
                 CAddress addr;
-                connman->OpenNetworkConnection(addr, NULL, strAddr.c_str());
+                OpenNetworkConnection(addr, NULL, strAddr.c_str());
                 
                 for (int i = 0; i < 10 && i < nLoop; i++)
                 {
@@ -1580,11 +1582,11 @@ void ThreadOpenConnections()
     int64_t nStart = GetTime();
     while (true)
     {
-        connman->ProcessOneShot();
+        ProcessOneShot();
 
         MilliSleep(500);
 
-        CSemaphoreGrant grant(*connman->semOutbound);
+        CSemaphoreGrant grant(*semOutbound);
         boost::this_thread::interruption_point();
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
@@ -1607,8 +1609,8 @@ void ThreadOpenConnections()
         int nOutbound = 0;
         set<vector<unsigned char> > setConnected;
         {
-            LOCK(connman->cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, connman->vNodes) {
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes) {
                 if (!pnode->fInbound) {
                     setConnected.insert(pnode->addr.GetGroup());
                     nOutbound++;
@@ -1650,29 +1652,29 @@ void ThreadOpenConnections()
         }
 
         if (addrConnect.IsValid())
-            connman->OpenNetworkConnection(addrConnect, &grant);
+            OpenNetworkConnection(addrConnect, &grant);
     }
 }
 
-void ThreadOpenAddedConnections()
+void CConnman::ThreadOpenAddedConnections()
 {
     {
-        LOCK(connman->cs_vAddedNodes);
-        connman->vAddedNodes = mapMultiArgs["-addnode"];
+        LOCK(cs_vAddedNodes);
+        vAddedNodes = mapMultiArgs["-addnode"];
     }
 
     if (HaveNameProxy()) {
         while(true) {
             list<string> lAddresses(0);
             {
-                LOCK(connman->cs_vAddedNodes);
-                BOOST_FOREACH(const std::string& strAddNode, connman->vAddedNodes)
+                LOCK(cs_vAddedNodes);
+                BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
                     lAddresses.push_back(strAddNode);
             }
             BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
                 CAddress addr;
-                CSemaphoreGrant grant(*connman->semOutbound);
-                connman->OpenNetworkConnection(addr, &grant, strAddNode.c_str());
+                CSemaphoreGrant grant(*semOutbound);
+                OpenNetworkConnection(addr, &grant, strAddNode.c_str());
                 MilliSleep(500);
             }
             MilliSleep(120000); // Retry every 2 minutes
@@ -1683,8 +1685,8 @@ void ThreadOpenAddedConnections()
     {
         list<string> lAddresses(0);
         {
-            LOCK(connman->cs_vAddedNodes);
-            BOOST_FOREACH(const std::string& strAddNode, connman->vAddedNodes)
+            LOCK(cs_vAddedNodes);
+            BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
                 lAddresses.push_back(strAddNode);
         }
 
@@ -1699,8 +1701,8 @@ void ThreadOpenAddedConnections()
         // Attempt to connect to each IP for each addnode entry until at least one is successful per addnode entry
         // (keeping in mind that addnode entries can have many IPs if fNameLookup)
         {
-            LOCK(connman->cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, connman->vNodes)
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes)
                 for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin(); it != lservAddressesToAdd.end(); ++it)
                     BOOST_FOREACH(const CService& addrNode, *(it))
                         if (pnode->addr == addrNode)
@@ -1712,8 +1714,8 @@ void ThreadOpenAddedConnections()
         }
         BOOST_FOREACH(vector<CService>& vserv, lservAddressesToAdd)
         {
-            CSemaphoreGrant grant(*connman->semOutbound);
-            connman->OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
+            CSemaphoreGrant grant(*semOutbound);
+            OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
             MilliSleep(500);
         }
         MilliSleep(120000); // Retry every 2 minutes
@@ -1775,7 +1777,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGran
 }
 
 
-void ThreadMessageHandler()
+void CConnman::ThreadMessageHandler()
 {
     boost::mutex condition_mutex;
     boost::unique_lock<boost::mutex> lock(condition_mutex);
@@ -1785,8 +1787,8 @@ void ThreadMessageHandler()
     {
         vector<CNode*> vNodesCopy;
         {
-            LOCK(connman->cs_vNodes);
-            vNodesCopy = connman->vNodes;
+            LOCK(cs_vNodes);
+            vNodesCopy = vNodes;
             BOOST_FOREACH(CNode* pnode, vNodesCopy) {
                 pnode->AddRef();
             }
@@ -1812,7 +1814,7 @@ void ThreadMessageHandler()
                     if (!g_signals.ProcessMessages(pnode))
                         pnode->CloseSocketDisconnect();
 
-                    if (pnode->nSendSize < connman->GetSendBufferSize())
+                    if (pnode->nSendSize < GetSendBufferSize())
                     {
                         if (!pnode->vRecvGetData.empty() || (!pnode->vRecvMsg.empty() && pnode->vRecvMsg[0].complete()))
                         {
@@ -1833,7 +1835,7 @@ void ThreadMessageHandler()
         }
 
         {
-            LOCK(connman->cs_vNodes);
+            LOCK(cs_vNodes);
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
@@ -2064,30 +2066,36 @@ void CConnman::StartNode(boost::thread_group& threadGroup, CScheduler& scheduler
     if (!GetBoolArg("-dnsseed", true))
         LogPrintf("DNS seeding disabled\n");
     else
-        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "dnsseed", &ThreadDNSAddressSeed));
+        threadDNSAddressSeed = std::thread(&TraceThread<std::function<void()> >, "dnsseed",
+                std::function<void()>(std::bind(&CConnman::ThreadDNSAddressSeed, this)));
 
     // Send and receive from sockets, accept connections
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "net", &ThreadSocketHandler));
+    threadSocketHandler = std::thread(&TraceThread<std::function<void()> >, "net",
+            std::function<void()>(std::bind(&CConnman::ThreadSocketHandler, this)));
 
     // Initiate outbound connections from -addnode
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "addcon", &ThreadOpenAddedConnections));
+    threadOpenAddedConnections = std::thread(&TraceThread<std::function<void()> >, "addcon",
+            std::function<void()>(std::bind(&CConnman::ThreadOpenAddedConnections, this)));
 
     // Initiate outbound connections
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "opencon", &ThreadOpenConnections));
+    threadOpenConnections = std::thread(&TraceThread<std::function<void()> >, "opencon",
+            std::function<void()>(std::bind(&CConnman::ThreadOpenConnections, this)));
 
     // Process messages
-    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "msghand", &ThreadMessageHandler));
+    threadMessageHandler = std::thread(&TraceThread<std::function<void()> >, "msghand",
+            std::function<void()>(std::bind(&CConnman::ThreadMessageHandler, this)));
 
 #if defined(USE_TLS)
     if (CNode::GetTlsFallbackNonTls())
     {
         // Clean pools of addresses for non-TLS connections
-        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "poolscleaner", &ThreadNonTLSPoolsCleaner));
+        threadNonTLSPoolsCleaner = std::thread(&TraceThread<std::function<void()> >, "poolscleaner",
+                std::function<void()>(std::bind(&CConnman::ThreadNonTLSPoolsCleaner, this)));
     }
 #endif
     
     // Dump network addresses
-    scheduler.scheduleEvery(&DumpAddresses, DUMP_ADDRESSES_INTERVAL);
+    scheduler.scheduleEvery(std::function<void()>(std::bind(&CConnman::DumpAddresses, this)), DUMP_ADDRESSES_INTERVAL);
 }
 
 void Relay(const CTransactionBase& tx, const CDataStream& ss)

--- a/src/net.h
+++ b/src/net.h
@@ -762,7 +762,6 @@ public:
     bool StopNode();
     void Stop();
     void NetCleanup();
-    void Interrupt();
 
     bool Bind(const CService &addr, unsigned int flags);
     bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);

--- a/src/net.h
+++ b/src/net.h
@@ -46,10 +46,6 @@ class CAddrMan;
 class CScheduler;
 class CNode;
 
-namespace boost {
-    class thread_group;
-} // namespace boost
-
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
@@ -761,7 +757,7 @@ public:
         }
     }
 
-    void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler , const Options& connOptions);
+    void StartNode(CScheduler& scheduler , const Options& connOptions);
     bool StopNode();
     void Stop();
     void NetCleanup();

--- a/src/net.h
+++ b/src/net.h
@@ -845,9 +845,7 @@ private:
     unsigned int nSendBufferMaxSize;
     unsigned int nReceiveFloodSize;
 
-    // // To be moved here in the next PR, when we will get rid of boost::thread!
-    //
-    // CThreadInterrupt interruptNet;
+    CThreadInterrupt interruptNet;
     std::mutex mutexMsgProc;
     // std::atomic<bool> flagInterruptMsgProc;
     //

--- a/src/net.h
+++ b/src/net.h
@@ -16,10 +16,13 @@
 #include "random.h"
 #include "streams.h"
 #include "sync.h"
+#include "threadinterrupt.h"
 #include "uint256.h"
 #include "utilstrencodings.h"
 
 #include <deque>
+#include <thread>
+#include <condition_variable>
 #include <stdint.h>
 
 #ifndef WIN32
@@ -847,19 +850,24 @@ private:
     // // To be moved here in the next PR, when we will get rid of boost::thread!
     //
     // CThreadInterrupt interruptNet;
+    // std::condition_variable condMsgProc;
+    // std::mutex mutexMsgProc;
+    // std::atomic<bool> flagInterruptMsgProc;
     //
-    // std::thread threadDNSAddressSeed;
-    // std::thread threadSocketHandler;
-    // std::thread threadOpenAddedConnections;
-    // std::thread threadOpenConnections;
-    // std::thread threadMessageHandler;
-    // std::thread threadNonTLSPoolsCleaner;
-    // void ThreadOpenConnections();
-    // void ThreadOpenAddedConnections();
-    // void ThreadNonTLSPoolsCleaner();
-    // void ThreadSocketHandler();
-    // void ThreadDNSAddressSeed();
-    // void void ThreadMessageHandler();
+    std::thread threadDNSAddressSeed;
+    std::thread threadSocketHandler;
+    std::thread threadOpenAddedConnections;
+    std::thread threadOpenConnections;
+    std::thread threadMessageHandler;
+    std::thread threadNonTLSPoolsCleaner;
+    void ThreadOpenConnections();
+    void ThreadOpenAddedConnections();
+    void ThreadNonTLSPoolsCleaner();
+    void ThreadSocketHandler();
+    void ThreadDNSAddressSeed();
+    void ThreadMessageHandler();
+
+    void DumpAddresses();
 
 };
 

--- a/src/net.h
+++ b/src/net.h
@@ -20,6 +20,7 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 
+#include <atomic>
 #include <deque>
 #include <thread>
 #include <condition_variable>
@@ -119,8 +120,8 @@ struct CombinerAll
 struct CNodeSignals
 {
     boost::signals2::signal<int ()> GetHeight;
-    boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
-    boost::signals2::signal<bool (CNode*, bool), CombinerAll> SendMessages;
+    boost::signals2::signal<bool (CNode*, const std::atomic<bool>&), CombinerAll> ProcessMessages;
+    boost::signals2::signal<bool (CNode*, bool, const std::atomic<bool>&), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
     boost::signals2::signal<void (NodeId)> FinalizeNode;
 };
@@ -847,8 +848,8 @@ private:
 
     CThreadInterrupt interruptNet;
     std::mutex mutexMsgProc;
-    // std::atomic<bool> flagInterruptMsgProc;
-    //
+    std::atomic<bool> flagInterruptMsgProc{false};
+
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;

--- a/src/net.h
+++ b/src/net.h
@@ -831,6 +831,8 @@ public:
     // that peer during `net_processing.cpp:PushNodeVersion()`.
     uint64_t GetLocalServices() const;
 
+    std::condition_variable condMsgProc;
+
 private:
     std::atomic<uint64_t> nTotalBytesRecv = 0;
     std::atomic<uint64_t> nTotalBytesSent = 0;
@@ -846,8 +848,7 @@ private:
     // // To be moved here in the next PR, when we will get rid of boost::thread!
     //
     // CThreadInterrupt interruptNet;
-    // std::condition_variable condMsgProc;
-    // std::mutex mutexMsgProc;
+    std::mutex mutexMsgProc;
     // std::atomic<bool> flagInterruptMsgProc;
     //
     std::thread threadDNSAddressSeed;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -207,5 +207,7 @@ bool SetSocketNonBlocking(SOCKET& hSocket, bool fNonBlocking);
  * Convert milliseconds to a struct timeval for e.g. select.
  */
 struct timeval MillisToTimeval(int64_t nTimeout);
+void InterruptSocks5(bool interrupt);
+void InterruptLookup(bool interrupt);
 
 #endif // BITCOIN_NETBASE_H

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -46,13 +46,14 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
+    std::atomic<bool> interruptDummy(false);
     connman.reset(new CConnman());
     CNode::ClearBanned();
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1, false, interruptDummy);
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
@@ -60,16 +61,17 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
-    SendMessages(&dummyNode2, false);
+    SendMessages(&dummyNode2, false, interruptDummy);
     BOOST_CHECK(!CNode::IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(CNode::IsBanned(addr1));  // ... but 1 still should be
     Misbehaving(dummyNode2.GetId(), 50);
-    SendMessages(&dummyNode2, false);
+    SendMessages(&dummyNode2, false, interruptDummy);
     BOOST_CHECK(CNode::IsBanned(addr2));
 }
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
+    std::atomic<bool> interruptDummy(false);
     connman.reset(new CConnman());
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
@@ -77,19 +79,20 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1, false, interruptDummy);
     BOOST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 10);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1, false, interruptDummy);
     BOOST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 1);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1, false, interruptDummy);
     BOOST_CHECK(CNode::IsBanned(addr1));
     mapArgs.erase("-banscore");
 }
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
+    std::atomic<bool> interruptDummy(false);
     connman.reset(new CConnman());
     CNode::ClearBanned();
     int64_t nStartTime = GetTime();
@@ -98,7 +101,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
     Misbehaving(dummyNode.GetId(), 100);
-    SendMessages(&dummyNode, false);
+    SendMessages(&dummyNode, false, interruptDummy);
     BOOST_CHECK(CNode::IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);

--- a/src/threadinterrupt.cpp
+++ b/src/threadinterrupt.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "threadinterrupt.h"
+
+CThreadInterrupt::operator bool() const
+{
+    return flag.load(std::memory_order_acquire);
+}
+
+void CThreadInterrupt::reset()
+{
+    flag.store(false, std::memory_order_release);
+}
+
+void CThreadInterrupt::operator()()
+{
+    {
+        std::unique_lock<std::mutex> lock(mut);
+        flag.store(true, std::memory_order_release);
+    }
+    cond.notify_all();
+}
+

--- a/src/threadinterrupt.h
+++ b/src/threadinterrupt.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_THREADINTERRUPT_H
+#define BITCOIN_THREADINTERRUPT_H
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+/*
+    A helper class for interruptible sleeps. Calling operator() will interrupt
+    any current sleep, and after that point operator bool() will return true
+    until reset.
+*/
+class CThreadInterrupt
+{
+public:
+    explicit operator bool() const;
+    void operator()();
+    void reset();
+
+    template <typename chronodurationtype>
+    bool sleep_for(chronodurationtype rel_time) {
+        std::unique_lock<std::mutex> lock(mut);
+        return !cond.wait_for(lock, rel_time,
+            [this]() { return flag.load(std::memory_order_acquire); }
+        );
+    }
+
+private:
+    std::condition_variable cond;
+    std::mutex mut;
+    std::atomic<bool> flag;
+};
+
+#endif // BITCOIN_THREADINTERRUPT_H

--- a/src/zen/tlsmanager.cpp
+++ b/src/zen/tlsmanager.cpp
@@ -9,8 +9,6 @@
 #include "tlsmanager.h"
 #include "utiltls.h"
 
-extern std::unique_ptr<CConnman> connman;
-
 using namespace std;
 namespace zen
 {

--- a/src/zen/tlsmanager.cpp
+++ b/src/zen/tlsmanager.cpp
@@ -6,9 +6,6 @@
 #include <openssl/dh.h>
 #endif
 
-#include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
-
 #include "tlsmanager.h"
 #include "utiltls.h"
 

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -1,13 +1,14 @@
+#ifndef BITCOIN_TLSMANAGER_H
+#define BITCOIN_TLSMANAGER_H
+
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include "tlsenums.h"
 #include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
 #include "../util.h"
 #include "../net.h"
 #include "sync.h"
-#include <boost/filesystem/path.hpp>
 #include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 #ifdef WIN32
@@ -50,3 +51,5 @@ public:
      bool initialize();
 };
 }
+
+#endif // BITCOIN_TLSMANAGER_H

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -19,6 +19,8 @@
 
 using namespace std;
 
+extern std::unique_ptr<CConnman> connman;
+
 namespace zen
 {
 


### PR DESCRIPTION
This PR removes all the instances of `boost::thread` from the networking subsystem, in favor of STL `<thread>` library.
One key difference between the libraries is that `boost::thread`s are interruptible; this feature has been replicated by the newly introduced class `CThreadInterrupt`.
The PR also removes the `boost::condition_variable` as well, preferring the STL equivalent.
Finally, `boost::thread_group` has been removed as well, but it has not been replaced with anything equivalent.