### PR TITLE
Update libzendoo to 0.5.0

### DIFF
--- a/contrib/debian/examples/mc_crypto_log_config.yaml
+++ b/contrib/debian/examples/mc_crypto_log_config.yaml
@@ -2,7 +2,7 @@ appenders:
 
   file:
     kind: rolling_file
-    path: test_log.log
+    path: FILENAME_PLACEHOLDER
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S)} | {({l}):5.5} | {f}:{L} — {m}{n}"
     policy:
@@ -11,7 +11,7 @@ appenders:
         limit: 10 kb
       roller:
         kind: fixed_window
-        pattern: test_log_{}.gz
+        pattern: FILENAME_PLACEHOLDER{}.gz
         count: 5
         base: 1
 

--- a/contrib/debian/examples/sample_log_config.yaml
+++ b/contrib/debian/examples/sample_log_config.yaml
@@ -1,0 +1,21 @@
+appenders:
+
+  file:
+    kind: rolling_file
+    path: test_log.log
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S)} | {({l}):5.5} | {f}:{L} — {m}{n}"
+    policy:
+      trigger:
+        kind: size
+        limit: 10 kb
+      roller:
+        kind: fixed_window
+        pattern: test_log_{}.gz
+        count: 5
+        base: 1
+
+root:
+  level: info
+  appenders:
+    - file

--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -1,10 +1,10 @@
 package=libzendoo
-$(package)_version=0.4.0
+$(package)_version=0.5.0
 $(package)_download_path=https://github.com/HorizenOfficial/zendoo-mc-cryptolib/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=e6941f27a1d8612b5a5c61f9d9f3fe0c6c977bb67726819440dc4c4f19f2c733
-$(package)_git_commit=7a1496312b1bcef259aa336e8477e3724a5e0df3
+$(package)_sha256_hash=b0b9d47a2a84a3fcc682658bc8a4afbc691277c31944855ee1a0d16eac4a0c5b
+$(package)_git_commit=21edcf2a03feed2730da410ea2d446a2223954c9
 $(package)_dependencies=rust
 $(package)_patches=cargo.config mcTest-compiler-flag.patch
 

--- a/qa/rpc-tests/test_framework/mc_test/mc_test.py
+++ b/qa/rpc-tests/test_framework/mc_test/mc_test.py
@@ -34,6 +34,8 @@ class MCTestUtils(object):
         args = [os.getenv("ZENDOOMC", os.path.join(self.srcdir, "zendoo/mcTest"))]
 
         args += [op, "-c", str(circuit_type), "-p", str(ps_type), "-s", str(segment_size), "-n", str(num_constraints)]
+        # we always use node0's cfg file, but we expect all these to be equal
+        args += ["-l", self.datadir + "/node0/sample_log_config.yaml"]
 
         if constant is not None and constant != False:
             args.append("-k")

--- a/qa/rpc-tests/test_framework/mc_test/mc_test.py
+++ b/qa/rpc-tests/test_framework/mc_test/mc_test.py
@@ -35,7 +35,7 @@ class MCTestUtils(object):
 
         args += [op, "-c", str(circuit_type), "-p", str(ps_type), "-s", str(segment_size), "-n", str(num_constraints)]
         # we always use node0's cfg file, but we expect all these to be equal
-        args += ["-l", self.datadir + "/node0/sample_log_config.yaml"]
+        args += ["-l", self.datadir + "/node0/mc_crypto_log_config.yaml"]
 
         if constant is not None and constant != False:
             args.append("-k")

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -149,6 +149,9 @@ def initialize_datadir(dirname, n):
         f.write("listenonion=0\n")
 #        f.write("debug=net\n")
 #        f.write("logtimemicros=1\n")
