### PR TITLE
Gp/unshielding to script fork

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -1,14 +1,23 @@
 zend v4.1.99
 =========
 
-This version is expected to deprecate on Mainnet at block **#XXXXXXX**, which will occur on **Month Xth XXXX at approximately XX:XX PM UTC**. Please, update to a newer version before Month XXth.
+This version is expected to deprecate on Mainnet at block **#1502084**, which will occur on **February 6th 2024 at approximately 12:00 PM UTC**. Please, update to a newer version before February 6th.
+
+A **hard fork** is going to activate on Testnet at block **#1396500**, on **January 3rd 2024 at approximately 12:00 PM UTC**.
 
 ## Important Notes
+- PR [#624](https://github.com/HorizenOfficial/zen/pull/624) is a follow-up in the gradual path of shielded pool deprecation, it introduces a hard fork requiring the unshielding of private funds to target only script addresses. After the hard fork, unshielding to P2PKH addresses or to P2PK addresses will not be allowed. For this reason, the following RPC commands have been (partially) deprecated: `z_sendmany` and `z_mergetoaddress` (check inline documentation for additional details).
 
 ## New Features and Improvements
+- Unshielding to script addresses only: a hard-fork is introduced which results in unshielding txs to target only P2SH addresses [#624](https://github.com/HorizenOfficial/zen/pull/624)
 
 ## Bugfixes
 
 ## Minor Changes
 
 ## Contributors
+
+[@JackPiri](https://github.com/JackPiri)
+[mantle0x](https://github.com/mantle0x)
+
+Special thanks to [mantle0x](https://github.com/mantle0x) for the first contribution to Zen!

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -162,7 +162,7 @@ testScripts=(
   'sc_big_commitment_tree.py',63,110
   'sc_big_commitment_tree_getblockmerkleroot.py',11,25
   'p2p_ignore_spent_tx.py',215,455
-  'shieldedpooldeprecation_rpc.py',558,1794
+  'shieldedpooldeprecation.py',370,550
   'mempool_size_limit.py',121,203
   'mempool_size_limit_more.py',103,160
   'mempool_size_limit_even_more.py',87,210

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -167,6 +167,7 @@ testScripts=(
   'mempool_size_limit_more.py',103,160
   'mempool_size_limit_even_more.py',87,210
   'mempool_hard_fork_cleaning.py',34,60
+  'unshieldingtoscriptonly.py',360,540
 );
 
 testScriptsExt=(

--- a/qa/rpc-tests/mempool_hard_fork_cleaning.py
+++ b/qa/rpc-tests/mempool_hard_fork_cleaning.py
@@ -36,6 +36,7 @@ class Test (BitcoinTestFramework):
         # ####################################################################################################
         # Fork 8 - Sidechain hard fork
         # ####################################################################################################
+        mark_logs("********** Fork 8 - Sidechain hard fork **********", self.nodes, DEBUG_MODE)
 
         mark_logs("Node 0 starts mining to reach the block immediately before the sidechain hard fork activation", self.nodes, DEBUG_MODE)
         sc_fork_height = ForkHeights['MINIMAL_SC']
@@ -60,65 +61,100 @@ class Test (BitcoinTestFramework):
 
 
 
+        # Preparation for fork12: some shielded notes are created (needed later, but must be prepared before fork11 occurs)
+        notes_to_create = 3
+        for i in range(notes_to_create):
+            opid = self.nodes[0].z_mergetoaddress(["ANY_TADDR"], self.nodes[0].z_getnewaddress(), Z_FEE, 2, 0)["opid"]
+            wait_and_assert_operationid_status(self.nodes[0], opid)
+            self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+
         # ####################################################################################################
         # Fork 11 - Shielded pool deprecation hard fork
         # ####################################################################################################
+        # ####################################################################################################
+        # Fork 12 - Unshielding to script only hard fork
+        # ####################################################################################################
+        for fork in range(11, 12 + 1):
+            if (fork == 11):
+                fork_descr = "Shielded Pool Deprecation"
+                fork_height = ForkHeights['SHIELDED_POOL_DEPRECATION']
+                tx_type_descr = "shielding transaction"
+            elif (fork == 12):
+                fork_descr = "Unshielding To Script Only"
+                fork_height = ForkHeights['UNSHIELDING_TO_SCRIPT_ONLY']
+                tx_type_descr = "unshielding transaction to publick-key-address"
 
-        mark_logs("Node 0 starts mining to get close to the Shieleded Pool Deprecation hard fork [Fork - 3]", self.nodes, DEBUG_MODE)
-        shielded_pool_deprecation_fork_height = ForkHeights['SHIELDED_POOL_DEPRECATION']
-        block_count = self.nodes[0].getblockcount()
-        self.nodes[1].generate(shielded_pool_deprecation_fork_height - block_count - 3)
-        self.sync_all()
+            mark_logs(f"********** Fork {fork} - {fork_descr} hard fork **********", self.nodes, DEBUG_MODE)
 
-        mark_logs("Split the network", self.nodes, DEBUG_MODE)
-        self.split_network(0)
+            mark_logs(f"Node 0 starts mining to get close to the {fork_descr} hard fork [Fork - 3]", self.nodes, DEBUG_MODE)
+            block_count = self.nodes[0].getblockcount()
+            self.nodes[1].generate(fork_height - block_count - 3)
+            self.sync_all()
 
-        mark_logs("Node 0 creates a shielding transaction", self.nodes, DEBUG_MODE)
-        total_funds_before_shielding = sum(x['amount'] for x in self.nodes[0].listunspent(0))
-        opid = self.nodes[0].z_mergetoaddress(["ANY_TADDR"], self.nodes[0].z_getnewaddress(), Z_FEE, 2, 2)["opid"]
-        wait_and_assert_operationid_status(self.nodes[0], opid)
+            mark_logs("Split the network", self.nodes, DEBUG_MODE)
+            self.split_network(0)
 
-        # Give time to the wallet to be notified and updated the balance (listunspent would otherwise return an outdated value)
-        wait_until(lambda: self.nodes[0].getmempoolinfo()['fullyNotified'] == True, 20)
-        assert_greater_than(total_funds_before_shielding, sum(x['amount'] for x in self.nodes[0].listunspent(0))) # Some less funds available
+            mark_logs(f"Node 0 creates {tx_type_descr}", self.nodes, DEBUG_MODE)
+            if (fork == 11):
+                total_funds_before = sum(x['amount'] for x in self.nodes[0].listunspent(0))
+                opid = self.nodes[0].z_mergetoaddress(["ANY_TADDR"], self.nodes[0].z_getnewaddress(), Z_FEE, 2, 0)["opid"]
+            elif (fork == 12):
+                total_funds_before = sum(x['amount'] for x in self.nodes[0].z_listunspent(0))
+                opid = self.nodes[0].z_mergetoaddress(["ANY_ZADDR"], self.nodes[0].getnewaddress(), Z_FEE, 0, 2)["opid"]
+            wait_and_assert_operationid_status(self.nodes[0], opid)
 
-        mark_logs("Join the network", self.nodes, DEBUG_MODE)
-        self.join_network(0)
+            # Give time to the wallet to be notified and updated the balance (listunspent would otherwise return an outdated value)
+            wait_until(lambda: self.nodes[0].getmempoolinfo()['fullyNotified'] == True, 20)
+            if (fork == 11):
+                assert_greater_than(total_funds_before, sum(x['amount'] for x in self.nodes[0].listunspent(0))) # Some less funds available
+            elif (fork == 12):
+                assert_greater_than(total_funds_before, sum(x['amount'] for x in self.nodes[0].z_listunspent(0))) # Some less funds available
 
-        mark_logs("Check that the shielding transaction is only available on node 0 (no rebroadcasting happens)", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
-        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+            mark_logs("Join the network", self.nodes, DEBUG_MODE)
+            self.join_network(0)
 
-        mark_logs("Node 1 mines one block, new height is [Fork - 2]", self.nodes, DEBUG_MODE)
-        self.nodes[1].generate(1)
-        sync_blocks(self.nodes)
+            mark_logs(f"Check that the {tx_type_descr} is only available on node 0 (no rebroadcasting happens)", self.nodes, DEBUG_MODE)
+            assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
+            assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
 
-        mark_logs("Check that the mempool situation is unchanged", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getblockcount(), shielded_pool_deprecation_fork_height - 2)
-        assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
-        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+            mark_logs("Node 1 mines one block, new height is [Fork - 2]", self.nodes, DEBUG_MODE)
+            self.nodes[1].generate(1)
+            sync_blocks(self.nodes)
 
-        mark_logs("Node 1 mines another block, new height is [Fork - 1] (shielding transaction can't be mined in the next block)", self.nodes, DEBUG_MODE)
-        self.nodes[1].generate(1)
-        sync_blocks(self.nodes)
+            mark_logs("Check that the mempool situation is unchanged", self.nodes, DEBUG_MODE)
+            assert_equal(self.nodes[0].getblockcount(), fork_height - 2)
+            assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
+            assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
 
-        mark_logs("Check that the shielding transaction has been evicted", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getblockcount(), shielded_pool_deprecation_fork_height - 1)
-        assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
-        assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
+            mark_logs(f"Node 1 mines another block, new height is [Fork - 1] ({tx_type_descr} can't be mined in the next block)", self.nodes, DEBUG_MODE)
+            self.nodes[1].generate(1)
+            sync_blocks(self.nodes)
 
-        mark_logs("Check that the shielding transaction is not rebroadcasted even in case of explicit request", self.nodes, DEBUG_MODE)
-        resenttxs = self.nodes[0].resendwallettransactions()
-        self.sync_all()
-        assert_equal(len(resenttxs), 0)
+            mark_logs(f"Check that the {tx_type_descr} has been evicted", self.nodes, DEBUG_MODE)
+            assert_equal(self.nodes[0].getblockcount(), fork_height - 1)
+            assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
+            assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
 
-        mark_logs("Check that the funds used for the shielding transaction are available again", self.nodes, DEBUG_MODE)
-        assert_equal(sum(x['amount'] for x in self.nodes[0].listunspent(0)), total_funds_before_shielding)
-        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), total_funds_before_shielding, "", "", True)
-        assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
-        self.sync_all()
+            mark_logs(f"Check that the {tx_type_descr} is not rebroadcasted even in case of explicit request", self.nodes, DEBUG_MODE)
+            resenttxs = self.nodes[0].resendwallettransactions()
+            self.sync_all()
+            assert_equal(len(resenttxs), 0)
 
-        mark_logs("RemoveStaleTransaction() function worked properly for block connection on a hard fork", self.nodes, DEBUG_MODE)
+            mark_logs(f"Check that the funds used for the {tx_type_descr} are available again", self.nodes, DEBUG_MODE)
+            if (fork == 11):
+                assert_equal(sum(x['amount'] for x in self.nodes[0].listunspent(0)), total_funds_before)
+                self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), total_funds_before, "", "", True)
+            elif (fork == 12):
+                assert_equal(sum(x['amount'] for x in self.nodes[0].z_listunspent(0)), total_funds_before)
+                notes_quantity = len(self.nodes[0].z_listunspent(0))
+                opid = self.nodes[0].z_mergetoaddress(["ANY_ZADDR"], self.nodes[0].z_getnewaddress(), Z_FEE, 0, notes_quantity)["opid"]
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+            assert_equal(self.nodes[0].getmempoolinfo()["size"], 1)
+            self.sync_all()
+
+            mark_logs("RemoveStaleTransaction() function worked properly for block connection on a hard fork", self.nodes, DEBUG_MODE)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -25,10 +25,11 @@ from test_framework.util import assert_equal, check_json_precision, \
 MINER_REWARD_POST_H200 = 7.50
 
 ForkHeights = {
-    'MINIMAL_SC':                420,
-    'SC_VERSION':                450,
-    'NON_CEASING_SC':            480,
-    'SHIELDED_POOL_DEPRECATION': 990
+    'MINIMAL_SC':                  420,
+    'SC_VERSION':                  450,
+    'NON_CEASING_SC':              480,
+    'SHIELDED_POOL_DEPRECATION':   990,
+    'UNSHIELDING_TO_SCRIPT_ONLY': 1010,
 }
 
 class syncType(Enum):

--- a/qa/rpc-tests/unshieldingtoscriptonly.py
+++ b/qa/rpc-tests/unshieldingtoscriptonly.py
@@ -14,7 +14,7 @@ from test_framework.util import assert_equal, assert_greater_than, \
 import sys
 
 RPC_VERIFY_REJECTED = -26
-RPC_HARD_FORK_DEPRECATION = -40 # TODO: update
+RPC_HARD_FORK_DEPRECATION = -40
 Z_FEE = 0.0001
 
 class ShieldedPoolDeprecationTest (BitcoinTestFramework):

--- a/qa/rpc-tests/unshieldingtoscriptonly.py
+++ b/qa/rpc-tests/unshieldingtoscriptonly.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework, ForkHeights
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, assert_greater_than, \
+    assert_greater_or_equal_than, initialize_chain_clean, start_nodes, \
+    connect_nodes, wait_and_assert_operationid_status, \
+    send_shielding_raw, send_unshielding_raw
+
+import sys
+
+RPC_VERIFY_REJECTED = -26
+RPC_HARD_FORK_DEPRECATION = -40 # TODO: update
+Z_FEE = 0.0001
+
+class ShieldedPoolDeprecationTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir, [['-debug=zrpcunsafe', '-experimentalfeatures', '-zmergetoaddress']] * 2)
+        connect_nodes(self.nodes, 0, 1)
+        self.is_network_split=False
+        self.sync_all()
+
+    def make_all_mature(self):
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+    def run_test (self):
+
+        ForkHeight_SPD = ForkHeights['SHIELDED_POOL_DEPRECATION']
+        ForkHeight = ForkHeights['UNSHIELDING_TO_SCRIPT_ONLY']
+
+        print("Mining blocks...")
+
+        self.nodes[0].generate(ForkHeight_SPD - 10)
+        self.sync_all()
+
+        # addresses
+        script_address = "zr3EMnGsEtpqTVbBdo4RztB3RQfNMUXt63j" # (0x 2092 0123456789012345678901234567890123456789 94a14d8a)
+        node0_zaddr0 = self.nodes[0].z_getnewaddress()
+
+        # generating some shielded notes
+        notes_to_create = 15
+        for repeat in range(notes_to_create):
+            opid = self.nodes[0].z_shieldcoinbase("*", node0_zaddr0, Z_FEE, 2)["opid"]
+            wait_and_assert_operationid_status(self.nodes[0], opid)
+            self.sync_all()
+        # generating some shielded notes through raw interface
+        notes_to_create_raw = 3
+        minimum_amount = 1.0
+        receive_result_and_key = [None] * notes_to_create_raw
+        for i in range(notes_to_create_raw):
+            zckeypair = self.nodes[0].zcrawkeygen()
+            zcsecretkey = zckeypair["zcsecretkey"]
+            zcaddress = zckeypair["zcaddress"]
+            tx_hash, encrypted_note = send_shielding_raw(self.nodes[0], minimum_amount, zcaddress)
+            receive_result_and_key[i] = [self.nodes[0].zcrawreceive(zcsecretkey, encrypted_note), zcsecretkey]
+            self.sync_all()
+        receive_result_and_key_index = 0
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+        
+        # first round pre-fork, second round post-fork
+        pre_fork_round = 0
+        post_fork_round = 1
+        for round in range(2):
+            blockcount = self.nodes[0].getblockcount()
+            if (round == pre_fork_round):
+                assert_greater_than(ForkHeight, blockcount + 1) # otherwise following tests would make no sense
+                                                                # +1 because a new tx would enter the blockchain on next mined block
+            elif (round == post_fork_round):
+                assert_equal(blockcount + 1, ForkHeight) # otherwise following tests would make no sense
+
+
+            # z_mergetoaddress
+            print(f"z_mergetoaddress ({'pre-fork' if round == pre_fork_round else 'post-fork'})")
+
+            try:
+                opid = self.nodes[0].z_mergetoaddress(["ANY_ZADDR"], self.nodes[0].getnewaddress(), Z_FEE, 0, 2)["opid"]
+                if (round == post_fork_round):
+                    assert(False)
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                if (round == pre_fork_round):
+                    print("Unexpected exception caught during testing: " + str(e.error))
+                    assert(False)
+                else:
+                    print("Expected exception caught during testing due to deprecation (error=" + str(e.error["code"]) + ")")
+                    assert_equal(e.error["code"], RPC_HARD_FORK_DEPRECATION)
+
+            self.make_all_mature()
+
+            try:
+                opid = self.nodes[0].z_mergetoaddress(["ANY_ZADDR"], script_address, Z_FEE, 0, 2)["opid"]
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                print("Unexpected exception caught during testing: " + str(e.error))
+                assert(False)
+
+            self.make_all_mature()
+
+            try:
+                opid = self.nodes[0].z_mergetoaddress(["ANY_ZADDR"], self.nodes[0].z_getnewaddress(), Z_FEE, 0, 2)["opid"]
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                print("Unexpected exception caught during testing: " + str(e.error))
+                assert(False)
+
+            self.make_all_mature()
+
+            # z_sendmany
+            print(f"z_sendmany ({'pre-fork' if round == pre_fork_round else 'post-fork'})")
+
+            try:
+                opid = self.nodes[0].z_sendmany(node0_zaddr0, [{"address": self.nodes[0].getnewaddress(), "amount": 1.0}], 1, Z_FEE)
+                if (round == post_fork_round):
+                    assert(False)
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                if (round == pre_fork_round):
+                    print("Unexpected exception caught during testing: " + str(e.error))
+                    assert(False)
+                else:
+                    print("Expected exception caught during testing due to deprecation (error=" + str(e.error["code"]) + ")")
+                    assert_equal(e.error["code"], RPC_HARD_FORK_DEPRECATION)
+
+            self.make_all_mature()
+
+            try:
+                opid = self.nodes[0].z_sendmany(node0_zaddr0, [{"address": script_address, "amount": 1.0}], 1, Z_FEE)
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                print("Unexpected exception caught during testing: " + str(e.error))
+                assert(False)
+
+            self.make_all_mature()
+
+            try:
+                opid = self.nodes[0].z_sendmany(node0_zaddr0, [{"address": self.nodes[0].z_getnewaddress(), "amount": 1.0}], 1, Z_FEE)
+                wait_and_assert_operationid_status(self.nodes[0], opid)
+                self.sync_all()
+            except JSONRPCException as e:
+                print("Unexpected exception caught during testing: " + str(e.error))
+                assert(False)
+
+            self.make_all_mature()
+
+            # raw
+            print(f"createrawtransaction/zcrawjoinsplit ({'pre-fork' if round == pre_fork_round else 'post-fork'})")
+
+            try:
+                receive_result_and_key_to_use = receive_result_and_key[receive_result_and_key_index]
+                send_unshielding_raw(self.nodes[0], receive_result_and_key_to_use[0], receive_result_and_key_to_use[1], self.nodes[0].getnewaddress())
+                if (round == post_fork_round):
+                    assert(False)
+                receive_result_and_key_index += 1
+                self.sync_all()
+            except JSONRPCException as e:
+                if (round == pre_fork_round):
+                    print("Unexpected exception caught during testing: " + str(e.error))
+                    assert(False)
+                else:
+                    print("Expected exception caught during testing due to deprecation (error=" + str(e.error["code"]) + ")")
+                    assert_equal(e.error["code"], RPC_VERIFY_REJECTED)
+
+            self.make_all_mature()
+
+            try:
+                receive_result_and_key_to_use = receive_result_and_key[receive_result_and_key_index]
+                send_unshielding_raw(self.nodes[0], receive_result_and_key_to_use[0], receive_result_and_key_to_use[1], script_address)
+                receive_result_and_key_index += 1
+                self.sync_all()
+            except JSONRPCException as e:
+                print("Unexpected exception caught during testing: " + str(e.error))
+                assert(False)
+
+            self.make_all_mature()
+
+
+            blockcount = self.nodes[0].getblockcount()
+            if (round == pre_fork_round):
+                assert_greater_than(ForkHeight, blockcount + 1) # otherwise previous tests would make no sense
+            elif (round == post_fork_round):
+                assert_greater_or_equal_than(blockcount, ForkHeight) # otherwise previous tests would make no sense
+
+            if (round == pre_fork_round):
+                self.nodes[0].generate(ForkHeight - blockcount - 1)
+                self.sync_all()
+
+
+if __name__ == '__main__':
+    ShieldedPoolDeprecationTest().main()

--- a/qa/rpc-tests/zcjoinsplit.py
+++ b/qa/rpc-tests/zcjoinsplit.py
@@ -4,118 +4,53 @@
 # Test joinsplit semantics
 #
 
-from test_framework.test_framework import BitcoinTestFramework, ForkHeights
-from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, start_node, assert_greater_than, \
-    assert_greater_or_equal_than, gather_inputs, connect_nodes, disconnect_nodes
-from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, start_node, \
+    gather_inputs
 
-RPC_VERIFY_REJECTED = -26
 
 class JoinSplitTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
         self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir))
-        connect_nodes(self.nodes, 0, 1)
 
     def run_test(self):
+        zckeypair = self.nodes[0].zcrawkeygen()
+        zcsecretkey = zckeypair["zcsecretkey"]
+        zcaddress = zckeypair["zcaddress"]
 
-        ForkHeight = ForkHeights['SHIELDED_POOL_DEPRECATION']
-        fork_crossing_margin = 10
+        (total_in, inputs) = gather_inputs(self.nodes[0], 45.75)
+        protect_tx = self.nodes[0].createrawtransaction(inputs, {})
+        joinsplit_result = self.nodes[0].zcrawjoinsplit(protect_tx, {}, {zcaddress:45.74}, 45.74, 0)
 
-        # first round pre-fork, second round crossing-fork, third round post-fork
-        pre_fork_round = 0
-        crossing_fork_round = 1
-        post_fork_round = 2
-        for round in range(3):
-            blockcount = self.nodes[0].getblockcount()
-            if (round == pre_fork_round):
-                assert_greater_than(ForkHeight, blockcount + 1) # otherwise following tests would make no sense
-                                                                # +1 because a new tx would enter the blockchain on next mined block
-            elif (round == crossing_fork_round):
-                assert_equal(blockcount + 1 + fork_crossing_margin, ForkHeight) # otherwise following tests would make no sense
-            elif (round == post_fork_round):
-                assert_equal(blockcount + 1, ForkHeight) # otherwise following tests would make no sense
+        receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
+        assert_equal(receive_result["exists"], False)
 
-            zckeypair = self.nodes[0].zcrawkeygen()
-            zcsecretkey = zckeypair["zcsecretkey"]
-            zcaddress = zckeypair["zcaddress"]
+        protect_tx = self.nodes[0].signrawtransaction(joinsplit_result["rawtxn"])
+        self.nodes[0].sendrawtransaction(protect_tx["hex"])
+        self.nodes[0].generate(1)
 
-            (total_in, inputs) = gather_inputs(self.nodes[0], 45.75)
+        receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
+        assert_equal(receive_result["exists"], True)
 
-            protect_tx = self.nodes[0].createrawtransaction(inputs, {})
-            joinsplit_result = self.nodes[0].zcrawjoinsplit(protect_tx, {}, {zcaddress: total_in - Decimal(0.01)}, total_in - Decimal(0.01), 0)
-
-            receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
-            assert_equal(receive_result["exists"], False)
-
-            protect_tx = self.nodes[0].signrawtransaction(joinsplit_result["rawtxn"])
-
-            # disconnect the nodes so that the chains are not synced
-            if (round == crossing_fork_round):
-                disconnect_nodes(self.nodes, 0, 1)
-
-            try:
-                self.nodes[0].sendrawtransaction(protect_tx["hex"])
-                if (round == post_fork_round):
-                    assert(False)
-            except JSONRPCException as e:
-                if (round == pre_fork_round or round == crossing_fork_round):
-                    print("Unexpected exception caught during testing: " + str(e.error))
-                    assert(False)
-                else:
-                    print("Expected exception caught during testing due to deprecation (error=" + str(e.error["code"]) + ")")
-                    assert_equal(e.error["code"], RPC_VERIFY_REJECTED)
-                    continue # other steps of this round are skipped
-
-            if (round == crossing_fork_round):
-                # advance chain on node1 (so that shielded pool deprecation hard fork is active)
-                self.nodes[1].generate(fork_crossing_margin)
-                connect_nodes(self.nodes, 0, 1)
-                self.sync_all()
-
-                # The deprecated transaction is not in the mempool anymore:
-                # - Node 0 removed the transaction as "stale"
-                # - Node 1 never received the transaction
-                assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
-                assert_equal(self.nodes[1].getmempoolinfo()["size"], 0)
-
-                continue # other steps of this round are skipped
-
+        # The pure joinsplit we create should be mined in the next block
+        # despite other transactions being in the mempool.
+        addrtest = self.nodes[0].getnewaddress()
+        for xx in range(0,10):
             self.nodes[0].generate(1)
+            for x in range(0,50):
+                self.nodes[0].sendtoaddress(addrtest, 0.01);
 
-            receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
-            assert_equal(receive_result["exists"], True)
+        joinsplit_tx = self.nodes[0].createrawtransaction([], {})
+        joinsplit_result = self.nodes[0].zcrawjoinsplit(joinsplit_tx, {receive_result["note"] : zcsecretkey}, {zcaddress: 45.73}, 0, 0.01)
 
-            # The pure joinsplit we create should be mined in the next block
-            # despite other transactions being in the mempool.
-            addrtest = self.nodes[0].getnewaddress()
-            for _ in range(0,10):
-                self.nodes[0].generate(1)
-                for _ in range(0,50):
-                    self.nodes[0].sendtoaddress(addrtest, 0.01)
+        self.nodes[0].sendrawtransaction(joinsplit_result["rawtxn"])
+        self.nodes[0].generate(1)
 
-            joinsplit_tx = self.nodes[0].createrawtransaction([], {})
-            joinsplit_result = self.nodes[0].zcrawjoinsplit(joinsplit_tx, {receive_result["note"] : zcsecretkey}, {zcaddress: 45.73}, 0, 0.01)
-
-            self.nodes[0].sendrawtransaction(joinsplit_result["rawtxn"])
-            self.nodes[0].generate(1)
-            self.sync_all()
-
-            receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
-            assert_equal(receive_result["exists"], True)
-
-            if (round == pre_fork_round):
-                blockcount = self.nodes[0].getblockcount()
-                assert_greater_than(ForkHeight, blockcount + 1 + fork_crossing_margin) # otherwise previous tests would make no sense
-                self.nodes[0].generate(ForkHeight - blockcount - 1 - fork_crossing_margin)
-                self.sync_all()
-            elif (round == crossing_fork_round or round == post_fork_round):
-                blockcount = self.nodes[0].getblockcount()
-                assert_greater_or_equal_than(blockcount, ForkHeight) # otherwise previous tests would make no sense
-
+        print("Done!")
+        receive_result = self.nodes[0].zcrawreceive(zcsecretkey, joinsplit_result["encryptednote1"])
+        assert_equal(receive_result["exists"], True)
 
 if __name__ == '__main__':
     JoinSplitTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -622,6 +622,7 @@ libzencash_a_SOURCES = \
     zen/forks/fork9_sidechainversionfork.cpp\
     zen/forks/fork10_nonceasingsidechainfork.cpp\
     zen/forks/fork11_shieldedpooldeprecationfork.cpp\
+    zen/forks/fork12_unshieldingtoscriptonlyfork.cpp\
     zen/tlsmanager.cpp\
     zen/delay.cpp \
     zen/websocket_server.cpp

--- a/src/gtest/test_forkmanager.cpp
+++ b/src/gtest/test_forkmanager.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include "zen/forkmanager.h"
 #include "chainparams.h"
-#include "zen/forks/fork11_shieldedpooldeprecationfork.h"
+#include "zen/forks/fork12_unshieldingtoscriptonlyfork.h"
 
 using namespace zen;
 
@@ -529,6 +529,9 @@ TEST(ForkManager, ShieldedPoolDeprecationForkMainnet) {
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight - 1), true);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight), false);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight + 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight + 1), true);
 }
 
 TEST(ForkManager, ShieldedPoolDeprecationForkTestnet) {
@@ -538,6 +541,9 @@ TEST(ForkManager, ShieldedPoolDeprecationForkTestnet) {
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight - 1), true);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight), false);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight + 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight + 1), true);
 }
 
 TEST(ForkManager, ShieldedPoolDeprecationForkRegtest) {
@@ -547,6 +553,9 @@ TEST(ForkManager, ShieldedPoolDeprecationForkRegtest) {
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight - 1), false);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight), false);
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight + 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().isShieldingForbidden(shieldedPoolDeprecationForkHeight + 1), true);
 
     bool alreadyPresent = !mapArgs.insert({"-regtestprotectcoinbase", ""}).second;
     EXPECT_EQ(ForkManager::getInstance().mustCoinBaseBeShielded(shieldedPoolDeprecationForkHeight - 1), true);
