### PR TITLE
Fix macOS Sonoma build

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -6,5 +6,8 @@ zend v5.0.99
 ## New Features and Improvements
 
 ## Bugfixes and Minor Changes
+- PR [#632](https://github.com/HorizenOfficial/zen/pull/632) updates some documentation files to align with the removal of shielded transaction which came with `v5.0.0`.
+- PR [#634](https://github.com/HorizenOfficial/zen/pull/634) fixes the `clang` build on MacOS Sonoma.
 
 ## Contributors
+* [@ptagl](https://github.com/ptagl)

--- a/src/snark/Makefile
+++ b/src/snark/Makefile
@@ -12,7 +12,7 @@ OPTFLAGS = -O2 -march=native -mtune=native
 FEATUREFLAGS = -DUSE_ASM -DMONTGOMERY_OUTPUT
 
 # Initialize this using "CXXFLAGS=... make". The makefile appends to that.
-CXXFLAGS += -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -Wno-deprecated-copy $(OPTFLAGS) $(FEATUREFLAGS) -DCURVE_$(CURVE)
+CXXFLAGS += -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -Wno-deprecated-copy -Wno-unused-but-set-variable $(OPTFLAGS) $(FEATUREFLAGS) -DCURVE_$(CURVE)
 
 DEPSRC = depsrc
 DEPINST = depinst


### PR DESCRIPTION
Clang 15 on Mac OS Sonoma failed to build Zend due to a warning within `Libsnark`.

This commit fixes the issue by disabling the warning. 