+
+    mc_crypto_cfg_file = os.path.join(os.path.dirname(__file__), "../../../contrib/debian/examples/sample_log_config.yaml")
+    shutil.copy(mc_crypto_cfg_file, os.path.join(datadir, "sample_log_config.yaml"))
     return datadir
 
 def rpc_url(i, rpchost=None):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -150,8 +150,12 @@ def initialize_datadir(dirname, n):
 #        f.write("debug=net\n")
 #        f.write("logtimemicros=1\n")
 
-    mc_crypto_cfg_file = os.path.join(os.path.dirname(__file__), "../../../contrib/debian/examples/sample_log_config.yaml")
-    shutil.copy(mc_crypto_cfg_file, os.path.join(datadir, "sample_log_config.yaml"))
+    mc_crypto_cfg_file = os.path.join(os.path.dirname(__file__), "../../../contrib/debian/examples/mc_crypto_log_config.yaml")
+    with open(os.path.join(datadir, "mc_crypto_log_config.yaml"), 'w') as o:
+        with open(mc_crypto_cfg_file, 'r') as f:
+            content = f.read()
+            content_new = re.sub('FILENAME_PLACEHOLDER', os.path.join(datadir, "mc_crypto.log"), content, flags = re.M)
+        o.write(content_new)
     return datadir
 
 def rpc_url(i, rpchost=None):

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -447,6 +447,10 @@ zend_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 zend_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(COVERAGE_FLAGS)
 zend_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(COVERAGE_FLAGS)
 
+if TARGET_DARWIN
+zend_LDFLAGS += -framework CoreFoundation
+endif
+
 if TARGET_WINDOWS
 zend_SOURCES += bitcoind-res.rc
 endif
@@ -647,6 +651,9 @@ zendoo_mcTest_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(COVERAGE_FLAGS)
 zendoo_mcTest_LDADD = $(ZENDOO_MCTEST_LIBS)
 zendoo_mcTest_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(COVERAGE_FLAGS)
 
+if TARGET_DARWIN
+zendoo_mcTest_LDFLAGS += -framework CoreFoundation
+endif
 
 
 CLEANFILES = leveldb/libleveldb.a leveldb/libmemenv.a *.gcda *.gcno */*.gcno wallet/*/*.gcno zen/*/*.gcno

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -36,6 +36,108 @@
  * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
  */
 