@@ -556,8 +565,35 @@ TEST(ForkManager, ShieldedPoolDeprecationForkRegtest) {
         mapArgs.erase("-regtestprotectcoinbase");
 }
 
+TEST(ForkManager, UnshieldingToScriptOnlyForkMainnet) {
+    SelectParams(CBaseChainParams::MAIN);
+
+    int unshieldingToScriptOnlyForkHeight = 2000000;
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight + 1), true);
+}
+
+TEST(ForkManager, UnshieldingToScriptOnlyForkTestnet) {
+    SelectParams(CBaseChainParams::TESTNET);
+
+    int unshieldingToScriptOnlyForkHeight = 2000000;
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight + 1), true);
+}
+
+TEST(ForkManager, UnshieldingToScriptOnlyForkRegtest) {
+    SelectParams(CBaseChainParams::REGTEST);
+
+    int unshieldingToScriptOnlyForkHeight = 1010;
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight - 1), false);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight), true);
+    EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight + 1), true);
+}
+
 TEST(ForkManager, HighestFork) {
     SelectParams(CBaseChainParams::MAIN);
     const Fork* highestFork = ForkManager::getInstance().getHighestFork();
-    EXPECT_EQ(typeid(*highestFork), typeid(ShieldedPoolDeprecationFork));
+    EXPECT_EQ(typeid(*highestFork), typeid(UnshieldingToScriptOnlyFork));
 }

