### PR TITLE
Fix startup warning

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -31,6 +31,7 @@ Starting from this release, `zend` includes a logging mechanism specific for the
 * Removed any reference to `boost::thread` from the networking code [#612](https://github.com/HorizenOfficial/zen/pull/612)
 * Copyright header update [#613](https://github.com/HorizenOfficial/zen/pull/613)
 * Fixed a sporadic error on the CI related to `sc_cert_nonceasing` and improved a few more tests [#618](https://github.com/HorizenOfficial/zen/pull/618)
+* Fixed the startup warning message that is shown when configuration files are missing [#619](https://github.com/HorizenOfficial/zen/pull/619)
 
 
 ## Contributors

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -79,6 +79,9 @@ void CopyDefaultConfigFile(const std::string& destination, const std::string& fi
 #endif
         // Copy default config file
         std::ifstream src(strConfPath, std::ios::binary);
+        if (!src.is_open()) {
+            throw std::runtime_error("Could not find default config file");
+        }
         src.exceptions(std::ifstream::badbit);
 
         std::ofstream dst(destination.c_str(), std::ios::binary);

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -48,18 +48,14 @@ void CopyDefaultConfigFile(const std::string& destination, const std::string& fi
             "                        WARNING:\n"
             "Automatically copying the default config file to:\n"
             "\n"
-#ifdef  __APPLE__
-            "~/Library/Application Support/Zen/%s\n"
-#else
-            "~/.zen/%s\n"
-#endif
+            "%s\n"
             "\n"
             " Running the default configuration file without review is considered a potential risk, as zend\n"
             " might accidentally compromise your privacy if there is a default option that you need to change!\n"
             "\n"
             "           Please restart zend to continue.\n"
             "           You will not see this warning again.\n"
-            "------------------------------------------------------------------\n", filename.c_str());
+            "------------------------------------------------------------------\n", destination.c_str());
 
 
 #ifdef __APPLE__


### PR DESCRIPTION
This PR fixes the startup warning message that is shown when default configuration files are missing. The message now shows the actual path that is being used, and not the default hardcoded one.

Also, if copying default config files fail, the execution fails with a proper error message, instead of creating empty config file in the destination directory.