### PR TITLE
fix: correct doxygen path in snark README.md

### DIFF
--- a/src/snark/README.md
+++ b/src/snark/README.md
@@ -256,7 +256,7 @@ with some (currently sparse) comments, install the `doxygen` and `graphviz` pack
 
     $ make doxy
 
-(this may take a few minutes). Then view the resulting [`doxygen/index.html`](doxygen/index.html).
+(this may take a few minutes). Then view the resulting [`doxygen/index.html`](../doxygen/index.html).
 
 ### Using libsnark as a library
 


### PR DESCRIPTION
Fix incorrect relative path to doxygen documentation in src/snark/README.md

- Change doxygen/index.html to ../doxygen/index.html
- Resolves "Cannot find file" error for doxygen documentation