--- a/src/gtest/test_forkmanager.cpp
+++ b/src/gtest/test_forkmanager.cpp
@@ -577,7 +577,7 @@ TEST(ForkManager, UnshieldingToScriptOnlyForkMainnet) {
 TEST(ForkManager, UnshieldingToScriptOnlyForkTestnet) {
     SelectParams(CBaseChainParams::TESTNET);
 
-    int unshieldingToScriptOnlyForkHeight = 2000000;
+    int unshieldingToScriptOnlyForkHeight = 1396500;
     EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight - 1), false);
     EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight), true);
     EXPECT_EQ(ForkManager::getInstance().mustUnshieldToScript(unshieldingToScriptOnlyForkHeight + 1), true);

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -1117,6 +1117,21 @@ bool CTransaction::ContextualCheck(CValidationState& state, int nHeight, int dos
                     }
                 }
             }
+            if (ForkManager::getInstance().mustUnshieldToScript(nHeight))
+            {
+                if (GetJoinSplitValueIn() > 0)
+                {
+                    for (auto const& out: vout)
+                    {
+                        if (out.scriptPubKey.GetType() != CScript::ScriptType::P2SH)
+                        {
+                            return state.DoS(dosLevel,
+                                             error("ContextualCheck(): tx unshielding to not P2SH deprecation"),
+                                             CValidationState::Code::INVALID, "bad-tx-unshielding-type");
+                        }
+                    }
+                }
+            }
         }
 
         return true;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -1123,7 +1123,7 @@ bool CTransaction::ContextualCheck(CValidationState& state, int nHeight, int dos
                 {
                     for (auto const& out: vout)
                     {
-                        if (out.scriptPubKey.GetType() != CScript::ScriptType::P2SH)
+                        if (!out.scriptPubKey.IsPayToScriptHash())
                         {
                             return state.DoS(dosLevel,
                                              error("ContextualCheck(): tx unshielding to not P2SH deprecation"),

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -123,7 +123,7 @@ namespace{
     /*!
       \return warning message
     */
-    std::string UnsieldingRPCMethodsDeprecationWarning()
+    std::string UnshieldingRPCMethodsDeprecationWarning()
     {
         int unshieldingToScriptOnlyForkHeight = GetUnshieldingToScriptOnlyForkHeight();
 
@@ -5296,8 +5296,8 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "z_sendmany \"fromaddress\" [{\"address\":... ,\"amount\":...},...] ( minconf ) ( fee ) (sendChangeToSource)\n"
             + ShieldingRPCMethodsDeprecationWarning(false) + "\n"
             + "Details: sending transparent funds to shielded addresses " + (AreShieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
-            + UnsieldingRPCMethodsDeprecationWarning() + "\n"
-            + "Details: sending shielded funds to script addresses " + (AreShieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
+            + UnshieldingRPCMethodsDeprecationWarning() + "\n"
+            + "Details: sending shielded funds to non-script addresses " + (AreUnshieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
 
             "\nSend multiple times. Amounts are double-precision floating point numbers."
             "\nChange from a taddr flows to a new taddr address, while change from zaddr returns to itself."
@@ -5421,17 +5421,17 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
     }
 
     // we want to forbid shielding transactions
-    if (chainActive.Height() + 1 >= GetShieldedPoolDeprecationForkHeight() &&
+    if (AreShieldingRPCMethodsDeprecated() &&
         fromTaddr && zaddrRecipients.size() > 0)
     {
         throw JSONRPCError(RPC_HARD_FORK_DEPRECATION, shieldedPoolDeprecationErrorMessage);
     }
 
     // we want to forbid unshielding to non-script addresses
-    if (chainActive.Height() + 1 >= GetUnshieldingToScriptOnlyForkHeight() &&
+    if (AreUnshieldingRPCMethodsDeprecated() &&
         !fromTaddr && taddrRecipients.size() > 0)
     {
-        for (const auto taddrRecipient: taddrRecipients)
+        for (const auto& taddrRecipient: taddrRecipients)
         {
             CBitcoinAddress address(std::get<0>(taddrRecipient));
             if (!address.IsScript())
@@ -5940,7 +5940,7 @@ UniValue z_shieldcoinbase(const UniValue& params, bool fHelp)
             + HelpExampleRpc("z_shieldcoinbase", "\"taddr\", \"zaddr\"")
         );
 
-    if (chainActive.Height() + 1 >= GetShieldedPoolDeprecationForkHeight())
+    if (AreShieldingRPCMethodsDeprecated())
     {
         throw JSONRPCError(RPC_HARD_FORK_DEPRECATION, shieldedPoolDeprecationErrorMessage);
     }
@@ -6114,9 +6114,9 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             "z_mergetoaddress [\"fromaddress\", ... ] \"toaddress\" ( fee ) ( transparent_limit ) ( shielded_limit ) ( memo )\n"
             + strDisabledMsg
             + ShieldingRPCMethodsDeprecationWarning(false) + "\n"
-            + "Details: merging transparent funds to shielded address " + (AreShieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
-            + UnsieldingRPCMethodsDeprecationWarning() + "\n"
-            + "Details: merging shielded funds to script address " + (AreShieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
+            + "Details: merging transparent funds to shielded addresses " + (AreShieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
+            + UnshieldingRPCMethodsDeprecationWarning() + "\n"
+            + "Details: merging shielded funds to non-script addresses " + (AreUnshieldingRPCMethodsDeprecated() ? "has been " : "is going to be ") + "deprecated.\n"
             + "\nMerge multiple UTXOs and notes into a single UTXO or note."
             + (AreShieldingRPCMethodsDeprecated() ? "" : "\nCoinbase UTXOs are ignored; use `z_shieldcoinbase` to combine those into a single note.") +            
             "\n\nThis is an asynchronous operation, and UTXOs selected for merging will be locked. If there is an error, they"
@@ -6278,14 +6278,14 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     }
 
     // we want to forbid shielding transactions
-    if (chainActive.Height() + 1 >= GetShieldedPoolDeprecationForkHeight() &&
+    if (AreShieldingRPCMethodsDeprecated() &&
         (useAny || useAnyUTXO || taddrs.size() > 0) && isToZaddr)
     {
         throw JSONRPCError(RPC_HARD_FORK_DEPRECATION, shieldedPoolDeprecationErrorMessage);
     }
 
     // we want to forbid unshielding to non-script addresses
-    if (chainActive.Height() + 1 >= GetUnshieldingToScriptOnlyForkHeight() &&
+    if (AreUnshieldingRPCMethodsDeprecated() &&
         !isToZaddr && !taddr.IsScript())
     {
         throw JSONRPCError(RPC_HARD_FORK_DEPRECATION, unshieldingToScriptOnlyErrorMessage);

--- a/src/zen/forkmanager.cpp
+++ b/src/zen/forkmanager.cpp
@@ -16,6 +16,7 @@
 #include "forks/fork9_sidechainversionfork.h"
 #include "forks/fork10_nonceasingsidechainfork.h"
 #include "forks/fork11_shieldedpooldeprecationfork.h"
+#include "forks/fork12_unshieldingtoscriptonlyfork.h"
 
 namespace zen {
 
@@ -201,6 +202,10 @@ bool ForkManager::isShieldingForbidden(int height) const {
     return getForkAtHeight(height)->isShieldingForbidden();
 }
 
+bool ForkManager::mustUnshieldToScript(int height) const {
+    return getForkAtHeight(height)->mustUnshieldToScript();
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// PRIVATE MEMBERS
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -223,6 +228,7 @@ ForkManager::ForkManager() {
     registerFork(new SidechainVersionFork());
     registerFork(new NonCeasingSidechainFork());
     registerFork(new ShieldedPoolDeprecationFork());
+    registerFork(new UnshieldingToScriptOnlyFork());
 }
 
 /**

--- a/src/zen/forkmanager.h
+++ b/src/zen/forkmanager.h
@@ -142,6 +142,11 @@ public:
      */
     bool isShieldingForbidden(int height) const;
 
+    /**
+     * @brief returns true if the unshielding (z->t) transactions must be performed towards script addresses
+     */
+    bool mustUnshieldToScript(int height) const;
+
     // ---------- forks redefined methods ----------
 
 private:

--- a/src/zen/forks/fork.h
+++ b/src/zen/forks/fork.h
@@ -144,6 +144,11 @@ public:
      */
     virtual bool isShieldingForbidden() const = 0;
 
+    /**
+     * @brief returns true if the unshielding (z->t) transactions must be performed towards script addresses
+     */
+    virtual bool mustUnshieldToScript() const = 0;
+
 protected:
     
     /**

--- a/src/zen/forks/fork0_originalfork.h
+++ b/src/zen/forks/fork0_originalfork.h
@@ -32,7 +32,7 @@ public:
     /**
      * @brief canSendCommunityFundsToTransparentAddress true if community funds can be sent to a transparent address
      */
-    inline virtual bool canSendCommunityFundsToTransparentAddress(CBaseChainParams::Network network) const;
+    virtual bool canSendCommunityFundsToTransparentAddress(CBaseChainParams::Network network) const;
 
     /**
      * @brief getReplayProtectionLevel returns the replay protection level provided by the current fork

--- a/src/zen/forks/fork0_originalfork.h
+++ b/src/zen/forks/fork0_originalfork.h
@@ -108,6 +108,12 @@ public:
      * @brief returns true if the shielding (t->z) transactions are forbidden
      */
     inline virtual bool isShieldingForbidden() const { return false; };
+
+    /**
+     * @brief returns true if the unshielding (z->t) transactions must be performed towards script addresses
+     */
+    virtual bool mustUnshieldToScript() const { return false; };
+
 };
 
 }

--- a/src/zen/forks/fork12_unshieldingtoscriptonlyfork.cpp
+++ b/src/zen/forks/fork12_unshieldingtoscriptonlyfork.cpp
@@ -1,0 +1,11 @@
+#include "fork12_unshieldingtoscriptonlyfork.h"
+
+namespace zen {
+
+UnshieldingToScriptOnlyFork::UnshieldingToScriptOnlyFork()
+{
+    setHeightMap({{CBaseChainParams::Network::MAIN,2000000},      // PLACEHOLDER
+                  {CBaseChainParams::Network::REGTEST,1010},      // PLACEHOLDER
+                  {CBaseChainParams::Network::TESTNET,2000000}}); // PLACEHOLDER
+}
+}

--- a/src/zen/forks/fork12_unshieldingtoscriptonlyfork.cpp
+++ b/src/zen/forks/fork12_unshieldingtoscriptonlyfork.cpp
@@ -5,7 +5,7 @@ namespace zen {
 UnshieldingToScriptOnlyFork::UnshieldingToScriptOnlyFork()
 {
     setHeightMap({{CBaseChainParams::Network::MAIN,2000000},      // PLACEHOLDER
-                  {CBaseChainParams::Network::REGTEST,1010},      // PLACEHOLDER
-                  {CBaseChainParams::Network::TESTNET,2000000}}); // PLACEHOLDER
+                  {CBaseChainParams::Network::REGTEST,1010},
+                  {CBaseChainParams::Network::TESTNET,1396500}});
 }
 }

--- a/src/zen/forks/fork12_unshieldingtoscriptonlyfork.h
+++ b/src/zen/forks/fork12_unshieldingtoscriptonlyfork.h
@@ -1,0 +1,20 @@
+#ifndef _UNSHIELDINGTOSCRIPTONLYFORK_H
+#define _UNSHIELDINGTOSCRIPTONLYFORK_H
+
+#include "fork11_shieldedpooldeprecationfork.h"
+
+namespace zen {
+
+class UnshieldingToScriptOnlyFork : public ShieldedPoolDeprecationFork
+{
+public:
+    UnshieldingToScriptOnlyFork();
+
+    /**
+     * @brief returns true if the unshielding (z->t) transactions must be performed towards script addresses
+     */
+    inline virtual bool mustUnshieldToScript() const { return true; };
+};
+
+}
+#endif // _UNSHIELDINGTOSCRIPTONLYFORK_H


### PR DESCRIPTION
This PR introduces a new hard fork related to unshielding transactions; after **testnet** block 1396500 **(to be later defined for mainnet)** every unshielding transaction (moving funds from the private pool back to the public pool) must provide transparent output with locking script of type P2SH.
A minor reorganization and refactoring test suite related to fork-manager and shielded-pool-deprecation fork is included in this PR.