### PR TITLE
Fix mc_crypto log config file path for Win

### DIFF
--- a/src/sc/sidechain.cpp
+++ b/src/sc/sidechain.cpp
@@ -24,7 +24,12 @@ bool Sidechain::InitZendoo()
 {
     CctpErrorCode ret_code = CctpErrorCode::OK;
 
+#ifdef WIN32
+    const std::wstring cfg_path = GetMcCryptoConfigFile().wstring();
+#else
     const std::string cfg_path = GetMcCryptoConfigFile().string();
+#endif
+
     zendoo_init(
         reinterpret_cast<path_char_t const*>(cfg_path.c_str()),
         cfg_path.size(),


### PR DESCRIPTION
This PR fixes a bug affecting Windows builds, caused by type mismatch when passing mc-crypto logger configuration file path to the dependency.