+namespace {
+
+void CopyDefaultConfigFile(const std::string& destination, const std::string& filename) {
+    try
+    {
+        // Warn user about using default config file
+        fprintf(stdout,
+            "------------------------------------------------------------------\n"
+            "                        WARNING:\n"
+            "Automatically copying the default config file to:\n"
+            "\n"
+#ifdef  __APPLE__
+            "~/Library/Application Support/Zen\n"
+#else
+            "~/.zen/%s\n"
+#endif
+            "\n"
+            " Running the default configuration file without review is considered a potential risk, as zend\n"
+            " might accidentally compromise your privacy if there is a default option that you need to change!\n"
+            "\n"
+            "           Please restart zend to continue.\n"
+            "           You will not see this warning again.\n"
+            "------------------------------------------------------------------\n", filename.c_str());
+
+
+#ifdef __APPLE__
+        // On Mac OS try to copy the default config file if zend is started from source folder zen/src/zend
+        std::string strConfPath("../contrib/debian/examples/" + filename);
+        if (!boost::filesystem::exists(strConfPath)){
+            strConfPath = "contrib/debian/examples/" + filename;
+        }
+#else
+        std::string strConfPath("/usr/share/doc/zen/examples/" + filename);
+
+        if (!boost::filesystem::exists(strConfPath))
+        {
+            strConfPath = "contrib/debian/examples/" + filename;
+        }
+
+        if (!boost::filesystem::exists(strConfPath))
+        {
+            strConfPath = "../contrib/debian/examples/" + filename;
+        }
+#endif
+        // Copy default config file
+        std::ifstream src(strConfPath, std::ios::binary);
+        src.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+        std::ofstream dst(destination.c_str(), std::ios::binary);
+        dst << src.rdbuf();
+    } catch (const std::exception& e) {
+        fprintf(stdout,
+            "------------------------------------------------------------------\n"
+            " There was an error copying the default configuration file!!!!\n"
+            "\n"
+            " Please create a configuration file in the data directory.\n"
+            " The default application data directories are:\n"
+            " Windows (pre Vista): C:\\Documents and Settings\\Username\\Application Data\\Zen\n"
+            " Windows (Vista and later): C:\\Users\\Username\\AppData\\Roaming\\Zen\n"
+            "\n"
+            " You can find the default configuration file at:\n"
+            " https://github.com/HorizenOfficial/zen/blob/master/contrib/debian/examples/%s\n"
+            "\n"
+            "                        WARNING:\n"
+            " Running the default configuration file without review is considered a potential risk, as zend\n"
+            " might accidentally compromise your privacy if there is a default option that you need to change!\n"
+            "------------------------------------------------------------------\n", filename.c_str());
+        fprintf(stderr, "Error copying configuration file: %s\n", e.what());
+    }
+}
+
+#ifdef WIN32
+void PrintFileMissingError(const std::string& filename) {
+    fprintf(stdout,
+        "------------------------------------------------------------------\n"
+        "                        ERROR:\n"
+        " The configuration file %s is missing.\n"
+        " Please create a valid %s in the application data directory.\n"
+        " The default application data directories are:\n"
+        "\n"
+        " Windows (pre Vista): C:\\Documents and Settings\\Username\\Application Data\\Zen\n"
+        " Windows (Vista and later): C:\\Users\\Username\\AppData\\Roaming\\Zen\n"
+        "\n"
+        " You can find the default configuration file at:\n"
+        " https://github.com/HorizenOfficial/zen/blob/master/contrib/debian/examples/%s\n"
+        "\n"
+        "                        WARNING:\n"
+        " Running the default configuration file without review is considered a potential risk, as zend\n"
+        " might accidentally compromise your privacy if there is a default option that you need to change!\n"
+        "\n"
+        " Please create a valid %s and restart to zend continue.\n"
+        "------------------------------------------------------------------\n",
+        filename.c_str(),
+        filename.c_str(),
+        filename.c_str(),
+        filename.c_str()
+        );
+}
+#endif
+
+} // namespace
+
 static bool fDaemon;
 
 void WaitForShutdown(boost::thread_group* threadGroup)
@@ -99,105 +201,38 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
             return false;
         }
