### PR TITLE
Fixed a sporadic error in sc_cert_nonceasing.py

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -30,7 +30,7 @@ Starting from this release, `zend` includes a logging mechanism specific for the
 * Minor refactoring of the code inside `ThreadSocketHandler()` [#608](https://github.com/HorizenOfficial/zen/pull/608)
 * Removed any reference to `boost::thread` from the networking code [#612](https://github.com/HorizenOfficial/zen/pull/612)
 * Copyright header update [#613](https://github.com/HorizenOfficial/zen/pull/613)
-* 
+* Fixed a sporadic error on the CI related to `sc_cert_nonceasing` and improved a few more tests [#618](https://github.com/HorizenOfficial/zen/pull/618)
 
 
 ## Contributors

--- a/qa/rpc-tests/checkblockatheight.py
+++ b/qa/rpc-tests/checkblockatheight.py
@@ -254,11 +254,11 @@ class checkblockatheight(BitcoinTestFramework):
 
         self.mark_logs("  Node0 generating 1 honest block")
         blocks.extend(self.nodes[0].generate(1)) 
-        sync_blocks(self.nodes, 1, False, 5)
+        sync_blocks(self.nodes[0:3])
 
         h_current = self.nodes[1].getblockcount()
 
-        # we will perform on attack aimed at reverting from this block (latest generated) upward
+        # we will perform an attack aimed at reverting from this block (latest generated) upward
         h_attacked = h_current
         hash_attacked = blocks[-1]
         assert hash_attacked == blocks[h_attacked]
@@ -331,7 +331,7 @@ class checkblockatheight(BitcoinTestFramework):
 
         print("  Node0 generating 1 honest block")
         blocks.extend(self.nodes[0].generate(1))
-        sync_blocks(self.nodes[0:2])
+        sync_blocks(self.nodes[0:3])
         
         # check tx is no more in mempool
         assert_equal(self.is_in_mempool(tx_1000, 1), False)
@@ -348,7 +348,6 @@ class checkblockatheight(BitcoinTestFramework):
 
         print("  Node3 generating 3 malicious blocks thus reverting the honest chain once the ntw is joined!")
         blocks.extend(self.nodes[3].generate(3))
-        sync_blocks(self.nodes, limit_loop=5)
         
         self.mark_logs("Joining network")
         self.join_network()

--- a/qa/rpc-tests/mempool_size_limit_even_more.py
+++ b/qa/rpc-tests/mempool_size_limit_even_more.py
@@ -72,7 +72,6 @@ class mempool_size_limit_even_more(BitcoinTestFramework):
         if (USE_SNAPSHOT):
             self.import_data_to_data_dir()
             os.remove(self.options.tmpdir+'/node0/regtest/debug.log') # make sure that we have only logs from this test
-            os.remove(self.options.tmpdir+'/node1/regtest/debug.log')
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
 

--- a/qa/rpc-tests/sc_cert_nonceasing.py
+++ b/qa/rpc-tests/sc_cert_nonceasing.py
@@ -263,7 +263,9 @@ class ncsc_cert_epochs(BitcoinTestFramework):
         fwt_amount = Decimal(0.5)
         fwd_tx = self.nodes[0].sc_send(
                                         [{'toaddress': "abcd", 'amount': fwt_amount, "scid": scid, "mcReturnAddress": self.nodes[0].getnewaddress()}],
-                                        {'minconf': 1} # this minconf is used to make sure that fwd_tx does not depend on cert_2
+                                        {'minconf': 102} # this minconf is used to make sure that fwd_tx does not depend on cert_2 ('minconf': 1)
+                                                         # in addition, since later in the test c0_block is invalidated and fwd_tx is checked for inclusion in the
+                                                         # mempool, we want to make sure coins mature before c0_block are used (here we are at c0_block+1 height)
                                       )
         assert(fwd_tx in self.nodes[0].getrawmempool())
 


### PR DESCRIPTION
The error was related to a wrong `minconf` parameter that was sometimes causing a transaction to be created with an input that could eventually "disappear" due to the disconnection of some blocks.