### PR TITLE
Grammatical and Punctuation Corrections and small other improvements for brand accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cd zen
 ./zcutil/build-mac-clang.sh
 ```
 
-* Install for Windows (Cross-Compiled, building on Windows is not supported yet)
+* Install for Windows (Cross-Compiled, Building on Windows is not currently supported)
 
 ```
 sudo update-alternatives --config x86_64-w64-mingw32-g++

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cd zen
 
 ```
 sudo update-alternatives --config x86_64-w64-mingw32-g++
-(chose: /usr/bin/x86_64-w64-mingw32-g++-posix)
+Choose the option: /usr/bin/x86_64-w64-mingw32-g++-posix.
 
 export HOST=x86_64-w64-mingw32
 ./zcutil/build.sh -j$(nproc)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Running Regression Tests
     pip install --upgrade websocket-client requests
     ```
 
-    2. MacOS
+    2. macOS
     ```{r, engine='bash'}
     brew install python
     pip install --upgrade pyzmq websocket-client requests


### PR DESCRIPTION
In the "Install for Windows" section, the phrase "(chose: /usr/bin/x86_64-w64-mingw32-g++-posix)" might be clearer as an instruction. For example, "Choose the option: /usr/bin/x86_64-w64-mingw32-g++-posix."

Grammatical and Punctuation Corrections:

In the phrase "building on Windows is not supported yet" (under the "Install for Windows" section), consider changing it to "Building on Windows is not currently supported" for clarity.
In the "Running Regression Tests" section, "MacOS" should be written as "macOS" to align with Apple's branding.