### PR TITLE
Add tool to dump address balances

### DIFF
--- a/contrib/debian/zen.install
+++ b/contrib/debian/zen.install
@@ -1,3 +1,4 @@
 usr/bin/zend
 usr/bin/zen-cli
 usr/bin/zen-fetch-params
+usr/bin/dumper

--- a/contrib/debian/zen.manpages
+++ b/contrib/debian/zen.manpages
@@ -1,2 +1,3 @@
 DEBIAN/manpages/zen-cli.1
 DEBIAN/manpages/zend.1
+DEBIAN/manpages/dumper.1

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -7,6 +7,7 @@ MANDIR=${MANDIR:-$TOPDIR/doc/man}
 ZEND=${ZCASHD:-$SRCDIR/zend}
 ZENCLI=${ZCASHCLI:-$SRCDIR/zen-cli}
 ZENTX=${ZCASHTX:-$SRCDIR/zen-tx}
+DUMPER=${DUMPER:-$SRCDIR/dumper}
 
 [ ! -x $ZEND ] && echo "$ZEND not found or not executable." && exit 1
 
@@ -21,7 +22,7 @@ ZECCOMMIT=$(echo $ZECVERSTR | awk -F- '{ print $NF }')
 echo "[COPYRIGHT]" > footer.h2m
 $ZEND --version | sed -n '1!p' >> footer.h2m
 
-for cmd in $ZEND $ZENCLI $ZENTX; do
+for cmd in $ZEND $ZENCLI $ZENTX $DUMPER; do
   cmdname="${cmd##*/}"
   help2man -N --version-string=$ZECVER --include=footer.h2m -o ${MANDIR}/${cmdname}.1 ${cmd}
   sed -i "s/\\\-$ZECCOMMIT//g" ${MANDIR}/${cmdname}.1

--- a/doc/man/dumper.1
+++ b/doc/man/dumper.1
@@ -1,0 +1,5 @@
+.TH DUMPER "1"
+.SH NAME
+dumper \- manual page for dumper
+
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -444,6 +444,40 @@ libbitcoin_cli_a_SOURCES = \
 nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
 #
 
+dumper_SOURCES = dumper.cpp
+dumper_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+dumper_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(COVERAGE_FLAGS)
+dumper_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(COVERAGE_FLAGS)
+
+dumper_LDADD = \
+  $(LIBBITCOIN_SERVER) \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBUNIVALUE) \
+  $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBZCASH) \
+  $(LIBZENCASH) \
+  $(LIBSNARK) \
+  $(LIBLEVELDB) \
+  $(LIBMEMENV) \
+  $(LIBSECP256K1) \
+  libbitcoin_wallet.a \
+  $(BOOST_LIBS) \
+  $(BDB_LIBS) \
+  $(SSL_LIBS) \
+  $(CRYPTO_LIBS) \
+  $(EVENT_PTHREADS_LIBS) \
+  $(EVENT_LIBS) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBZCASH_LIBS)
+
+if ENABLE_ZMQ
+dumper_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
+endif
+
+noinst_PROGRAMS += \
+  dumper
+
 # bitcoind binary #
 zend_SOURCES = bitcoind.cpp
 zend_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)