+
+        bool should_return = false;
+        // zen.conf
         try
         {
             ReadConfigFile(mapArgs, mapMultiArgs);
         } catch (const missing_zcash_conf& e) {
-            try
-            {
 
 #ifdef WIN32
-                fprintf(stdout,
-                    "------------------------------------------------------------------\n"
-                    "                        ERROR:\n"
-                    " The configuration file zen.conf is missing.\n"
-                    " Please create a valid zen.conf in the application data directory.\n"
-                    " The default application data directories are:\n"
-                    "\n"
-                    " Windows (pre Vista): C:\\Documents and Settings\\Username\\Application Data\\Zen\n"
-                    " Windows (Vista and later): C:\\Users\\Username\\AppData\\Roaming\\Zen\n"
-                    "\n"
-                    " You can find the default configuration file at:\n"
-                    " https://github.com/HorizenOfficial/zen/blob/master/contrib/debian/examples/zen.conf\n"
-                    "\n"
-                    "                        WARNING:\n"
-                    " Running the default configuration file without review is considered a potential risk, as zend\n"
-                    " might accidentally compromise your privacy if there is a default option that you need to change!\n"
-                    "\n"
-                    " Please create a valid zen.conf and restart to zend continue.\n"
-                    "------------------------------------------------------------------\n");
-                return false;
-#endif
-                // Warn user about using default config file
-                fprintf(stdout,
-                    "------------------------------------------------------------------\n"
-                    "                        WARNING:\n"
-                    "Automatically copying the default config file to:\n"
-                    "\n"
-#ifdef  __APPLE__
-                    "~/Library/Application Support/Zen\n"
+            PrintFileMissingError("zen.conf");
 #else
-                    "~/.zen/zen.conf\n"
+            CopyDefaultConfigFile(GetConfigFile().string(), "zen.conf");
 #endif
-                    "\n"
-                    " Running the default configuration file without review is considered a potential risk, as zend\n"
-                    " might accidentally compromise your privacy if there is a default option that you need to change!\n"
-                    "\n"
-                    "           Please restart zend to continue.\n"
-                    "           You will not see this warning again.\n"
-                    "------------------------------------------------------------------\n");
-
-
-#ifdef __APPLE__
-                // On Mac OS try to copy the default config file if zend is started from source folder zen/src/zend
-                std::string strConfPath("../contrib/debian/examples/zen.conf");
-                if (!boost::filesystem::exists(strConfPath)){
-                    strConfPath = "contrib/debian/examples/zen.conf";
-                }
-#else
-                std::string strConfPath("/usr/share/doc/zen/examples/zen.conf");
-
-                if (!boost::filesystem::exists(strConfPath))
-                {
-                    strConfPath = "contrib/debian/examples/zen.conf";
-                }
-
-                if (!boost::filesystem::exists(strConfPath))
-                {
-                    strConfPath = "../contrib/debian/examples/zen.conf";
-                }
-#endif
-                // Copy default config file
-                std::ifstream src(strConfPath, std::ios::binary);
-                src.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-
-                std::ofstream dst(GetConfigFile().string().c_str(), std::ios::binary);
-                dst << src.rdbuf();
-                return false;
-            } catch (const std::exception& e) {
-                fprintf(stdout,
-                    "------------------------------------------------------------------\n"
-                    " There was an error copying the default configuration file!!!!\n"
-                    "\n"
-                    " Please create a configuration file in the data directory.\n"
-                    " The default application data directories are:\n"
-                    " Windows (pre Vista): C:\\Documents and Settings\\Username\\Application Data\\Zen\n"
-                    " Windows (Vista and later): C:\\Users\\Username\\AppData\\Roaming\\Zen\n"
-                    "\n"
-                    " You can find the default configuration file at:\n"
-                    " https://github.com/HorizenOfficial/zen/blob/master/contrib/debian/examples/zen.conf\n"
-                    "\n"
-                    "                        WARNING:\n"
-                    " Running the default configuration file without review is considered a potential risk, as zend\n"
-                    " might accidentally compromise your privacy if there is a default option that you need to change!\n"
-                    "------------------------------------------------------------------\n");
-                fprintf(stderr, "Error copying configuration file: %s\n", e.what());
-                return false;
-            }
+            should_return = true;
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
+            should_return = true;
+        }
+
+        // sample_log_config.yaml
+        if (!boost::filesystem::exists(GetMcCryptoConfigFile())) {
+#ifdef WIN32
+            PrintFileMissingError("sample_log_config.yaml");
+#else
+            CopyDefaultConfigFile(GetMcCryptoConfigFile().string(), "sample_log_config.yaml");
+#endif
+            should_return = true;
+        }
+        if (should_return) {
             return false;
         }
+
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
         if (!SelectParamsFromCommandLine()) {
             fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1249,6 +1249,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if(!Sidechain::InitSidechainsFolder())
         return InitError(strprintf(_("Cannot create or access sidechains folder.")));
 
+    // Initialize Zendoo
+    if(!Sidechain::InitZendoo())
+        return InitError(strprintf(_("Cannot initialize Zendoo.")));
+
     // Initialize DLog keys
     if(!Sidechain::InitDLogKeys())
         return InitError(strprintf(_("Cannot initialize DLog keys in sidechains folder.")));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -324,6 +324,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), 288));
     strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), 3));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), "zen.conf"));
