### PR TITLE
Refactor sockets

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -212,6 +212,7 @@ BITCOIN_CORE_H = \
   undo.h \
   util.h \
   utilmoneystr.h \
+  util/sock.h \
   utilstrencodings.h \
   utiltime.h \
   validationinterface.h \
@@ -397,6 +398,7 @@ libbitcoin_common_a_SOURCES = \
   script/script_error.cpp \
   script/sign.cpp \
   script/standard.cpp \
+  util/sock.cpp \
   $(BITCOIN_CORE_H) \
   $(LIBZCASH_H)
 

--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -41,6 +41,7 @@ zen_gtest_SOURCES += \
 	gtest/test_pow.cpp \
 	gtest/test_random.cpp \
 	gtest/test_rpc.cpp \
+	gtest/test_sock.cpp \
 	gtest/test_getblocktemplate.cpp \
 	gtest/test_timedata.cpp \
 	gtest/test_transaction.cpp \

--- a/src/compat.h
+++ b/src/compat.h
@@ -89,6 +89,14 @@ typedef u_int SOCKET;
 #define THREAD_PRIORITY_ABOVE_NORMAL    (-2)
 #endif
 
+// The type of the option value passed to getsockopt & setsockopt
+// differs between Windows and non-Windows.
+#ifndef WIN32
+typedef void* sockopt_arg_type;
+#else
+typedef char* sockopt_arg_type;
+#endif
+
 #if HAVE_DECL_STRNLEN == 0
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN

--- a/src/compat.h
+++ b/src/compat.h
@@ -109,4 +109,11 @@ bool static inline IsSelectableSocket(SOCKET s) {
 #endif
 }
 
+// Note these both should work with the current usage of poll, but best to be safe
+// WIN32 poll is broken https://daniel.haxx.se/blog/2012/10/10/wsapoll-is-broken/
+// __APPLE__ poll is broke https://github.com/bitcoin/bitcoin/pull/14336#issuecomment-437384408
+#if defined(__linux__)
+#define USE_POLL
+#endif
+
 #endif // BITCOIN_COMPAT_H

--- a/src/gtest/test_asyncproofverifier.cpp
+++ b/src/gtest/test_asyncproofverifier.cpp
@@ -27,7 +27,7 @@ public:
         mempool.reset(new CTxMemPool(::minRelayTxFee, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1000000));
         connman.reset(new CConnman());
 
-        dummyNode.reset(new CNode(INVALID_SOCKET, CAddress(), "", true));
+        dummyNode.reset(new CNode(nullptr, CAddress(), "", true));
         dummyNode->id = 7;
 
         sidechain.creationBlockHeight = 100;

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -430,7 +430,7 @@ public:
     }
 
     CNodeExt():
-        CNode(INVALID_SOCKET, CAddress(ip(0xa0b0c002)), "", true)
+        CNode(nullptr, CAddress(ip(0xa0b0c002)), "", true)
     {
     }
 