--- a/src/dumper.cpp
+++ b/src/dumper.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 The Horizen Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <getopt.h>
+#include <unordered_map>
+
+#include "txdb.h"
+#include "chainparams.h"
+#include "script/script.h"
+#include "main.h"
+#include "base58.h"
+
+constexpr size_t nCoinDBCache = (1 << 31);
+constexpr int maxOpenFiles = 1000;
+constexpr int MAX_RECONSIDER = 100;
+constexpr size_t MPOOL_SIZE = MAX_RECONSIDER * 4000000; // do not bother, we empty the mempool anyway
+
+const char* usage = R"([-t] [-H height]
+
+  -h, --help:    print this help message
+  -t, --testnet: use testnet (default: mainnet)
+  -H, --height:  use given height (default: best known tip)
+)";
+
+void print_usage(char const* self) {
+    std::cout << "Usage: " << self << " " << usage << std::endl;
+    exit(-1);
+}
+
+int main(int argc, char *argv[]) {
+    bool testnet = false;
+    int height = INT_MAX;
+
+    char opt;
+    int option_index = 0;
+    static struct option long_options[] = {
+        {"help",    no_argument,       0,  'h' },
+        {"testnet", no_argument,       0,  't' },
+        {"height",  required_argument, 0,  'H' },
+        {0,         0,                 0,  0 }
+    };
+
+    while ((opt = getopt_long(argc, argv, "thH:", long_options, &option_index)) != -1) {
+        switch (opt) {
+            case 't':
+                testnet = true;
+                break;
+            case 'h':
+                print_usage(argv[0]);
+                break;
+            case 'H':
+                height = atoi(optarg);
+                if (height < 1) print_usage(argv[0]);
+                break;
+            case '?':
+                print_usage(argv[0]);
+                break;
+      }
+    }
+
+    if (!testnet) {
+        std::cerr << "Initializing MAINNET parameters" << std::endl;
+        SelectParams(CBaseChainParams::MAIN);
+    }
+    else {
+        std::cerr << "Initializing TESTNET parameters" << std::endl;
+        SelectParams(CBaseChainParams::TESTNET);
+    }
+
+    const CChainParams& chainparams = Params();
+    std::cerr << "Loading block index..." << std::flush;
+    pblocktree = new CBlockTreeDB(nCoinDBCache, maxOpenFiles, false, false);
+    CCoinsViewDB* pcoinsdbview = new CCoinsViewDB(nCoinDBCache, maxOpenFiles, false, false);
+    pcoinsTip = new CCoinsViewCache(pcoinsdbview);
+    LoadBlockIndex();
+    std::cerr << " done!" << std::endl;
+
+    int best_height = pcoinsTip->GetHeight();
+    if (height != INT_MAX && (height <= best_height - MAX_RECONSIDER || height > best_height)) {
+        std::cerr << "Invalid height requested; current height: " << best_height << std::endl;
+        return -1;
+    }
+
+    uint256 inv_hash;
+    CBlockIndex* pblockindex = nullptr;
+    std::unique_ptr<ECCVerifyHandle> globalVerifyHandle(new ECCVerifyHandle());
+    ECC_Start();
+    mempool.reset(new CTxMemPool(CFeeRate(0), MPOOL_SIZE));
+    if (height != INT_MAX && height < best_height) {
+        std::cerr << "Setting desired height (" << height << ") ..." << std::flush;
+        pblockindex = chainActive[height + 1];
+        CValidationState state;
+        InvalidateBlock(state, pblockindex);
+        if (state.IsValid()) {
+            ActivateBestChain(state);
+        }
+        mempool->clear();
+        std::cerr << " done!" << std::endl;
+    }
+    FlushStateToDisk();
+
+    size_t tot_known = 0;
+    size_t tot_utxos = 0;
+    size_t tot_amount = 0;
+    size_t tot_p2pk, tot_p2pkh, tot_p2sh, tot_others;
+    tot_p2pk = tot_p2pkh = tot_p2sh = tot_others = 0;
+
+    std::cerr << "Dumping utxos..." << std::flush;
+    std::unordered_map<std::string, AddressInfo> agg = pcoinsdbview->dumpUtxoSet();
+    for (auto const& [addr, info]: agg) {
+        switch (info.type) {
+            case CScript::ScriptType::P2SH:
+                tot_p2sh++;
+                break;
+            case CScript::ScriptType::P2PKH:
+                tot_p2pkh++;
+                break;
+            case CScript::ScriptType::P2PK:
+                tot_p2pk++;
+                break;
+            default:
+                std::cerr << "Unknown address type found!" << std::endl;
+                tot_others++;
+        }
+
+        std::cout << addr << "," << info.amount << "," << (int)info.type << std::endl;
+        tot_utxos += info.count;
+        tot_amount += info.amount;
+    }
+    std::cerr << " done!" << std::endl;
+    std::cerr << "Tot addresses: " << agg.size() << std::endl;
+    std::cerr << "Tot utxos: " << tot_utxos << std::endl;
+    std::cerr << "Tot P2PK: " << tot_p2pk << std::endl;
+    std::cerr << "Tot P2PKH: " << tot_p2pkh << std::endl;
+    std::cerr << "Tot P2SH: " << tot_p2sh << std::endl;
+    std::cerr << "Tot Others: " << tot_others << std::endl;
+
+    std::cerr << "Checking correctness..." << std::flush;
+    CCoinsStats stats;
+    if (pcoinsdbview->GetStats(stats)) {
+        assert(stats.nTransactionOutputs == tot_utxos);
+        assert(stats.nTotalAmount == tot_amount);
+    }
+    std::cerr << " ok" << std::endl;
+
+    if (pblockindex) {
+        connman.reset(new CConnman()); // needed to prevent ActivateBestChain from crashing
+        std::cerr << "Restoring previous height..." << std::flush;
+        CValidationState state;
+        ReconsiderBlock(state, pblockindex);
+        if (state.IsValid()) {
+            ActivateBestChain(state);
+        }
+        std::cerr << " ok" << std::endl;
+    }
+    FlushStateToDisk();
+}

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,7 +11,7 @@
 #include "coins.h"
 #include "leveldbwrapper.h"
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -48,6 +48,13 @@ static const int64_t nMinDbCache = 4;
 
 static const std::string DEFAULT_INDEX_VERSION_STR = "0.0";
 static const std::string CURRENT_INDEX_VERSION_STR = "1.0";