+    strUsage += HelpMessageOpt("-mc_crypto_conf=<file>", strprintf(_("Specify configuration file for libzendoo logging (default: %s)"), "mc_crypto_log_config.yaml"));
     if (mode == HMM_BITCOIND)
     {
 #if !defined(WIN32)

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -26,7 +26,7 @@ bool Sidechain::InitZendoo()
 
     const std::string cfg_path = GetMcCryptoConfigFile().string();
     zendoo_init(
-        (path_char_t const*) cfg_path.c_str(),
+        reinterpret_cast<path_char_t const*>(cfg_path.c_str()),
         cfg_path.size(),
         &ret_code
     );

--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -20,6 +20,24 @@ static const boost::filesystem::path Sidechain::GetSidechainDataDir()
     return sidechainsDataDir;
 }
 
+bool Sidechain::InitZendoo()
+{
+    CctpErrorCode ret_code = CctpErrorCode::OK;
+
+    const std::string cfg_path = GetMcCryptoConfigFile().string();
+    zendoo_init(
+        (path_char_t const*) cfg_path.c_str(),
+        cfg_path.size(),
+        &ret_code
+    );
+
+    if (ret_code != CctpErrorCode::OK) {
+        return error("%s():%d - ERROR: Failed initializing Zendoo library, err %d\n",
+            __func__, __LINE__, ret_code);
+    }
+    return true;
+}
+
 bool Sidechain::InitDLogKeys()
 {
     CctpErrorCode errorCode;

--- a/src/sc/sidechain.h
+++ b/src/sc/sidechain.h
@@ -12,6 +12,7 @@ class CCoinsViewCache;
 namespace Sidechain
 {
     static const boost::filesystem::path GetSidechainDataDir();
+    bool InitZendoo();
     bool InitDLogKeys();
     bool InitSidechainsFolder();
     void ClearSidechainsFolder();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -198,6 +198,11 @@ boost::filesystem::path GetDebugLogPath()
     return GetDataDir() / "debug.log";
 }
 
+boost::filesystem::path GetMCCryptoLogPath()
+{
+    return GetDataDir(false) / "mc_crypto.log";
+}
+
 void OpenDebugLog()
 {
     boost::call_once(&DebugPrintInit, debugPrintInitFlag);
@@ -627,7 +632,7 @@ boost::filesystem::path GetConfigFile()
 
 boost::filesystem::path GetMcCryptoConfigFile()
 {
-    boost::filesystem::path pathConfigFile(GetArg("-mc_crypto_conf", "sample_log_config.yaml"));
+    boost::filesystem::path pathConfigFile(GetArg("-mc_crypto_conf", "mc_crypto_log_config.yaml"));
     if (!pathConfigFile.is_absolute())
         pathConfigFile = GetDataDir(false) / pathConfigFile;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -625,6 +625,15 @@ boost::filesystem::path GetConfigFile()
     return pathConfigFile;
 }
 
+boost::filesystem::path GetMcCryptoConfigFile()
+{
+    boost::filesystem::path pathConfigFile(GetArg("-mc_crypto_conf", "sample_log_config.yaml"));
+    if (!pathConfigFile.is_absolute())
+        pathConfigFile = GetDataDir(false) / pathConfigFile;
+
+    return pathConfigFile;
+}
+
 void ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -131,6 +131,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetMcCryptoConfigFile();
+boost::filesystem::path GetMCCryptoLogPath();
 #ifndef WIN32
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);

--- a/src/util.h
+++ b/src/util.h
@@ -130,6 +130,7 @@ boost::filesystem::path GetDefaultDataDir();
 const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 boost::filesystem::path GetConfigFile();
+boost::filesystem::path GetMcCryptoConfigFile();
 #ifndef WIN32
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);


### PR DESCRIPTION
This PR updates libzendoo dependency to version 0.5.0.

This new version of libzendoo introduces a new logging system, which takes options from a specific configuration file. A default configuration file for the new system is added to the repository, with the name `mc_crypto_log_config.yaml`.
On the first run, zend copies the default config file to the configured datadir, and modifies it so that the new logs are stored in the same datadir (where also `debug.log` is located).