### PR TITLE
Typo corrections and checks improvements

### DIFF
--- a/doc/release-notes/release-notes-current.md
+++ b/doc/release-notes/release-notes-current.md
@@ -9,7 +9,10 @@ zend v5.0.99
 - PR [#632](https://github.com/HorizenOfficial/zen/pull/632) updates some documentation files to align with the removal of shielded transaction which came with `v5.0.0`.
 - PR [#634](https://github.com/HorizenOfficial/zen/pull/634) fixes the `clang` build on MacOS Sonoma.
 - PR [#635](https://github.com/HorizenOfficial/zen/pull/635) fixes a sporadic failure on the Python test mempool_size_limit.py.
+- PR [#636](https://github.com/HorizenOfficial/zen/pull/636) typo corrections and mempool checks simplification
 
 ## Contributors
 * [@ptagl](https://github.com/ptagl)
 * [@drgora](https://github.com/drgora)
+* [@a-petrini](https://github.com/a-petrini)
+* [@JackPiri](https://github.com/JackPiri)

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -133,17 +133,17 @@ bool CCoins::IsFromCert() const {
     return (nVersion & 0x7f) == (SC_CERT_VERSION & 0x7f);
 }
 
-bool CCoins::isOutputMature(unsigned int outPos, int nSpendingHeigh) const
+bool CCoins::isOutputMature(unsigned int outPos, int nSpendingHeight) const
 {
     if (!IsCoinBase() && !IsFromCert())
         return true;
 
     if (IsCoinBase())
-        return nSpendingHeigh >= (nHeight + COINBASE_MATURITY);
+        return nSpendingHeight >= (nHeight + COINBASE_MATURITY);
 
     //Hereinafter a cert
     if (outPos >= nFirstBwtPos)
-        return nSpendingHeigh >= nBwtMaturityHeight;
+        return nSpendingHeight >= nBwtMaturityHeight;
     else
         return true;
 }

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -61,7 +61,9 @@ public:
     const CAmount mainchainBackwardTransferRequestScFee;
 
     // memory only
-    const int nFirstBwtPos;
+    const int nFirstBwtPos; // this is "if there are any bwt then they start at this pos,
+                            //          but there is no guarantee at this pos there is a bwt
+                            //          (there can be nothing at all)"
 
     /** Construct a CScCertificate that qualifies as IsNull() */
     CScCertificate(int versionIn = SC_CERT_VERSION);


### PR DESCRIPTION
This PR corrects a few typos and provides rewording on several comments that did not match what is currently implemented in the code, or were simply wrong / outdated.

It also simplifies a few checks in removeStaleTransactions and removeStaleCertificates.