+
+struct AddressInfo {
+    CScript::ScriptType type = CScript::ScriptType::UNKNOWN;
+    bool                pubkey_known = false;
+    size_t              count = 0;
+    CAmount             amount = 0;
+};
 
 struct CDiskTxPos : public CDiskBlockPos
 {
@@ -153,6 +160,7 @@ public:
                     CCswNullifiersMap& cswNullifies)                           override;
     bool GetStats(CCoinsStats &stats)                                    const override;
     void Dump_info() const;
+    std::unordered_map<std::string, AddressInfo> dumpUtxoSet() const;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/zcutil/build-debian-package.sh
+++ b/zcutil/build-debian-package.sh
@@ -42,9 +42,12 @@ chmod 0755 -R "$BUILD_DIR"/*
 #cp "$SRC_DEB"/postrm "$BUILD_DIR"/DEBIAN
 #cp "$SRC_DEB"/preinst "$BUILD_DIR"/DEBIAN
 #cp "$SRC_DEB"/prerm "$BUILD_DIR"/DEBIAN
+# Strip the dumper binary, no need to bloat the package with redundant debug symbols
+strip $SRC_PATH/src/dumper
 # Copy binaries
 cp "$SRC_PATH"/src/zend "$DEB_BIN"
 cp "$SRC_PATH"/src/zen-cli "$DEB_BIN"
+cp $SRC_PATH/src/dumper $DEB_BIN
 cp "$SRC_PATH"/zcutil/fetch-params.sh "$DEB_BIN"/zen-fetch-params
 # Copy docs
 cp "$SRC_PATH"/doc/release-notes/release-notes-$(cut -d "-" -f 1-2 <<<${PACKAGE_VERSION})* "$DEB_DOC"/changelog ||
@@ -55,6 +58,7 @@ cp -r "$SRC_DEB"/examples "$DEB_DOC"
 # Copy manpages
 cp "$SRC_DOC"/man/zend.1 "$DEB_MAN"/zend.1
 cp "$SRC_DOC"/man/zen-cli.1 "$DEB_MAN"/zen-cli.1
+cp "$SRC_DOC"/man/dumper.1 "$DEB_MAN"/dumper.1
 cp "$SRC_DOC"/man/zen-fetch-params.1 "$DEB_MAN"/zen-fetch-params.1
 # Copy bash completion files
 cp "$SRC_PATH"/contrib/zend.bash-completion "$DEB_CMP"/zend
@@ -65,12 +69,13 @@ gzip --best -n "$DEB_DOC"/changelog.Debian
 
 gzip --best -n "$DEB_MAN"/zend.1
 gzip --best -n "$DEB_MAN"/zen-cli.1
+gzip --best -n $DEB_MAN/dumper.1
 gzip --best -n "$DEB_MAN"/zen-fetch-params.1
 
 cd "$SRC_PATH"/contrib
 
 # Create the control file
-dpkg-shlibdeps "$DEB_BIN"/zend "$DEB_BIN"/zen-cli
+dpkg-shlibdeps "$DEB_BIN"/zend "$DEB_BIN"/zen-cli "$DEB_BIN"/dumper
 dpkg-gencontrol -P"$BUILD_DIR" -v"$DEBVERSION"
 
 # Create the Debian package


### PR DESCRIPTION
This PR adds a new tool to the repository, `dumper`.

`dumper` is compiled as a standalone binary, which can be used to extract aggregated information representing account balances at a given height. The information is represented in the form of a map of `address -> amount`, which is printed to `stdout` with a csv format.

Please see `./dumper --help` for further information.