--- a/src/gtest/test_sock.cpp
+++ b/src/gtest/test_sock.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "compat.h"
+#include "util/sock.h"
+
+static bool SocketIsClosed(const SOCKET& s)
+{
+    // Notice that if another thread is running and creates its own socket after `s` has been
+    // closed, it may be assigned the same file descriptor number. In this case, our test will
+    // wrongly pretend that the socket is not closed.
+    int type;
+    socklen_t len = sizeof(type);
+    return getsockopt(s, SOL_SOCKET, SO_TYPE, (sockopt_arg_type)&type, &len) == SOCKET_ERROR;
+}
+
+static SOCKET CreateSocket()
+{
+    const SOCKET s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s != static_cast<SOCKET>(SOCKET_ERROR));
+    return s;
+}
+
+
+TEST(Sock, ConstructorDestructor) {
+    SOCKET s = CreateSocket();
+    {
+        Sock sock(s);
+        ASSERT_EQ(sock.Get(), s);
+        ASSERT_FALSE(SocketIsClosed(s));
+    }
+    ASSERT_TRUE(SocketIsClosed(s));
+}
+
+TEST(Sock, MoveConstructor) {
+    SOCKET s = CreateSocket();
+    Sock sock(s);
+    ASSERT_EQ(sock.Get(), s);
+    ASSERT_FALSE(SocketIsClosed(s));
+
+    Sock sock2(std::move(sock));
+    ASSERT_EQ(sock.Get(), INVALID_SOCKET);
+    ASSERT_EQ(sock2.Get(), s);
+    ASSERT_FALSE(SocketIsClosed(s));
+}
+
+TEST(Sock, MoveAssignment) {
+    SOCKET s = CreateSocket();
+    Sock sock(s);
+    ASSERT_EQ(sock.Get(), s);
+    ASSERT_FALSE(SocketIsClosed(s));
+
+    Sock sock2 = std::move(sock);
+    ASSERT_EQ(sock.Get(), INVALID_SOCKET);
+    ASSERT_EQ(sock2.Get(), s);
+    ASSERT_FALSE(SocketIsClosed(s));
+}
+
+TEST(Sock, Reset) {
+    const SOCKET s = CreateSocket();
+    Sock sock(s);
+    ASSERT_FALSE(SocketIsClosed(s));
+    sock.Reset();
+    ASSERT_TRUE(SocketIsClosed(s));
+}
+
+#ifndef WIN32 // Windows does not have socketpair(2).
+
+static void CreateSocketPair(int s[2]) {
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, s) == 0);
+}
+
+static void SendAndRecvMessage(const Sock& sender, const Sock& receiver) {
+    const char* msg = "abcd";
+    constexpr size_t msg_len = 4;
+    char recv_buf[10];
+
+    ASSERT_EQ(sender.Send(msg, msg_len, 0), msg_len);
+    ASSERT_EQ(receiver.Recv(recv_buf, sizeof(recv_buf), 0), msg_len);
+    ASSERT_EQ(strncmp(msg, recv_buf, msg_len), 0);
+}
+
+TEST(Sock, SendAndReceive) {
+    int s[2];
+    CreateSocketPair(s);
+
+    {
+        Sock sock0(s[0]);
+        Sock sock1(s[1]);
+
+        SendAndRecvMessage(sock0, sock1);
+
+        Sock sock0moved = std::move(sock0);
+        Sock sock1moved = std::move(sock1);
+
+        SendAndRecvMessage(sock1moved, sock0moved);
+    }
+
+    ASSERT_TRUE(SocketIsClosed(s[0]));
+    ASSERT_TRUE(SocketIsClosed(s[1]));
+}
+
+TEST(Sock, Wait)
+{
+    int s[2];
+    CreateSocketPair(s);
+
+    Sock sock0(s[0]);
+    Sock sock1(s[1]);
+
+    constexpr int64_t millis_in_day = 24 * 60 * 60 * 1000;
+    std::thread waiter([&sock0]() { ASSERT_EQ(sock0.Wait(millis_in_day, Sock::RECV), 1); });
+
+    ASSERT_EQ(sock1.Send("a", 1, 0), 1);
+
+    waiter.join();
+}
+
+#endif /* WIN32 */
+

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -223,7 +223,7 @@ int printStats(bool mining)
     {
         LOCK2(cs_main, connman->cs_vNodes);
         connections = connman->vNodes.size();
-        tlsConnections = std::count_if(connman->vNodes.begin(), connman->vNodes.end(), [](CNode* n) {return n->ssl != NULL;});
+        tlsConnections = std::count_if(connman->vNodes.begin(), connman->vNodes.end(), [](CNode* n) {return n->GetSSL() != nullptr;});
     }
     unsigned long mempool_count = mempool->size();
 /*

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -464,7 +464,7 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
 
     // Set the no-delay option (disable Nagle's algorithm) on the TCP socket.
     const int on{1};
-    if (sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) == SOCKET_ERROR) {
+    if (sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, (sockopt_arg_type)&on, sizeof(on)) == SOCKET_ERROR) {
         LogPrint("net", "Unable to set TCP_NODELAY on a newly created socket, continuing anyway\n");
     }
 
@@ -500,11 +500,7 @@ std::unique_ptr<Sock> static ConnectSocketDirectly(const CService &addrConnect, 
 #endif
 
     //Disable Nagle's algorithm
-#ifdef WIN32
-    sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, (const char*)&set, sizeof(int));
-#else
-    sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, (void*)&set, sizeof(int));
-#endif
+    sock->SetSockOpt(IPPROTO_TCP, TCP_NODELAY, (sockopt_arg_type)&set, sizeof(int));
 
     // Set to non-blocking
     if (!sock->SetNonBlocking()) {

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,6 +11,7 @@
 
 #include "compat.h"
 #include "serialize.h"
+#include "util/sock.h"
 
 #include <stdint.h>
 #include <string>
@@ -195,12 +196,23 @@ bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nM
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault = 0, bool fAllowLookup = true, unsigned int nMaxSolutions = 0);
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
-bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
-bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
+
+/**
+ * Create a TCP socket in the given address family.
+ * @param[in] address_family The socket is created in the same address family as this address.
+ * @return pointer to the created Sock object or unique_ptr that owns nothing in case of failure
+ */
+std::unique_ptr<Sock> CreateSockTCP(const CService& address_family);
+
+/**
+ * Socket factory. Defaults to `CreateSockTCP()`, but can be overridden by unit tests.
+ */
+extern std::function<std::unique_ptr<Sock>(const CService&)> CreateSock;
+
+bool ConnectSocket(const CService &addr, Sock& sock, int nTimeout, bool *outProxyConnectionFailed = 0);
+bool ConnectSocketByName(CService &addr, Sock& sock, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
-/** Close socket and set hSocket to INVALID_SOCKET */
-bool CloseSocket(SOCKET& hSocket);
 /** Disable or enable blocking-mode for a socket */
 bool SetSocketNonBlocking(SOCKET& hSocket, bool fNonBlocking);
 /**

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -209,8 +209,8 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family);
  */
 extern std::function<std::unique_ptr<Sock>(const CService&)> CreateSock;
 
-bool ConnectSocket(const CService &addr, Sock& sock, int nTimeout, bool *outProxyConnectionFailed = 0);
-bool ConnectSocketByName(CService &addr, Sock& sock, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
+std::unique_ptr<Sock> ConnectSocket(const CService &addr, int nTimeout, bool *outProxyConnectionFailed = 0);
+std::unique_ptr<Sock> ConnectSocketByName(CService &addr, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 /** Disable or enable blocking-mode for a socket */

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     connman.reset(new CConnman());
     CNode::ClearBanned();
     CAddress addr1(ip(0xa0b0c001));
-    CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+    CNode dummyNode1(nullptr, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     SendMessages(&dummyNode1, false, interruptDummy);
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
     CAddress addr2(ip(0xa0b0c002));
-    CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+    CNode dummyNode2(nullptr, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2, false, interruptDummy);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
     CAddress addr1(ip(0xa0b0c001));
-    CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+    CNode dummyNode1(nullptr, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1, false, interruptDummy);
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
     CAddress addr(ip(0xa0b0c001));
-    CNode dummyNode(INVALID_SOCKET, addr, "", true);
+    CNode dummyNode(nullptr, addr, "", true);
     dummyNode.nVersion = 1;
     Misbehaving(dummyNode.GetId(), 100);
     SendMessages(&dummyNode, false, interruptDummy);

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -1,0 +1,260 @@
+#include "compat.h"
+#include "tinyformat.h"
+#include "sock.h"
+#include "util.h"
+
+#include <codecvt>
+#include <cwchar>
+#include <locale>
+#include <string>
+
+#ifdef USE_POLL
+#include <poll.h>
+#endif
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+Sock::Sock() : m_socket(INVALID_SOCKET), m_ssl(nullptr) {}
+
+Sock::Sock(SOCKET s, SSL* ssl) : m_socket(s), m_ssl(ssl) {}
+
+Sock::Sock(Sock&& other)
+{
+    m_socket = other.m_socket;
+    m_ssl    = other.m_ssl;
+    other.m_socket = INVALID_SOCKET;
+    other.m_ssl    = nullptr;
+}
+
+Sock::~Sock() { Reset(); }
+
+Sock& Sock::operator=(Sock&& other)
+{
+    Reset();
+    m_socket = other.m_socket;
+    m_ssl    = other.m_ssl;
+    other.m_socket = INVALID_SOCKET;
+    other.m_ssl    = nullptr;
+    return *this;
+}
+
+SOCKET Sock::Get() const { return m_socket; }
+
+SSL* Sock::GetSSL() const { return m_ssl; }
+bool Sock::SetSSL(SSL* ssl) {
+    if (m_ssl) {
+        SSL_free(m_ssl);
+    }
+
+    m_ssl = ssl;
+    if (!m_ssl) {
+        return false;
+    }
+    return SSL_set_fd(m_ssl, m_socket);
+}
+
+/*
+SOCKET Sock::Release()
+{
+    const SOCKET s = m_socket;
+    m_socket = INVALID_SOCKET;
+    return s;
+}
+*/
+
+bool Sock::Reset() { return Close(); }
+
+ssize_t Sock::Send(const void* data, size_t len, int flags) const
+{
+    if (m_ssl) {
+        ERR_clear_error(); // clear the error queue
+        return SSL_write(m_ssl, static_cast<const char*>(data), len);
+    }
+    return send(m_socket, static_cast<const char*>(data), len, flags);
+}
+
+ssize_t Sock::Recv(void* buf, size_t len, int flags) const
+{
+    if (m_ssl) {
+        ERR_clear_error(); // clear the error queue
+        return SSL_read(m_ssl, static_cast<char*>(buf), len);
+    }
+    return recv(m_socket, static_cast<char*>(buf), len, flags);
+}
+
+int Sock::Wait(int64_t timeout, Event requested) const
+{
+#ifdef USE_POLL
+    pollfd fd;
+    fd.fd = m_socket;
+    fd.events = 0;
+    if (requested & RECV) {
+        fd.events |= POLLIN;
+    }
+    if (requested & SEND) {
+        fd.events |= POLLOUT;
+    }
+
+    return poll(&fd, 1, count_milliseconds(timeout));
+#else
+    if (!IsSelectable()) {
+        return -1;
+    }
+
+    fd_set fdset_recv;
+    fd_set fdset_send;
+    FD_ZERO(&fdset_recv);
+    FD_ZERO(&fdset_send);
+
+    if (requested & RECV) {
+        FD_SET(m_socket, &fdset_recv);
+    }
+
+    if (requested & SEND) {
+        FD_SET(m_socket, &fdset_send);
+    }
+
+    timeval timeout_struct = MillisToTimeval(timeout);
+
+    return select(m_socket + 1, &fdset_recv, &fdset_send, nullptr, &timeout_struct);
+#endif /* USE_POLL */
+}
+
+
+#ifdef WIN32
+std::string NetworkErrorString(int err)
+{
+    wchar_t buf[256];
+    buf[0] = 0;
+    if(FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+            nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            buf, ARRAYSIZE(buf), nullptr))
+    {
+        return strprintf("%s (%d)", std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf), err);
+    }
+    else
+    {
+        return strprintf("Unknown error (%d)", err);
+    }
+}
+#else
+std::string NetworkErrorString(int err)
+{
+    char buf[256];
+    buf[0] = 0;
+    /* Too bad there are two incompatible implementations of the
+     * thread-safe strerror. */
+    const char *s;
+#ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
+    s = strerror_r(err, buf, sizeof(buf));
+#else /* POSIX variant always returns message in buffer */
+    s = buf;
+    if (strerror_r(err, buf, sizeof(buf)))
+        buf[0] = 0;
+#endif
+    return strprintf("%s (%d)", s, err);
+}
+#endif
+
+bool Sock::Close()
+{
+        LogPrintf("CLosing socket: %d. Error: %s\n", m_socket, NetworkErrorString(WSAGetLastError()));
+    if (m_ssl) {
+        SSL_free(m_ssl);
+        m_ssl = nullptr;
+    }
+
+    if (m_socket == INVALID_SOCKET)
+        return false;
+#ifdef WIN32
+    int ret = closesocket(m_socket);
+#else
+    int ret = close(m_socket);
+#endif
+    if (ret) {
+        LogPrintf("Socket close failed: %d. Error: %s\n", m_socket, NetworkErrorString(WSAGetLastError()));
+    }
+    m_socket = INVALID_SOCKET;
+    return ret != SOCKET_ERROR;
+}
+
+int Sock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
+{
+    return getsockopt(m_socket, level, opt_name, static_cast<char*>(opt_val), opt_len);
+}
+
+int Sock::SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const
+{
+    return setsockopt(m_socket, level, opt_name, static_cast<const char*>(opt_val), opt_len);
+}
+
+bool Sock::SetNonBlocking() const
+{
+#ifdef WIN32
+    u_long on{1};
+    if (ioctlsocket(m_socket, FIONBIO, &on) == SOCKET_ERROR) {
+        return false;
+    }
+#else
+    const int flags{fcntl(m_socket, F_GETFL, 0)};
+    if (flags == SOCKET_ERROR) {
+        return false;
+    }
+    if (fcntl(m_socket, F_SETFL, flags | O_NONBLOCK) == SOCKET_ERROR) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool Sock::IsSelectable() const
+{
+#if defined(USE_POLL) || defined(WIN32)
+    return true;
+#else
+    return m_socket < FD_SETSIZE;
+#endif
+}
+
+int Sock::Connect(const sockaddr* addr, socklen_t addr_len) const
+{
+    return connect(m_socket, addr, addr_len);
+}
+
+std::unique_ptr<Sock> Sock::Accept(sockaddr* addr, socklen_t* addr_len) const
+{
+#ifdef WIN32
+    static constexpr auto ERR = INVALID_SOCKET;
+#else
+    static constexpr auto ERR = SOCKET_ERROR;
+#endif
+
+    std::unique_ptr<Sock> sock;
+
+    const SOCKET socket = accept(m_socket, addr, addr_len);
+    if (socket != ERR) {
+        try {
+            sock = std::make_unique<Sock>(socket);
+        } catch (const std::exception&) {
+#ifdef WIN32
+            closesocket(socket);
+#else
+            close(socket);
+#endif
+        }
+    }
+
+    return sock;
+}
+
+int Sock::Bind(const sockaddr* addr, socklen_t addr_len) const
+{
+    return bind(m_socket, addr, addr_len);
+}
+
+int Sock::Listen(int backlog) const
+{
+    return listen(m_socket, backlog);
+}
+

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <memory>
+
+#include "compat.h"
+
+typedef struct ssl_st SSL;
+
+class Sock
+{
+public:
+    /**
+     * Default constructor, creates an empty object that does nothing when destroyed.
+     */
+    Sock();
+
+    /**
+     * Take ownership of an existent socket.
+     */
+    explicit Sock(SOCKET s, SSL* ssl = nullptr);
+
+    /**
+     * Copy constructor, disabled because closing the same socket twice is undesirable.
+     */
+    Sock(const Sock&) = delete;
+
+    /**
+     * Move constructor, grab the socket from another object and close ours (if set).
+     */
+    Sock(Sock&& other);
+
+    /**
+     * Destructor, close the socket or do nothing if empty.
+     */
+    virtual ~Sock();
+
+    /**
+     * Copy assignment operator, disabled because closing the same socket twice is undesirable.
+     */
+    Sock& operator=(const Sock&) = delete;
+
+    /**
+     * Move assignment operator, grab the socket from another object and close ours (if set).
+     */
+    virtual Sock& operator=(Sock&& other);
+
+    /**
+     * Get the value of the contained socket.
+     * @return socket or INVALID_SOCKET if empty
+     */
+    virtual SOCKET Get() const;
+
+    virtual SSL* GetSSL() const;
+    virtual bool SetSSL(SSL* ssl);
+
+    /**
+     * Get the value of the contained socket and drop ownership. It will not be closed by the
+     * destructor after this call.
+     * @return socket or INVALID_SOCKET if empty
+     */
+    //virtual SOCKET Release();
+
+    /**
+     * Close if non-empty.
+     */
+    virtual bool Reset();
+
+    /**
+     * send(2) wrapper. Equivalent to `send(this->Get(), data, len, flags);`. Code that uses this
+     * wrapper can be unit-tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual ssize_t Send(const void* data, size_t len, int flags) const;
+
+    /**
+     * recv(2) wrapper. Equivalent to `recv(this->Get(), buf, len, flags);`. Code that uses this
+     * wrapper can be unit-tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual ssize_t Recv(void* buf, size_t len, int flags) const;
+
+    using Event = uint8_t;
+
+    /**
+     * If passed to `Wait()`, then it will wait for readiness to read from the socket.
+     */
+    static constexpr Event RECV = 0b01;
+
+    /**
+     * If passed to `Wait()`, then it will wait for readiness to send to the socket.
+     */
+    static constexpr Event SEND = 0b10;
+
+    /**
+     * Wait for readiness for input (recv) or output (send).
+     * @param[in] timeout Wait this much for at least one of the requested events to occur.
+     * @param[in] requested Wait for those events, bitwise-or of `RECV` and `SEND`.
+     * @return true on success and false otherwise
+     */
+    virtual int Wait(int64_t timeout, Event requested) const;
+    int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const;
+    int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const;
+    bool SetNonBlocking() const;
+    bool IsSelectable() const;
+    int Connect(const sockaddr* addr, socklen_t addr_len) const;
+    std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const;
+    int Bind(const sockaddr* addr, socklen_t addr_len) const;
+    int Listen(int backlog) const;
+
+private:
+    /**
+     * Contained socket. `INVALID_SOCKET` designates the object is empty.
+     */
+    SOCKET m_socket;
+    SSL*   m_ssl; // TODO: remember to free this!!!
+
+    /** Close socket and set hSocket to INVALID_SOCKET */
+    bool Close();
+};
+
+/** Return readable error string for a network error code */
+std::string NetworkErrorString(int err);
+
+struct timeval MillisToTimeval(int64_t nTimeout);

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -16,8 +16,7 @@
 #else
 #include <fcntl.h>
 #endif
-
-using namespace std;
+#include "util/sock.h"
 
 extern std::unique_ptr<CConnman> connman;
 
@@ -28,17 +27,16 @@ namespace zen
  * @brief A class to wrap some of zen specific TLS functionalities used in the net.cpp
  * 
  */
-class TLSManager
+namespace TLSManager
 {
-public:
      /* This is set as a custom error number which is not an error in OpenSSL protocol.
         A true (not null) OpenSSL error returned by ERR_get_error() consists of a library number,
         function code and reason code. */
      static const long SELECT_TIMEDOUT = 0xFFFFFFFF;
 
-     int waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, SSL* ssl, int timeoutMilliSec, unsigned long& err_code);
+     int waitFor(SSLConnectionRoutine eRoutine, const CAddress& peerAddress, Sock& sock, int timeoutMilliSec, unsigned long& err_code);
 
-     SSL* connect(SOCKET hSocket, const CAddress& addrConnect, unsigned long& err_code);
+     SSL* connect(Sock& sock, const CAddress& addrConnect, unsigned long& err_code);
      SSL_CTX* initCtx(
         TLSContextType ctxType,
         const boost::filesystem::path& privateKeyFile,
@@ -46,8 +44,8 @@ public:
         const std::vector<boost::filesystem::path>& trustedDirs);
 
      bool prepareCredentials();
-     SSL* accept(SOCKET hSocket, const CAddress& addr, unsigned long& err_code);
-     bool isNonTLSAddr(const string& strAddr, const vector<NODE_ADDR>& vPool, CCriticalSection& cs);
+     SSL* accept(Sock& sock, const CAddress& addr, unsigned long& err_code);
+     bool isNonTLSAddr(const std::string& strAddr, const std::vector<NODE_ADDR>& vPool, CCriticalSection& cs);
      void cleanNonTLSPool(std::vector<NODE_ADDR>& vPool, CCriticalSection& cs);
      int threadSocketHandler(CNode* pnode, fd_set& fdsetRecv, fd_set& fdsetSend, fd_set& fdsetError);
      bool initialize();

--- a/src/zen/tlsmanager.h
+++ b/src/zen/tlsmanager.h
@@ -47,7 +47,7 @@ namespace TLSManager
      SSL* accept(Sock& sock, const CAddress& addr, unsigned long& err_code);
      bool isNonTLSAddr(const std::string& strAddr, const std::vector<NODE_ADDR>& vPool, CCriticalSection& cs);
      void cleanNonTLSPool(std::vector<NODE_ADDR>& vPool, CCriticalSection& cs);
-     int threadSocketHandler(CNode* pnode, fd_set& fdsetRecv, fd_set& fdsetSend, fd_set& fdsetError);
+     int threadSocketHandler(CNode* pnode, const std::unordered_map<SOCKET, Sock::Events>& events);
      bool initialize();
 };
 }


### PR DESCRIPTION
This PR stems from Bitcoin PR20788, with the goal of making sockets handling safer and better encapsulated.
All direct accesses to SOCKET fds are now handled in the `Sock` class, which ensures that sockets and associated SSL sessions are closed properly on destruction.

Finally, this PR switches Linux syscall to wait on sockets from `select()` to `poll()`, achieving more flexibility in terms of usable fds, and possibly better performance.